### PR TITLE
Cleanup commitFutures that have failed.

### DIFF
--- a/server/src/main/java/io/atomix/copycat/server/state/MemberState.java
+++ b/server/src/main/java/io/atomix/copycat/server/state/MemberState.java
@@ -28,9 +28,8 @@ class MemberState {
   private int index;
   private long matchIndex;
   private long nextIndex;
-  private long attemptTime;
-  private int attemptCount;
   private long commitTime;
+  private long commitStartTime;
 
   public MemberState(Address address) {
     this.address = Assert.notNull(address, "address");
@@ -106,62 +105,32 @@ class MemberState {
   }
 
   /**
-   * Returns the member commit attempt time.
-   *
-   * @return The member commit attempt time.
-   */
-  long getAttemptTime() {
-    return attemptTime;
-  }
-
-  /**
-   * Sets the member commit attempt time.
-   *
-   * @param attemptTime The member commit attempt time.
-   * @return The member state.
-   */
-  MemberState setAttemptTime(long attemptTime) {
-    this.attemptTime = attemptTime;
-    return this;
-  }
-
-  /**
-   * Returns the commit attempt count.
-   *
-   * @return The commit attempt count.
-   */
-  int getAttemptCount() {
-    return attemptCount;
-  }
-
-  /**
-   * Resets the commit attempt count.
-   *
-   * @return The member state.
-   */
-  MemberState resetAttemptCount() {
-    this.attemptCount = 0;
-    this.attemptTime = 0;
-    return this;
-  }
-
-  /**
-   * Increments the commit attempt count.
-   *
-   * @return The member state.
-   */
-  MemberState incrementAttemptCount() {
-    attemptCount++;
-    return this;
-  }
-
-  /**
    * Returns the member commit time.
    *
    * @return The member commit time.
    */
   long getCommitTime() {
     return commitTime;
+  }
+
+  /**
+   * Returns the member commit start time.
+   *
+   * @return The member commit start time.
+   */
+  long getCommitStartTime() {
+    return commitStartTime;
+  }
+
+  /**
+   * Sets the member commit start time.
+   *
+   * @param startTime The member commit attempt start time.
+   * @return The member state.
+   */
+  MemberState setCommitStartTime(long startTime) {
+    this.commitStartTime = startTime;
+    return this;
   }
 
   /**


### PR DESCRIPTION
Scenario: Start a 3 node cluster c1, c2 and c3. Let's assume c1 becomes LEADER. Shut down c2 and c3.
Expected: c1 should eventually detect that it is partitioned away and should step down and become a FOLLOWER

What we see is that c1 remains in leader state. Stops heart beating because commitFuture and nextCommitFuture are both non-null and incomplete. We never fail commitFuture when we detect the communication with follower(s) failed.

Later if we bring back c2 and c3 up, They will start their own polls since they can no longer receive heartbeats from c1. c1 continues to remain in LEADER state and can never rejoin others.

Solution: Exceptionally complete commitFuture if a quorum of successful commits cannot be guaranteed.
This change also disables exponential backoff when interacting with down followers as it can interfere with the ability to detect and fail commitFutures that have no chance of success.