### PR TITLE
Only send emptyCommits to a down follower

### DIFF
--- a/server/src/main/java/io/atomix/copycat/server/state/LeaderState.java
+++ b/server/src/main/java/io/atomix/copycat/server/state/LeaderState.java
@@ -951,7 +951,9 @@ final class LeaderState extends ActiveState {
         // If the log is empty then send an empty commit.
         // If the next index hasn't yet been set then we send an empty commit first.
         // If the next index is greater than the last index then send an empty commit.
-        if (context.getLog().isEmpty() || member.getNextIndex() > context.getLog().lastIndex()) {
+        // If the member failed to respond to recent communication send an empty commit. This
+        // helps avoid doing expensive work until we can ascertain the member is back up.
+        if (context.getLog().isEmpty() || member.getNextIndex() > context.getLog().lastIndex() || member.getFailureCount() > 0) {
           emptyCommit(member);
         } else {
           entriesCommit(member);


### PR DESCRIPTION
When a down follower's log is significantly behind the leader's log, each AE request from leader to this follower will be a full batch of log entries. This results in a lot of wasted work. With this change we only send non-empty AE request if the follower has successfully responded to recent communication.