### PR TITLE
Allow servers to compact their logs once all events have been acked

### DIFF
--- a/client/src/main/java/io/atomix/copycat/client/session/ClientSession.java
+++ b/client/src/main/java/io/atomix/copycat/client/session/ClientSession.java
@@ -639,6 +639,7 @@ public class ClientSession implements Session, Managed<Session> {
   private void onOpen(long sessionId) {
     LOGGER.debug("Registered session: {}", sessionId);
     this.id = sessionId;
+    this.eventVersion = id;
     this.state = State.OPEN;
     for (Consumer<Session> listener : openListeners) {
       listener.accept(this);

--- a/protocol/src/main/java/io/atomix/copycat/client/response/PublishResponse.java
+++ b/protocol/src/main/java/io/atomix/copycat/client/response/PublishResponse.java
@@ -68,20 +68,23 @@ public class PublishResponse extends SessionResponse<PublishResponse> {
     status = Status.forId(buffer.readByte());
     if (status == Status.OK) {
       error = null;
-      version = buffer.readLong();
-    } else {
+    } else if (buffer.readBoolean()) {
       error = RaftError.forId(buffer.readByte());
     }
+    version = buffer.readLong();
   }
 
   @Override
   public void writeObject(BufferOutput<?> buffer, Serializer serializer) {
     buffer.writeByte(status.id());
-    if (status == Status.OK) {
-      buffer.writeLong(version);
-    } else {
-      buffer.writeByte(error.id());
+    if (status == Status.ERROR) {
+      if (error != null) {
+        buffer.writeBoolean(true).writeByte(error.id());
+      } else {
+        buffer.writeBoolean(false);
+      }
     }
+    buffer.writeLong(version);
   }
 
   @Override

--- a/server/src/main/java/io/atomix/copycat/server/request/AppendRequest.java
+++ b/server/src/main/java/io/atomix/copycat/server/request/AppendRequest.java
@@ -61,7 +61,6 @@ public class AppendRequest extends AbstractRequest<AppendRequest> {
   private long logTerm;
   private List<Entry> entries = new ArrayList<>(128);
   private long commitIndex;
-  private long globalIndex;
 
   /**
    * Returns the requesting node's current term.
@@ -117,23 +116,13 @@ public class AppendRequest extends AbstractRequest<AppendRequest> {
     return commitIndex;
   }
 
-  /**
-   * Returns the leader's global index.
-   *
-   * @return The leader global index.
-   */
-  public long globalIndex() {
-    return globalIndex;
-  }
-
   @Override
   public void writeObject(BufferOutput<?> buffer, Serializer serializer) {
     buffer.writeLong(term)
       .writeInt(leader)
       .writeLong(logIndex)
       .writeLong(logTerm)
-      .writeLong(commitIndex)
-      .writeLong(globalIndex);
+      .writeLong(commitIndex);
 
     buffer.writeInt(entries.size());
     for (Entry entry : entries) {
@@ -149,7 +138,6 @@ public class AppendRequest extends AbstractRequest<AppendRequest> {
     logIndex = buffer.readLong();
     logTerm = buffer.readLong();
     commitIndex = buffer.readLong();
-    globalIndex = buffer.readLong();
 
     int numEntries = buffer.readInt();
     entries.clear();
@@ -163,7 +151,7 @@ public class AppendRequest extends AbstractRequest<AppendRequest> {
 
   @Override
   public int hashCode() {
-    return Objects.hash(getClass(), term, leader, logIndex, logTerm, entries, commitIndex, globalIndex);
+    return Objects.hash(getClass(), term, leader, logIndex, logTerm, entries, commitIndex);
   }
 
   @Override
@@ -175,15 +163,14 @@ public class AppendRequest extends AbstractRequest<AppendRequest> {
         && request.logIndex == logIndex
         && request.logTerm == logTerm
         && request.entries.equals(entries)
-        && request.commitIndex == commitIndex
-        && request.globalIndex == globalIndex;
+        && request.commitIndex == commitIndex;
     }
     return false;
   }
 
   @Override
   public String toString() {
-    return String.format("%s[term=%d, leader=%s, logIndex=%d, logTerm=%d, entries=[%d], commitIndex=%d, globalIndex=%d]", getClass().getSimpleName(), term, leader, logIndex, logTerm, entries.size(), commitIndex, globalIndex);
+    return String.format("%s[term=%d, leader=%s, logIndex=%d, logTerm=%d, entries=[%d], commitIndex=%d]", getClass().getSimpleName(), term, leader, logIndex, logTerm, entries.size(), commitIndex);
   }
 
   /**
@@ -291,18 +278,6 @@ public class AppendRequest extends AbstractRequest<AppendRequest> {
     }
 
     /**
-     * Sets the request global index.
-     *
-     * @param index The global recycle index.
-     * @return The append request builder.
-     * @throws IllegalArgumentException if index is not positive
-     */
-    public Builder withGlobalIndex(long index) {
-      request.globalIndex = Assert.argNot(index, index < 0, "global index must not be negative");
-      return this;
-    }
-
-    /**
      * @throws IllegalStateException if the term, log term, log index, commit index, or global index are not positive, or 
      * if entries is null 
      */
@@ -314,7 +289,6 @@ public class AppendRequest extends AbstractRequest<AppendRequest> {
       Assert.stateNot(request.logTerm < 0, "log term must not be negative");
       Assert.stateNot(request.entries == null, "entries cannot be null");
       Assert.stateNot(request.commitIndex < 0, "commit index must not be negative");
-      Assert.stateNot(request.globalIndex < 0, "global index must not be negative");
       return request;
     }
 

--- a/server/src/main/java/io/atomix/copycat/server/state/LeaderState.java
+++ b/server/src/main/java/io/atomix/copycat/server/state/LeaderState.java
@@ -788,7 +788,7 @@ final class LeaderState extends ActiveState {
       context.checkThread();
       if (isOpen()) {
         if (commitError == null) {
-          KeepAliveEntry entry = context.getLog().get(index);
+          UnregisterEntry entry = context.getLog().get(index);
           applyEntry(entry).whenCompleteAsync((sessionResult, sessionError) -> {
             if (isOpen()) {
               if (sessionError == null) {

--- a/server/src/main/java/io/atomix/copycat/server/state/LeaderState.java
+++ b/server/src/main/java/io/atomix/copycat/server/state/LeaderState.java
@@ -417,7 +417,7 @@ final class LeaderState extends ActiveState {
         .setSequence(request.sequence())
         .setCommand(command);
       index = context.getLog().append(entry);
-      LOGGER.debug("{} - Appended entry to log at index {}", context.getAddress(), index);
+      LOGGER.debug("{} - Appended {} to log at index {}", context.getAddress(), entry, index);
     }
 
     replicator.commit(index).whenComplete((commitIndex, commitError) -> {

--- a/server/src/main/java/io/atomix/copycat/server/state/PassiveState.java
+++ b/server/src/main/java/io/atomix/copycat/server/state/PassiveState.java
@@ -177,10 +177,8 @@ class PassiveState extends AbstractState {
 
     // If we've made it this far, apply commits and send a successful response.
     long commitIndex = request.commitIndex();
-    long globalIndex = request.globalIndex();
     context.getThreadContext().execute(() -> applyCommits(commitIndex)).thenRun(() -> {
-      context.setGlobalIndex(globalIndex);
-      context.getLog().commit(globalIndex);
+      context.getLog().commit(context.getLastCompleted());
     });
 
     return AppendResponse.builder()

--- a/server/src/main/java/io/atomix/copycat/server/state/ServerCommit.java
+++ b/server/src/main/java/io/atomix/copycat/server/state/ServerCommit.java
@@ -50,10 +50,10 @@ class ServerCommit implements Commit<Operation<?>> {
    *
    * @param entry The entry.
    */
-  void reset(OperationEntry<?> entry) {
+  void reset(OperationEntry<?> entry, long timestamp) {
     this.index = entry.getIndex();
     this.session = sessions.getSession(entry.getSession());
-    this.instant = Instant.ofEpochMilli(entry.getTimestamp());
+    this.instant = Instant.ofEpochMilli(timestamp);
     this.operation = entry.getOperation();
     open = true;
   }

--- a/server/src/main/java/io/atomix/copycat/server/state/ServerCommitPool.java
+++ b/server/src/main/java/io/atomix/copycat/server/state/ServerCommitPool.java
@@ -44,12 +44,12 @@ class ServerCommitPool implements AutoCloseable {
    * @param entry The entry for which to acquire the commit.
    * @return The commit to acquire.
    */
-  public ServerCommit acquire(OperationEntry entry) {
+  public ServerCommit acquire(OperationEntry entry, long timestamp) {
     ServerCommit commit = pool.poll();
     if (commit == null) {
       commit = new ServerCommit(this, cleaner, sessions);
     }
-    commit.reset(entry);
+    commit.reset(entry, timestamp);
     return commit;
   }
 

--- a/server/src/main/java/io/atomix/copycat/server/state/ServerSession.java
+++ b/server/src/main/java/io/atomix/copycat/server/state/ServerSession.java
@@ -489,7 +489,7 @@ class ServerSession implements Session {
     // Linearizable events must be sent synchronously, so only send them within a synchronous context.
     if (context.synchronous() && context.consistency() == Command.ConsistencyLevel.LINEARIZABLE) {
       sendLinearizableEvent(event);
-    } else {
+    } else if (context.consistency() != Command.ConsistencyLevel.LINEARIZABLE) {
       sendSequentialEvent(event);
     }
   }

--- a/server/src/main/java/io/atomix/copycat/server/state/ServerSession.java
+++ b/server/src/main/java/io/atomix/copycat/server/state/ServerSession.java
@@ -430,11 +430,13 @@ class ServerSession implements Session {
    * @return The index of the highest event acked for the session.
    */
   long getLastCompleted() {
+    // If there are any queued events, return the index prior to the first event in the queue.
     EventHolder event = events.poll();
     if (event != null && event.eventVersion > eventAckVersion) {
       return event.eventVersion - 1;
     }
-    return eventAckVersion;
+    // If no events are queued, return the highest index applied to the session.
+    return version;
   }
 
   /**

--- a/server/src/main/java/io/atomix/copycat/server/state/ServerSession.java
+++ b/server/src/main/java/io/atomix/copycat/server/state/ServerSession.java
@@ -441,7 +441,7 @@ class ServerSession implements Session {
    */
   long getLastCompleted() {
     // If there are any queued events, return the index prior to the first event in the queue.
-    EventHolder event = events.poll();
+    EventHolder event = events.peek();
     if (event != null && event.eventVersion > eventAckVersion) {
       return event.eventVersion - 1;
     }
@@ -457,7 +457,6 @@ class ServerSession implements Session {
    */
   private ServerSession clearEvents(long version) {
     if (version > eventAckVersion) {
-      LOGGER.debug("{} - Clearing events up to {}", id, version);
       EventHolder event = events.peek();
       while (event != null && event.eventVersion <= version) {
         events.remove();

--- a/server/src/main/java/io/atomix/copycat/server/state/ServerState.java
+++ b/server/src/main/java/io/atomix/copycat/server/state/ServerState.java
@@ -66,7 +66,6 @@ public class ServerState {
   private long term;
   private int lastVotedFor;
   private long commitIndex;
-  private long globalIndex;
 
   @SuppressWarnings("unchecked")
   ServerState(Address address, Collection<Address> members, Log log, StateMachine stateMachine, ConnectionManager connections, ThreadContext threadContext) {

--- a/server/src/main/java/io/atomix/copycat/server/state/ServerState.java
+++ b/server/src/main/java/io/atomix/copycat/server/state/ServerState.java
@@ -337,27 +337,6 @@ public class ServerState {
   }
 
   /**
-   * Sets the recycle index.
-   *
-   * @param globalIndex The recycle index.
-   * @return The Raft context.
-   */
-  ServerState setGlobalIndex(long globalIndex) {
-    Assert.argNot(globalIndex < 0, "global index must be positive");
-    this.globalIndex = Math.max(this.globalIndex, globalIndex);
-    return this;
-  }
-
-  /**
-   * Returns the recycle index.
-   *
-   * @return The state recycle index.
-   */
-  public long getGlobalIndex() {
-    return globalIndex;
-  }
-
-  /**
    * Returns the server state machine.
    *
    * @return The server state machine.
@@ -373,6 +352,15 @@ public class ServerState {
    */
   public long getLastApplied() {
     return stateMachine.getLastApplied();
+  }
+
+  /**
+   * Returns the last index completed for all sessions.
+   *
+   * @return The last index completed for all sessions.
+   */
+  public long getLastCompleted() {
+    return stateMachine.getLastCompleted();
   }
 
   /**

--- a/server/src/main/java/io/atomix/copycat/server/state/ServerStateMachine.java
+++ b/server/src/main/java/io/atomix/copycat/server/state/ServerStateMachine.java
@@ -535,10 +535,14 @@ class ServerStateMachine implements AutoCloseable {
    * Updates the last completed event version based on a commit at the given index.
    */
   private void updateLastCompleted(long index) {
-    lastCompleted = index;
+    long lastCompleted = index;
     for (ServerSession session : executor.context().sessions().sessions.values()) {
       lastCompleted = Math.min(lastCompleted, session.getLastCompleted());
     }
+
+    if (lastCompleted < this.lastCompleted)
+      throw new IllegalStateException("inconsistent session state");
+    this.lastCompleted = lastCompleted;
   }
 
   /**

--- a/server/src/main/java/io/atomix/copycat/server/state/ServerStateMachineContext.java
+++ b/server/src/main/java/io/atomix/copycat/server/state/ServerStateMachineContext.java
@@ -17,15 +17,12 @@
 package io.atomix.copycat.server.state;
 
 import io.atomix.copycat.client.Command;
-import io.atomix.copycat.server.CopycatServer;
 import io.atomix.copycat.server.StateMachineContext;
 
 import java.time.Clock;
 import java.time.Instant;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 
 /**
@@ -34,11 +31,9 @@ import java.util.concurrent.CompletableFuture;
  * @author <a href="http://github.com/kuujo>Jordan Halterman</a>
  */
 class ServerStateMachineContext implements StateMachineContext {
-  private CopycatServer.State state = CopycatServer.State.INACTIVE;
   private final ServerClock clock = new ServerClock();
   private final ConnectionManager connections;
   private final ServerSessionManager sessions;
-  private final Map<Long, CompletableFuture<Void>> futures = new HashMap<>();
   private long version;
   private boolean synchronous;
   private Command.ConsistencyLevel consistency;
@@ -46,15 +41,6 @@ class ServerStateMachineContext implements StateMachineContext {
   public ServerStateMachineContext(ConnectionManager connections, ServerSessionManager sessions) {
     this.connections = connections;
     this.sessions = sessions;
-  }
-
-  /**
-   * Returns the server state.
-   *
-   * @return The server state.
-   */
-  CopycatServer.State state() {
-    return state;
   }
 
   /**

--- a/server/src/test/java/io/atomix/copycat/server/state/ActiveStateTest.java
+++ b/server/src/test/java/io/atomix/copycat/server/state/ActiveStateTest.java
@@ -51,7 +51,6 @@ public class ActiveStateTest extends AbstractStateTest<ActiveState> {
           .withLogIndex(0)
           .withLogTerm(0)
           .withCommitIndex(0)
-          .withGlobalIndex(0)
           .build();
 
       AppendResponse response = state.append(request).get();

--- a/server/src/test/java/io/atomix/copycat/server/state/FollowerStateTest.java
+++ b/server/src/test/java/io/atomix/copycat/server/state/FollowerStateTest.java
@@ -349,7 +349,6 @@ public class FollowerStateTest extends AbstractStateTest<FollowerState> {
           .withLogIndex(0)
           .withLogTerm(0)
           .withCommitIndex(0)
-          .withGlobalIndex(0)
           .build();
 
       AppendResponse response2 = state.append(request2).get();

--- a/server/src/test/java/io/atomix/copycat/server/state/PassiveStateTest.java
+++ b/server/src/test/java/io/atomix/copycat/server/state/PassiveStateTest.java
@@ -88,7 +88,6 @@ public class PassiveStateTest extends AbstractStateTest<PassiveState> {
           .withLogIndex(0)
           .withLogTerm(0)
           .withCommitIndex(0)
-          .withGlobalIndex(0)
           .build();
 
       AppendResponse response = state.append(request).get();

--- a/test/src/test/java/io/atomix/copycat/test/ClusterTest.java
+++ b/test/src/test/java/io/atomix/copycat/test/ClusterTest.java
@@ -283,21 +283,21 @@ public class ClusterTest extends ConcurrentTestCase {
   /**
    * Tests submitting a command.
    */
-  public void testTwoOfFourNodeSubmitCommandWithNoneConsistency() throws Throwable {
+  public void testThreeOfFourNodeSubmitCommandWithNoneConsistency() throws Throwable {
     testSubmitCommand(3, 4, Command.ConsistencyLevel.NONE);
   }
 
   /**
    * Tests submitting a command.
    */
-  public void testTwoOfFourNodeSubmitCommandWithSequentialConsistency() throws Throwable {
+  public void testThreeOfFourNodeSubmitCommandWithSequentialConsistency() throws Throwable {
     testSubmitCommand(3, 4, Command.ConsistencyLevel.SEQUENTIAL);
   }
 
   /**
    * Tests submitting a command.
    */
-  public void testTwoOfFourNodeSubmitCommandWithLinearizableConsistency() throws Throwable {
+  public void testThreeOfFourNodeSubmitCommandWithLinearizableConsistency() throws Throwable {
     testSubmitCommand(3, 4, Command.ConsistencyLevel.LINEARIZABLE);
   }
 
@@ -900,7 +900,7 @@ public class ClusterTest extends ConcurrentTestCase {
         resume();
       });
 
-      await(5000, 4);
+      await(2000, 4);
     }
   }
 

--- a/test/src/test/java/io/atomix/copycat/test/ClusterTest.java
+++ b/test/src/test/java/io/atomix/copycat/test/ClusterTest.java
@@ -61,7 +61,7 @@ public class ClusterTest extends ConcurrentTestCase {
     createServers(3);
     CopycatServer joiner = createServer(nextAddress());
     joiner.open().thenRun(this::resume);
-    await();
+    await(5000);
   }
 
   /**
@@ -71,15 +71,15 @@ public class ClusterTest extends ConcurrentTestCase {
     createServers(3);
     CopycatClient client = createClient();
     submit(client, 0, 10000);
-    await();
+    await(30000);
     CopycatServer joiner = createServer(nextAddress());
     joiner.open().thenRun(this::resume);
-    await();
+    await(30000);
     joiner.onStateChange(state -> {
       if (state == CopycatServer.State.FOLLOWER)
         resume();
     });
-    await();
+    await(30000);
   }
 
   /**
@@ -103,7 +103,7 @@ public class ClusterTest extends ConcurrentTestCase {
     List<CopycatServer> servers = createServers(3);
     CopycatServer server = servers.get(0);
     server.close().thenRun(this::resume);
-    await();
+    await(5000);
   }
 
   /**
@@ -113,7 +113,7 @@ public class ClusterTest extends ConcurrentTestCase {
     List<CopycatServer> servers = createServers(3);
     CopycatServer server = servers.stream().filter(s -> s.state() == RaftServer.State.LEADER).findFirst().get();
     server.close().thenRun(this::resume);
-    await();
+    await(5000);
   }
 
   /**
@@ -259,7 +259,7 @@ public class ClusterTest extends ConcurrentTestCase {
       resume();
     });
 
-    await();
+    await(5000);
   }
 
   /**
@@ -337,7 +337,7 @@ public class ClusterTest extends ConcurrentTestCase {
       resume();
     });
 
-    await();
+    await(5000);
   }
 
   /**
@@ -492,7 +492,7 @@ public class ClusterTest extends ConcurrentTestCase {
       resume();
     });
 
-    await();
+    await(5000);
   }
 
   /**
@@ -547,7 +547,7 @@ public class ClusterTest extends ConcurrentTestCase {
       resume();
     });
 
-    await(0, 2);
+    await(5000, 2);
   }
 
   /**
@@ -610,7 +610,7 @@ public class ClusterTest extends ConcurrentTestCase {
       resume();
     });
 
-    await(0, 4);
+    await(5000, 4);
   }
 
   /**
@@ -669,7 +669,7 @@ public class ClusterTest extends ConcurrentTestCase {
       resume();
     });
 
-    await(0, 2);
+    await(5000, 2);
   }
 
   /**
@@ -738,7 +738,7 @@ public class ClusterTest extends ConcurrentTestCase {
       resume();
     });
 
-    await(0, 4);
+    await(5000, 4);
   }
 
   /**
@@ -774,7 +774,7 @@ public class ClusterTest extends ConcurrentTestCase {
       resume();
     });
 
-    await(0, 3);
+    await(5000, 3);
   }
 
   /**
@@ -806,7 +806,7 @@ public class ClusterTest extends ConcurrentTestCase {
         resume();
       });
 
-      await(0, 2);
+      await(5000, 2);
     }
   }
 
@@ -846,7 +846,7 @@ public class ClusterTest extends ConcurrentTestCase {
         resume();
       });
 
-      await(0, 2);
+      await(5000, 2);
     }
 
     CopycatServer leader = servers.stream().filter(s -> s.state() == CopycatServer.State.LEADER).findFirst().get();
@@ -860,7 +860,7 @@ public class ClusterTest extends ConcurrentTestCase {
         resume();
       });
 
-      await(0, 2);
+      await(5000, 2);
     }
   }
 
@@ -903,7 +903,7 @@ public class ClusterTest extends ConcurrentTestCase {
         resume();
       });
 
-      await(0, 4);
+      await(5000, 4);
     }
   }
 
@@ -970,7 +970,7 @@ public class ClusterTest extends ConcurrentTestCase {
       servers.add(server);
     }
 
-    await(0, nodes);
+    await(5000, nodes);
 
     return servers;
   }
@@ -992,7 +992,7 @@ public class ClusterTest extends ConcurrentTestCase {
       servers.add(server);
     }
 
-    await(0, live);
+    await(5000, live);
 
     return servers;
   }
@@ -1016,7 +1016,7 @@ public class ClusterTest extends ConcurrentTestCase {
   private CopycatClient createClient() throws Throwable {
     CopycatClient client = CopycatClient.builder(members).withTransport(new LocalTransport(registry)).build();
     client.open().thenRun(this::resume);
-    await();
+    await(5000);
     clients.add(client);
     return client;
   }

--- a/test/src/test/java/io/atomix/copycat/test/ClusterTest.java
+++ b/test/src/test/java/io/atomix/copycat/test/ClusterTest.java
@@ -806,7 +806,7 @@ public class ClusterTest extends ConcurrentTestCase {
         resume();
       });
 
-      await(5000, 2);
+      await(10000, 2);
     }
   }
 
@@ -903,7 +903,7 @@ public class ClusterTest extends ConcurrentTestCase {
         resume();
       });
 
-      await(5000, 4);
+      await(10000, 4);
     }
   }
 

--- a/test/src/test/java/io/atomix/copycat/test/ClusterTest.java
+++ b/test/src/test/java/io/atomix/copycat/test/ClusterTest.java
@@ -892,7 +892,7 @@ public class ClusterTest extends ConcurrentTestCase {
       resume();
     });
 
-    for (int i = 0 ; i < 1000; i++) {
+    for (int i = 0; i < 10000; i++) {
       String event = UUID.randomUUID().toString();
       value.set(event);
       client.submit(new TestEvent(event, false, Command.ConsistencyLevel.LINEARIZABLE)).thenAccept(result -> {
@@ -900,7 +900,7 @@ public class ClusterTest extends ConcurrentTestCase {
         resume();
       });
 
-      await(30000, 4);
+      await(5000, 4);
     }
   }
 


### PR DESCRIPTION
This PR modifies the way logs are committed/compacted to fix #25.

Currently, Copycat does not allow servers to compact any segment that contains entries that haven't been stored on `100%` of the servers in the cluster. The reasoning behind this decision was because session events are dependent on commands being applied to the state machine. When events are published to a session, they're held in memory on each server until received by the client. Events are sequenced in a manner similar to how the leader sequences entries to followers. When an event batch is sent to a client, the server that sends the batch with the index of the previous event. The client verifies that it received the previous event and acks the new event in the response. While it's normally safe for a server to take a snapshot before other servers have applied a command, the dependency of events on commands means if one server doesn't apply *all* commands for each session, servers can end up with inconsistent event histories. Thus, in order to avoid this case, Copycat currently requires that a command be persisted on all servers before it can be removed from the log.

But this approach is not ideal for obvious reasons. As long as at least one server in a configuration is down, no server can compact its logs. This PR proposes a fix to allow servers to compact their logs once all events have been received by their respective clients.

Servers already track which events have been received by which clients through keep-alive requests. When a client sends a `KeepAliveRequest` for an open session, it sends with it the index of the highest event for which it has received a batch. Event indexes are based on the commands by which events were triggered. For instance, if the application of a command at index `100` triggers the publishing of an event to 5 sessions, the `index` of that event will be `100`. Once each session has received event `100` and sends a `KeepAliveRequest`, a `KeepAliveEntry` with the highest index received by the client is logged, replicated, committed, and applied to the internal state machine.

So, since the system already logs and replicates information about the highest event index received for each session, and because event indexes are based on log indexes, we can use the *lowest* acked event index for all sessions as the basis for safe log compaction. When a client submits a `KeepAliveRequest` and an associated `KeepAliveEntry` is committed and applied, each server recalculates the lowest index received by any session. Session IDs are initialized to the index of the session's `RegisterEntry`, and so each session's event index is also initialized to that index as well (by definition, sessions can't receive events prior to their registration). This ensures that the lowest received index is not reset to `0` when a new session is registered. When the lowest index received by all sessions is recalculated, the log is updated to make segments containing earlier entries available for compaction.