### PR TITLE
Fixed a bug in comparator used for commitTime computation

### DIFF
--- a/server/src/main/java/io/atomix/copycat/server/state/LeaderState.java
+++ b/server/src/main/java/io/atomix/copycat/server/state/LeaderState.java
@@ -905,9 +905,7 @@ final class LeaderState extends ActiveState {
     private long commitTime() {
       int quorumIndex = quorumIndex();
       if (quorumIndex >= 0) {
-        long commitTime = context.getCluster().getActiveMembers((m1, m2) -> (int) (m2.getCommitTime() - m1.getCommitTime())).get(quorumIndex).getCommitTime();
-        if (commitTime > 0)
-          return commitTime;
+        return context.getCluster().getActiveMembers((m1, m2) -> Long.compare(m2.getCommitTime(), m1.getCommitTime())).get(quorumIndex).getCommitTime();
       }
       return System.currentTimeMillis();
     }


### PR DESCRIPTION
The comparator used in commitTime() function has a subtle bug since we downcast the difference (a long value) to int. This can cause int overflow.