### PR TITLE
Ensure events published during session registration are associated with register entries

### DIFF
--- a/server/src/main/java/io/atomix/copycat/server/state/LeaderState.java
+++ b/server/src/main/java/io/atomix/copycat/server/state/LeaderState.java
@@ -603,7 +603,9 @@ final class LeaderState extends ActiveState {
       if (isOpen()) {
         if (commitError == null) {
           RegisterEntry entry = context.getLog().get(index);
-          applyEntry(entry).whenComplete((sessionId, sessionError) -> {
+
+          LOGGER.debug("{} - Applying {}", context.getAddress(), entry);
+          context.getStateMachine().apply(entry, true).whenComplete((sessionId, sessionError) -> {
             if (isOpen()) {
               if (sessionError == null) {
                 future.complete(logResponse(RegisterResponse.builder()

--- a/server/src/main/java/io/atomix/copycat/server/state/ServerSession.java
+++ b/server/src/main/java/io/atomix/copycat/server/state/ServerSession.java
@@ -64,7 +64,7 @@ class ServerSession implements Session {
   private boolean suspect;
   private boolean unregistering;
   private boolean expired;
-  private boolean closed;
+  private boolean closed = true;
   private final Map<String, Listeners<Object>> eventListeners = new ConcurrentHashMap<>();
   private final Listeners<Session> openListeners = new Listeners<>();
   private final Listeners<Session> closeListeners = new Listeners<>();
@@ -80,6 +80,13 @@ class ServerSession implements Session {
   @Override
   public long id() {
     return id;
+  }
+
+  /**
+   * Opens the session.
+   */
+  void open() {
+    closed = false;
   }
 
   /**
@@ -390,6 +397,7 @@ class ServerSession implements Session {
 
   @Override
   public Session publish(String event, Object message) {
+    Assert.stateNot(closed, "session is not open");
     Assert.state(context.consistency() != null, "session events can only be published during command execution");
 
     // If the client acked a version greater than the current event sequence number since we know the client must have received it from another server.


### PR DESCRIPTION
This PR fixes #41 by simply setting the context prior to calling the state machine's `register` method. This will ensure that events published in the `register` method are properly associated with the index of the `RegisterEntry` and that events will be received by the client before the session registration is complete.

One additional safety measure added in this PR is to ensure that state machines cannot publish events to the session being registered. If events are published to the session being registered, events would never be acknowledged by the client since it doesn't yet know about its session. So, we throw `IllegalStateException` on attempts to publish events to the session being registered, but publishing to other sessions should be allowed and events will be linearizable.