### PR TITLE
Prevent race conditions when expiring sessions

### DIFF
--- a/server/src/main/java/io/atomix/copycat/server/state/LeaderState.java
+++ b/server/src/main/java/io/atomix/copycat/server/state/LeaderState.java
@@ -171,6 +171,7 @@ final class LeaderState extends ActiveState {
         try (UnregisterEntry entry = context.getLog().create(UnregisterEntry.class)) {
           entry.setTerm(term)
             .setSession(session.id())
+            .setExpired(true)
             .setTimestamp(System.currentTimeMillis());
           index = context.getLog().append(entry);
           LOGGER.debug("{} - Appended {} to log at index {}", context.getAddress(), entry, index);
@@ -784,6 +785,7 @@ final class LeaderState extends ActiveState {
     try (UnregisterEntry entry = context.getLog().create(UnregisterEntry.class)) {
       entry.setTerm(context.getTerm())
         .setSession(request.session())
+        .setExpired(false)
         .setTimestamp(timestamp);
       index = context.getLog().append(entry);
       LOGGER.debug("{} - Appended {}", context.getAddress(), entry);

--- a/server/src/main/java/io/atomix/copycat/server/state/ServerStateMachine.java
+++ b/server/src/main/java/io/atomix/copycat/server/state/ServerStateMachine.java
@@ -299,7 +299,7 @@ class ServerStateMachine implements AutoCloseable {
       // If the session was already marked suspect, that indicates that the session did not commit a keep alive
       // request before its timeout. We assume that such cases indicate that a session has expired and thus
       // call expire callbacks in the state machine.
-      if (session.isSuspect()) {
+      if (entry.isExpired()) {
         executor.executor().execute(() -> {
           // Update the state machine context with the unregister entry's index. This ensures that events published
           // within the expire or close methods will be properly associated with the unregister entry's index.

--- a/server/src/main/java/io/atomix/copycat/server/storage/entry/UnregisterEntry.java
+++ b/server/src/main/java/io/atomix/copycat/server/storage/entry/UnregisterEntry.java
@@ -15,7 +15,10 @@
  */
 package io.atomix.copycat.server.storage.entry;
 
+import io.atomix.catalyst.buffer.BufferInput;
+import io.atomix.catalyst.buffer.BufferOutput;
 import io.atomix.catalyst.serializer.SerializeWith;
+import io.atomix.catalyst.serializer.Serializer;
 import io.atomix.catalyst.util.ReferenceManager;
 
 /**
@@ -25,6 +28,7 @@ import io.atomix.catalyst.util.ReferenceManager;
  */
 @SerializeWith(id=227)
 public class UnregisterEntry extends SessionEntry<UnregisterEntry> {
+  private boolean expired;
 
   public UnregisterEntry() {
   }
@@ -38,9 +42,41 @@ public class UnregisterEntry extends SessionEntry<UnregisterEntry> {
     return true;
   }
 
+  /**
+   * Sets whether the session was expired by a leader.
+   *
+   * @param expired Whether the session was expired by a leader.
+   * @return The unregister entry.
+   */
+  public UnregisterEntry setExpired(boolean expired) {
+    this.expired = expired;
+    return this;
+  }
+
+  /**
+   * Returns whether the session was expired by a leader.
+   *
+   * @return Whether the session was expired by a leader.
+   */
+  public boolean isExpired() {
+    return expired;
+  }
+
+  @Override
+  public void writeObject(BufferOutput<?> buffer, Serializer serializer) {
+    super.writeObject(buffer, serializer);
+    buffer.writeBoolean(expired);
+  }
+
+  @Override
+  public void readObject(BufferInput<?> buffer, Serializer serializer) {
+    super.readObject(buffer, serializer);
+    expired = buffer.readBoolean();
+  }
+
   @Override
   public String toString() {
-    return String.format("%s[index=%d, term=%d, session=%d, timestamp=%d]", getClass().getSimpleName(), getIndex(), getTerm(), getSession(), getTimestamp());
+    return String.format("%s[index=%d, term=%d, session=%d, expired=%b, timestamp=%d]", getClass().getSimpleName(), getIndex(), getTerm(), getSession(), isExpired(), getTimestamp());
   }
 
 }


### PR DESCRIPTION
This PR fixes #42 by adding an `expired` field to `UnregisterEntry`. When a leader detects that a session has expired, it logs the `UnregisterEntry` with `expired=true`. This allows the internal state machine on each server to determine that the leader expired the session (as opposed to the client unregistering it).