### PR TITLE
Ensure tombstones are retained in the log until applied on all servers

### DIFF
--- a/server/src/main/java/io/atomix/copycat/server/response/ConfigurationResponse.java
+++ b/server/src/main/java/io/atomix/copycat/server/response/ConfigurationResponse.java
@@ -72,7 +72,10 @@ public class ConfigurationResponse<T extends ConfigurationResponse<T>> extends A
       activeMembers = serializer.readObject(buffer);
       passiveMembers = serializer.readObject(buffer);
     } else {
-      error = RaftError.forId(buffer.readByte());
+      int errorCode = buffer.readByte();
+      if (errorCode != 0) {
+        error = RaftError.forId(errorCode);
+      }
     }
   }
 
@@ -84,7 +87,7 @@ public class ConfigurationResponse<T extends ConfigurationResponse<T>> extends A
       serializer.writeObject(activeMembers, buffer);
       serializer.writeObject(passiveMembers, buffer);
     } else {
-      buffer.writeByte(error.id());
+      buffer.writeByte(error != null ? error.id() : 0);
     }
   }
 

--- a/server/src/main/java/io/atomix/copycat/server/state/LeaderState.java
+++ b/server/src/main/java/io/atomix/copycat/server/state/LeaderState.java
@@ -1013,6 +1013,7 @@ final class LeaderState extends ActiveState {
       // If the active members list is empty (a configuration change occurred between an append request/response)
       // ensure all commit futures are completed and cleared.
       if (members.isEmpty()) {
+        context.setCommitIndex(context.getLog().lastIndex());
         for (Map.Entry<Long, CompletableFuture<Long>> entry : commitFutures.entrySet()) {
           entry.getValue().complete(entry.getKey());
         }

--- a/server/src/main/java/io/atomix/copycat/server/state/LeaderState.java
+++ b/server/src/main/java/io/atomix/copycat/server/state/LeaderState.java
@@ -233,6 +233,8 @@ final class LeaderState extends ActiveState {
       index = context.getLog().append(entry);
       LOGGER.debug("{} - Appended {} to log at index {}", context.getAddress(), entry, index);
 
+      // Store the index of the configuration entry in order to prevent other configurations from
+      // being logged and committed concurrently. This is an important safety property of Raft.
       configuring = index;
       context.getCluster().configure(entry.getIndex(), entry.getActive(), entry.getPassive());
     }
@@ -241,6 +243,7 @@ final class LeaderState extends ActiveState {
     replicator.commit(index).whenComplete((commitIndex, commitError) -> {
       context.checkThread();
       if (isOpen()) {
+        // Reset the configuration index to allow new configuration changes to be committed.
         configuring = 0;
         if (commitError == null) {
           future.complete(logResponse(JoinResponse.builder()
@@ -306,6 +309,8 @@ final class LeaderState extends ActiveState {
       index = context.getLog().append(entry);
       LOGGER.debug("{} - Appended {} to log at index {}", context.getAddress(), entry, index);
 
+      // Store the index of the configuration entry in order to prevent other configurations from
+      // being logged and committed concurrently. This is an important safety property of Raft.
       configuring = index;
       context.getCluster().configure(entry.getIndex(), entry.getActive(), entry.getPassive());
     }
@@ -314,6 +319,7 @@ final class LeaderState extends ActiveState {
     replicator.commit(index).whenComplete((commitIndex, commitError) -> {
       context.checkThread();
       if (isOpen()) {
+        // Reset the configuration index to allow new configuration changes to be committed.
         configuring = 0;
         if (commitError == null) {
           future.complete(logResponse(LeaveResponse.builder()
@@ -873,6 +879,8 @@ final class LeaderState extends ActiveState {
       if (context.getCluster().getMembers().size() == 0)
         return CompletableFuture.completedFuture(null);
 
+      // If no commit future already exists, that indicates there's no heartbeat currently under way.
+      // Create a new commit future and commit to all members in the cluster.
       if (commitFuture == null) {
         commitFuture = new CompletableFuture<>();
         commitTime = System.currentTimeMillis();
@@ -880,7 +888,13 @@ final class LeaderState extends ActiveState {
           commit(member);
         }
         return commitFuture;
-      } else if (nextCommitFuture == null) {
+      }
+      // If a commit future already exists, that indicates there is a heartbeat currently underway.
+      // We don't want to allow callers to be completed by a heartbeat that may already almost be done.
+      // So, we create the next commit future if necessary and return that. Once the current heartbeat
+      // completes the next future will be used to do another heartbeat. This ensures that only one
+      // heartbeat can be outstanding at any given point in time.
+      else if (nextCommitFuture == null) {
         nextCommitFuture = new CompletableFuture<>();
         return nextCommitFuture;
       } else {
@@ -898,12 +912,23 @@ final class LeaderState extends ActiveState {
       if (index == 0)
         return commit();
 
+      // If there are no other servers in the cluster, immediately commit the index.
       if (context.getCluster().getMembers().isEmpty()) {
         context.setCommitIndex(index);
         context.setGlobalIndex(index);
         return CompletableFuture.completedFuture(index);
       }
+      // If there are no other active members in the cluster, update the commit index and complete
+      // the commit but ensure append entries requests are sent to passive members.
+      else if (context.getCluster().getActiveMembers().isEmpty()) {
+        context.setCommitIndex(index);
+        for (MemberState member : context.getCluster().getMembers()) {
+          commit(member);
+        }
+        return CompletableFuture.completedFuture(index);
+      }
 
+      // Ensure append requests are being sent to all members, including passive members.
       return commitFutures.computeIfAbsent(index, i -> {
         for (MemberState member : context.getCluster().getMembers()) {
           commit(member);
@@ -971,24 +996,43 @@ final class LeaderState extends ActiveState {
     private void commitEntries() {
       context.checkThread();
 
-      // Sort the list of replicas, order by the last index that was replicated
-      // to the replica. This will allow us to determine the median index
-      // for all known replicated entries across all cluster members.
-      List<MemberState> members = context.getCluster().getActiveMembers((m1, m2) ->
-        Long.compare(m2.getMatchIndex() != 0 ? m2.getMatchIndex() : 0l, m1.getMatchIndex() != 0 ? m1.getMatchIndex() : 0l));
-
-      // Set the current commit index as the median matchIndex.
-      long commitIndex = members.get(quorumIndex()).getMatchIndex();
-
       // The global index may have increased even if the commit index didn't. Update the global index.
       // The global index is calculated by the maximum matchIndex for *all* servers in the cluster, including
       // passive members. This is critical since passive members still have state machines and thus it's still
       // important to ensure that tombstones are applied to their state machines.
-      context.setGlobalIndex(context.getCluster().getMembers().stream().mapToLong(MemberState::getMatchIndex).max().getAsLong());
+      // If the members list is empty, use the local server's last log index as the global index.
+      context.setGlobalIndex(context.getCluster().getMembers().stream().mapToLong(MemberState::getMatchIndex).max().orElse(context.getLog().lastIndex()));
 
-      // Once the commit index is set, complete futures up to the given index.
+      // Sort the list of replicas, order by the last index that was replicated to the replica. This will allow
+      // us to determine the median index for all known replicated entries across all cluster members.
+      // Note that this sort should be fast in most cases since the list should already be sorted, but there
+      // may still be a more efficient way to go about this.
+      List<MemberState> members = context.getCluster().getActiveMembers((m1, m2) ->
+        Long.compare(m2.getMatchIndex() != 0 ? m2.getMatchIndex() : 0l, m1.getMatchIndex() != 0 ? m1.getMatchIndex() : 0l));
+
+      // If the active members list is empty (a configuration change occurred between an append request/response)
+      // ensure all commit futures are completed and cleared.
+      if (members.isEmpty()) {
+        for (Map.Entry<Long, CompletableFuture<Long>> entry : commitFutures.entrySet()) {
+          entry.getValue().complete(entry.getKey());
+        }
+        commitFutures.clear();
+        return;
+      }
+
+      // Calculate the current commit index as the median matchIndex.
+      long commitIndex = members.get(quorumIndex()).getMatchIndex();
+
+      // If the commit index has increased then update the commit index. Note that in order to ensure
+      // the leader completeness property holds, verify that the commit index is greater than or equal to
+      // the index of the leader's no-op entry. Update the commit index and trigger commit futures.
       if (commitIndex > 0 && commitIndex > context.getCommitIndex() && (leaderIndex > 0 && commitIndex >= leaderIndex)) {
         context.setCommitIndex(commitIndex);
+
+        // TODO: This seems like an annoyingly expensive operation to perform on every response.
+        // Futures could simply be stored in a hash map and we could use a sequential index starting
+        // from the previous commit index to get the appropriate futures. But for now, at least this
+        // ensures that no memory leaks can occur.
         SortedMap<Long, CompletableFuture<Long>> futures = commitFutures.headMap(commitIndex, true);
         for (Map.Entry<Long, CompletableFuture<Long>> entry : futures.entrySet()) {
           entry.getValue().complete(entry.getKey());
@@ -1065,9 +1109,14 @@ final class LeaderState extends ActiveState {
         .withCommitIndex(context.getCommitIndex())
         .withGlobalIndex(context.getGlobalIndex());
 
+      // Build a list of entries to send to the member.
       if (!context.getLog().isEmpty()) {
         long index = prevIndex != 0 ? prevIndex + 1 : context.getLog().firstIndex();
 
+        // We build a list of entries up to the MAX_BATCH_SIZE. Note that entries in the log may
+        // be null if they've been compacted and the member to which we're sending entries is just
+        // joining the cluster or is otherwise far behind. Null entries are simply skipped and not
+        // counted towards the size of the batch.
         int size = 0;
         while (index <= context.getLog().lastIndex()) {
           Entry entry = context.getLog().get(index);
@@ -1082,6 +1131,7 @@ final class LeaderState extends ActiveState {
         }
       }
 
+      // Release the previous entry back to the entry pool.
       if (prevEntry != null) {
         prevEntry.release();
       }
@@ -1205,8 +1255,7 @@ final class LeaderState extends ActiveState {
      * Updates the match index when a response is received.
      */
     private void updateMatchIndex(MemberState member, AppendResponse response) {
-      // If the replica returned a valid match index then update the existing match index. Because the
-      // replicator pipelines replication, we perform a MAX(matchIndex, logIndex) to get the true match index.
+      // If the replica returned a valid match index then update the existing match index.
       member.setMatchIndex(Math.max(member.getMatchIndex(), response.logIndex()));
     }
 
@@ -1215,8 +1264,6 @@ final class LeaderState extends ActiveState {
      */
     private void updateNextIndex(MemberState member) {
       // If the match index was set, update the next index to be greater than the match index if necessary.
-      // Note that because of pipelining append requests, the next index can potentially be much larger than
-      // the match index. We rely on the algorithm to reject invalid append requests.
       member.setNextIndex(Math.max(member.getNextIndex(), Math.max(member.getMatchIndex() + 1, 1)));
     }
 
@@ -1255,6 +1302,8 @@ final class LeaderState extends ActiveState {
         LOGGER.debug("{} - Appended {} to log at index {}", context.getAddress(), entry, index);
 
         // Immediately apply the configuration upon appending the configuration entry.
+        // Store the index of the configuration in order to block other configurations from taking
+        // place at the same time.
         configuring = index;
         context.getCluster().configure(entry.getIndex(), entry.getActive(), entry.getPassive());
       }

--- a/server/src/main/java/io/atomix/copycat/server/state/LeaderState.java
+++ b/server/src/main/java/io/atomix/copycat/server/state/LeaderState.java
@@ -997,11 +997,11 @@ final class LeaderState extends ActiveState {
       context.checkThread();
 
       // The global index may have increased even if the commit index didn't. Update the global index.
-      // The global index is calculated by the maximum matchIndex for *all* servers in the cluster, including
+      // The global index is calculated by the minimum matchIndex for *all* servers in the cluster, including
       // passive members. This is critical since passive members still have state machines and thus it's still
       // important to ensure that tombstones are applied to their state machines.
       // If the members list is empty, use the local server's last log index as the global index.
-      context.setGlobalIndex(context.getCluster().getMembers().stream().mapToLong(MemberState::getMatchIndex).max().orElse(context.getLog().lastIndex()));
+      context.setGlobalIndex(context.getCluster().getMembers().stream().mapToLong(MemberState::getMatchIndex).min().orElse(context.getLog().lastIndex()));
 
       // Sort the list of replicas, order by the last index that was replicated to the replica. This will allow
       // us to determine the median index for all known replicated entries across all cluster members.

--- a/server/src/main/java/io/atomix/copycat/server/state/PassiveState.java
+++ b/server/src/main/java/io/atomix/copycat/server/state/PassiveState.java
@@ -178,7 +178,7 @@ class PassiveState extends AbstractState {
     // If we've made it this far, apply commits and send a successful response.
     long commitIndex = request.commitIndex();
     context.getThreadContext().execute(() -> applyCommits(commitIndex)).thenRun(() -> {
-      context.getLog().commit(context.getLastCompleted());
+      context.getLog().compactor().minorIndex(context.getLastCompleted());
     });
 
     return AppendResponse.builder()

--- a/server/src/main/java/io/atomix/copycat/server/state/ServerState.java
+++ b/server/src/main/java/io/atomix/copycat/server/state/ServerState.java
@@ -66,6 +66,7 @@ public class ServerState {
   private long term;
   private int lastVotedFor;
   private long commitIndex;
+  private long globalIndex;
 
   @SuppressWarnings("unchecked")
   ServerState(Address address, Collection<Address> members, Log log, StateMachine stateMachine, ConnectionManager connections, ThreadContext threadContext) {
@@ -323,6 +324,7 @@ public class ServerState {
     Assert.argNot(commitIndex < 0, "commit index must be positive");
     Assert.argNot(commitIndex < this.commitIndex, "cannot decrease commit index");
     this.commitIndex = commitIndex;
+    log.commit(commitIndex);
     return this;
   }
 
@@ -333,6 +335,28 @@ public class ServerState {
    */
   public long getCommitIndex() {
     return commitIndex;
+  }
+
+  /**
+   * Sets the global index.
+   *
+   * @param globalIndex The global index.
+   * @return The Raft context.
+   */
+  ServerState setGlobalIndex(long globalIndex) {
+    Assert.argNot(globalIndex < 0, "global index must be positive");
+    this.globalIndex = Math.max(this.globalIndex, globalIndex);
+    log.compactor().majorIndex(globalIndex);
+    return this;
+  }
+
+  /**
+   * Returns the global index.
+   *
+   * @return The global index.
+   */
+  public long getGlobalIndex() {
+    return globalIndex;
   }
 
   /**

--- a/server/src/main/java/io/atomix/copycat/server/storage/compaction/Compaction.java
+++ b/server/src/main/java/io/atomix/copycat/server/storage/compaction/Compaction.java
@@ -40,8 +40,8 @@ public enum Compaction {
    */
   MINOR {
     @Override
-    CompactionManager manager() {
-      return new MinorCompactionManager();
+    CompactionManager manager(Compactor compactor) {
+      return new MinorCompactionManager(compactor.minorIndex());
     }
   },
 
@@ -55,8 +55,8 @@ public enum Compaction {
    */
   MAJOR {
     @Override
-    CompactionManager manager() {
-      return new MajorCompactionManager();
+    CompactionManager manager(Compactor compactor) {
+      return new MajorCompactionManager(compactor.majorIndex());
     }
   };
 
@@ -65,6 +65,6 @@ public enum Compaction {
    *
    * @return The compaction manager for the compaction type.
    */
-  abstract CompactionManager manager();
+  abstract CompactionManager manager(Compactor compactor);
 
 }

--- a/server/src/main/java/io/atomix/copycat/server/storage/compaction/Compaction.java
+++ b/server/src/main/java/io/atomix/copycat/server/storage/compaction/Compaction.java
@@ -41,7 +41,7 @@ public enum Compaction {
   MINOR {
     @Override
     CompactionManager manager(Compactor compactor) {
-      return new MinorCompactionManager(compactor.minorIndex());
+      return new MinorCompactionManager(compactor);
     }
   },
 
@@ -56,7 +56,7 @@ public enum Compaction {
   MAJOR {
     @Override
     CompactionManager manager(Compactor compactor) {
-      return new MajorCompactionManager(compactor.majorIndex());
+      return new MajorCompactionManager(compactor);
     }
   };
 

--- a/server/src/main/java/io/atomix/copycat/server/storage/compaction/MajorCompactionManager.java
+++ b/server/src/main/java/io/atomix/copycat/server/storage/compaction/MajorCompactionManager.java
@@ -41,6 +41,11 @@ import java.util.List;
  * @author <a href="http://github.com/kuujo>Jordan Halterman</a>
  */
 public final class MajorCompactionManager implements CompactionManager {
+  private long compactIndex;
+
+  public MajorCompactionManager(long compactIndex) {
+    this.compactIndex = compactIndex;
+  }
 
   @Override
   public List<CompactionTask> buildTasks(Storage storage, SegmentManager segments) {
@@ -52,7 +57,7 @@ public final class MajorCompactionManager implements CompactionManager {
    * Returns a list of segments lists to clean, where segments are grouped according to how they will be merged during 
    * cleaning.
    */
-  public static List<List<Segment>> getCleanableGroups(Storage storage, SegmentManager manager) {
+  public List<List<Segment>> getCleanableGroups(Storage storage, SegmentManager manager) {
     List<List<Segment>> clean = new ArrayList<>();
     List<Segment> segments = null;
     Segment previousSegment = null;
@@ -95,11 +100,11 @@ public final class MajorCompactionManager implements CompactionManager {
    * @param manager The segment manager.
    * @return A list of cleanable log segments.
    */
-  private static List<Segment> getCleanableSegments(SegmentManager manager) {
+  private List<Segment> getCleanableSegments(SegmentManager manager) {
     List<Segment> segments = new ArrayList<>(manager.segments().size());
     Segment lastSegment = manager.lastSegment();
     for (Segment segment : manager.segments()) {
-      if ((segment.isFull() || segment.isCompacted()) && segment.lastIndex() < manager.commitIndex() && lastSegment.firstIndex() <= manager.commitIndex() && !lastSegment.isEmpty()) {
+      if ((segment.isFull() || segment.isCompacted()) && segment.lastIndex() < compactIndex && lastSegment.firstIndex() <= compactIndex && !lastSegment.isEmpty()) {
         segments.add(segment);
       } else {
         break;

--- a/server/src/main/java/io/atomix/copycat/server/storage/compaction/MajorCompactionTask.java
+++ b/server/src/main/java/io/atomix/copycat/server/storage/compaction/MajorCompactionTask.java
@@ -95,10 +95,12 @@ public final class MajorCompactionTask implements CompactionTask {
   private final SegmentManager manager;
   private final List<List<Segment>> groups;
   private List<List<Predicate<Long>>> cleaners;
+  private final long compactIndex;
 
-  MajorCompactionTask(SegmentManager manager, List<List<Segment>> groups) {
+  MajorCompactionTask(SegmentManager manager, List<List<Segment>> groups, long compactIndex) {
     this.manager = Assert.notNull(manager, "manager");
     this.groups = Assert.notNull(groups, "segments");
+    this.compactIndex = compactIndex;
   }
 
   @Override
@@ -195,14 +197,23 @@ public final class MajorCompactionTask implements CompactionTask {
     try (Entry entry = segment.get(index)) {
       // If an entry was found, remove the entry from the segment.
       if (entry != null) {
-        // If the entry has been cleaned, skip the entry in the compact segment.
-        // Note that for major compaction this process includes normal and tombstone entries.
-        long offset = segment.offset(index);
-        if (offset == -1 || cleaner.test(offset)) {
-          compactSegment.skip(1);
-          LOGGER.debug("Cleaned entry {} from segment {}", index, segment.descriptor().id());
+        // If the entry's index is less than the major compact index then it can be safely removed if cleaned.
+        // If the entry's index is greater than the major compact index, the entry must not be a tombstone.
+        // Tombstones may only be removed from the log if their index is less than the major compact index.
+        if (index <= compactIndex || !entry.isTombstone()) {
+          // If the entry has been cleaned, skip the entry in the compact segment.
+          // Note that for major compaction this process includes normal and tombstone entries.
+          long offset = segment.offset(index);
+          if (offset == -1 || cleaner.test(offset)) {
+            compactSegment.skip(1);
+            LOGGER.debug("Cleaned entry {} from segment {}", index, segment.descriptor().id());
+          }
+          // If the entry hasn't been cleaned, simply transfer it to the new segment.
+          else {
+            compactSegment.append(entry);
+          }
         }
-        // If the entry hasn't been cleaned, simply transfer it to the new segment.
+        // If the entry doesn't meet the criteria for compaction, transfer it to the new segment.
         else {
           compactSegment.append(entry);
         }

--- a/server/src/main/java/io/atomix/copycat/server/storage/compaction/MinorCompactionManager.java
+++ b/server/src/main/java/io/atomix/copycat/server/storage/compaction/MinorCompactionManager.java
@@ -55,6 +55,11 @@ import java.util.List;
  * @author <a href="http://github.com/kuujo>Jordan Halterman</a>
  */
 public final class MinorCompactionManager implements CompactionManager {
+  private long compactIndex;
+
+  public MinorCompactionManager(long compactIndex) {
+    this.compactIndex = compactIndex;
+  }
 
   @Override
   public List<CompactionTask> buildTasks(Storage storage, SegmentManager segments) {
@@ -74,7 +79,7 @@ public final class MinorCompactionManager implements CompactionManager {
     List<Segment> segments = new ArrayList<>();
     for (Segment segment : manager.segments()) {
       // Only allow compaction of segments that are full.
-      if (segment.isCompacted() || (segment.isFull() && segment.lastIndex() < manager.commitIndex() && manager.currentSegment().firstIndex() <= manager.commitIndex() && !manager.currentSegment().isEmpty())) {
+      if (segment.isCompacted() || (segment.isFull() && segment.lastIndex() < compactIndex && manager.currentSegment().firstIndex() <= manager.commitIndex() && !manager.currentSegment().isEmpty())) {
         // Calculate the percentage of entries that have been marked for cleaning in the segment.
         double cleanPercentage = segment.cleanCount() / (double) segment.count();
 

--- a/server/src/main/java/io/atomix/copycat/server/storage/compaction/MinorCompactionManager.java
+++ b/server/src/main/java/io/atomix/copycat/server/storage/compaction/MinorCompactionManager.java
@@ -15,6 +15,7 @@
  */
 package io.atomix.copycat.server.storage.compaction;
 
+import io.atomix.catalyst.util.Assert;
 import io.atomix.copycat.server.storage.Segment;
 import io.atomix.copycat.server.storage.SegmentManager;
 import io.atomix.copycat.server.storage.Storage;
@@ -55,10 +56,10 @@ import java.util.List;
  * @author <a href="http://github.com/kuujo>Jordan Halterman</a>
  */
 public final class MinorCompactionManager implements CompactionManager {
-  private long compactIndex;
+  private final Compactor compactor;
 
-  public MinorCompactionManager(long compactIndex) {
-    this.compactIndex = compactIndex;
+  MinorCompactionManager(Compactor compactor) {
+    this.compactor = Assert.notNull(compactor, "compactor");
   }
 
   @Override
@@ -79,7 +80,7 @@ public final class MinorCompactionManager implements CompactionManager {
     List<Segment> segments = new ArrayList<>();
     for (Segment segment : manager.segments()) {
       // Only allow compaction of segments that are full.
-      if (segment.isCompacted() || (segment.isFull() && segment.lastIndex() < compactIndex && manager.currentSegment().firstIndex() <= manager.commitIndex() && !manager.currentSegment().isEmpty())) {
+      if (segment.isCompacted() || (segment.isFull() && segment.lastIndex() < compactor.minorIndex() && manager.currentSegment().firstIndex() <= manager.commitIndex() && !manager.currentSegment().isEmpty())) {
         // Calculate the percentage of entries that have been marked for cleaning in the segment.
         double cleanPercentage = segment.cleanCount() / (double) segment.count();
 

--- a/server/src/test/java/io/atomix/copycat/server/state/ActiveStateTest.java
+++ b/server/src/test/java/io/atomix/copycat/server/state/ActiveStateTest.java
@@ -51,6 +51,7 @@ public class ActiveStateTest extends AbstractStateTest<ActiveState> {
           .withLogIndex(0)
           .withLogTerm(0)
           .withCommitIndex(0)
+          .withGlobalIndex(0)
           .build();
 
       AppendResponse response = state.append(request).get();
@@ -66,7 +67,11 @@ public class ActiveStateTest extends AbstractStateTest<ActiveState> {
   public void testAppendTermUpdatedAndTransitionedToFollower() throws Throwable {
     runOnServer(() -> {
       serverState.setTerm(1);
-      AppendRequest request = AppendRequest.builder().withTerm(2).build();
+      AppendRequest request = AppendRequest.builder()
+        .withTerm(2)
+        .withCommitIndex(0)
+        .withGlobalIndex(0)
+        .build();
 
       AppendResponse response = state.append(request).get();
 

--- a/server/src/test/java/io/atomix/copycat/server/state/CandidateStateTest.java
+++ b/server/src/test/java/io/atomix/copycat/server/state/CandidateStateTest.java
@@ -49,6 +49,8 @@ public class CandidateStateTest extends AbstractStateTest<CandidateState> {
       AppendRequest request = AppendRequest.builder()
         .withTerm(2)
         .withLeader(leader)
+        .withCommitIndex(0)
+        .withGlobalIndex(0)
         .build();
 
       AppendResponse response = state.append(request).get();

--- a/server/src/test/java/io/atomix/copycat/server/state/FollowerStateTest.java
+++ b/server/src/test/java/io/atomix/copycat/server/state/FollowerStateTest.java
@@ -349,6 +349,7 @@ public class FollowerStateTest extends AbstractStateTest<FollowerState> {
           .withLogIndex(0)
           .withLogTerm(0)
           .withCommitIndex(0)
+          .withGlobalIndex(0)
           .build();
 
       AppendResponse response2 = state.append(request2).get();

--- a/server/src/test/java/io/atomix/copycat/server/state/PassiveStateTest.java
+++ b/server/src/test/java/io/atomix/copycat/server/state/PassiveStateTest.java
@@ -88,6 +88,7 @@ public class PassiveStateTest extends AbstractStateTest<PassiveState> {
           .withLogIndex(0)
           .withLogTerm(0)
           .withCommitIndex(0)
+          .withGlobalIndex(0)
           .build();
 
       AppendResponse response = state.append(request).get();
@@ -107,6 +108,8 @@ public class PassiveStateTest extends AbstractStateTest<PassiveState> {
       AppendRequest request = AppendRequest.builder()
         .withTerm(2)
         .withLeader(leader)
+        .withCommitIndex(0)
+        .withGlobalIndex(0)
         .build();
 
       AppendResponse response = state.append(request).get();
@@ -129,6 +132,8 @@ public class PassiveStateTest extends AbstractStateTest<PassiveState> {
         .withLeader(serverState.getCluster().getActiveMembers().iterator().next().getAddress().hashCode())
         .withLogIndex(2)
         .withLogTerm(2)
+        .withCommitIndex(0)
+        .withGlobalIndex(0)
         .build();
 
       AppendResponse response = state.append(request).get();
@@ -150,6 +155,8 @@ public class PassiveStateTest extends AbstractStateTest<PassiveState> {
         .withLeader(serverState.getCluster().getActiveMembers().iterator().next().getAddress().hashCode())
         .withLogIndex(2)
         .withLogTerm(2)
+        .withCommitIndex(0)
+        .withGlobalIndex(0)
         .build();
 
       AppendResponse response = state.append(request).get();
@@ -171,6 +178,8 @@ public class PassiveStateTest extends AbstractStateTest<PassiveState> {
         .withLeader(serverState.getCluster().getActiveMembers().iterator().next().getAddress().hashCode())
         .withLogIndex(1)
         .withLogTerm(1)
+        .withCommitIndex(0)
+        .withGlobalIndex(0)
         .withEntries(new TestEntry().setIndex(2).setTerm(1))
         .build();
 
@@ -193,6 +202,8 @@ public class PassiveStateTest extends AbstractStateTest<PassiveState> {
         .withLeader(serverState.getCluster().getActiveMembers().iterator().next().getAddress().hashCode())
         .withLogIndex(2)
         .withLogTerm(2)
+        .withCommitIndex(0)
+        .withGlobalIndex(0)
         .build();
 
       AppendResponse response = state.append(request).get();
@@ -213,6 +224,8 @@ public class PassiveStateTest extends AbstractStateTest<PassiveState> {
         .withLeader(serverState.getCluster().getActiveMembers().iterator().next().getAddress().hashCode())
         .withLogIndex(0)
         .withLogTerm(0)
+        .withCommitIndex(0)
+        .withGlobalIndex(0)
         .withEntries(new TestEntry().setIndex(1).setTerm(1))
         .build();
 
@@ -238,6 +251,8 @@ public class PassiveStateTest extends AbstractStateTest<PassiveState> {
         .withLeader(serverState.getCluster().getActiveMembers().iterator().next().getAddress().hashCode())
         .withLogIndex(0)
         .withLogTerm(0)
+        .withCommitIndex(0)
+        .withGlobalIndex(0)
         .withEntries(new TestEntry().setIndex(2).setTerm(1))
         .build();
 
@@ -264,6 +279,8 @@ public class PassiveStateTest extends AbstractStateTest<PassiveState> {
         .withLeader(serverState.getCluster().getActiveMembers().iterator().next().getAddress().hashCode())
         .withLogIndex(1)
         .withLogTerm(1)
+        .withCommitIndex(0)
+        .withGlobalIndex(0)
         .withEntries(new TestEntry().setIndex(2).setTerm(2), new TestEntry().setIndex(3).setTerm(3), new TestEntry().setIndex(4).setTerm(3))
         .build();
 
@@ -291,6 +308,8 @@ public class PassiveStateTest extends AbstractStateTest<PassiveState> {
         .withLeader(serverState.getCluster().getActiveMembers().iterator().next().getAddress().hashCode())
         .withLogIndex(1)
         .withLogTerm(1)
+        .withCommitIndex(0)
+        .withGlobalIndex(0)
         .withEntries(new TestEntry().setIndex(2).setTerm(1), new TestEntry().setIndex(4).setTerm(1))
         .build();
 
@@ -385,28 +404,6 @@ public class PassiveStateTest extends AbstractStateTest<PassiveState> {
       VoteRequest request = VoteRequest.builder().withCandidate(1).withLogIndex(1).withLogTerm(1).withTerm(1).build();
       VoteResponse response = state.vote(request).get();
       assertIllegalMemberStateError(response);
-    });
-  }
-
-  public void testForward() throws Throwable {
-    // TODO
-  }
-
-  public void testHandleAppend() throws Throwable {
-    // TODO
-  }
-
-  public void testHandleAppendRejectedWhenRequestTermIsOld() throws Throwable {
-    runOnServer(() -> {
-      serverState.setTerm(3);
-      AppendRequest request = AppendRequest.builder().withTerm(2).build();
-
-      AppendResponse response = state.handleAppend(request);
-
-      threadAssertEquals(response.status(), Status.OK);
-      threadAssertEquals(serverState.getTerm(), 3L);
-      threadAssertEquals(response.term(), 3L);
-      threadAssertFalse(response.succeeded());
     });
   }
 

--- a/server/src/test/java/io/atomix/copycat/server/storage/AbstractLogTest.java
+++ b/server/src/test/java/io/atomix/copycat/server/storage/AbstractLogTest.java
@@ -129,18 +129,25 @@ public abstract class AbstractLogTest {
    * Appends {@code numEntries} increasingly numbered ByteBuffer wrapped entries to the log.
    */
   protected List<Long> appendEntries(int numEntries) {
-    return appendEntries(numEntries, (int) log.length() + 1);
+    return appendEntries(numEntries, (int) log.length() + 1, false);
+  }
+
+  /**
+   * Appends {@code numEntries} increasingly numbered ByteBuffer wrapped entries to the log.
+   */
+  protected List<Long> appendEntries(int numEntries, boolean tombstone) {
+    return appendEntries(numEntries, (int) log.length() + 1, tombstone);
   }
 
   /**
    * Appends {@code numEntries} increasingly numbered ByteBuffer wrapped entries to the log, starting at the
    * {@code startingId}.
    */
-  protected List<Long> appendEntries(int numEntries, int startingId) {
+  protected List<Long> appendEntries(int numEntries, int startingId, boolean tombstone) {
     List<Integer> entryIds = IntStream.range(startingId, startingId + numEntries).boxed().collect(Collectors.toList());
     return entryIds.stream().map(entryId -> {
       try (TestEntry entry = log.create(TestEntry.class)) {
-        entry.setTerm(1).setPadding(entryPadding);
+        entry.setTerm(1).setTombstone(tombstone).setPadding(entryPadding);
         return log.append(entry);
       }
     }).collect(Collectors.toList());

--- a/server/src/test/java/io/atomix/copycat/server/storage/FileLogTest.java
+++ b/server/src/test/java/io/atomix/copycat/server/storage/FileLogTest.java
@@ -76,7 +76,7 @@ public class FileLogTest extends LogTest {
       }
     }
 
-    log.commit(entriesPerSegment * 5).compactor().compact().join();
+    log.commit(entriesPerSegment * 5).compactor().minorIndex(entriesPerSegment * 5).compact().join();
     log.close();
 
     try (Log log = createLog()) {

--- a/server/src/test/java/io/atomix/copycat/server/storage/LogTest.java
+++ b/server/src/test/java/io/atomix/copycat/server/storage/LogTest.java
@@ -139,7 +139,7 @@ public abstract class LogTest extends AbstractLogTest {
     assertFalse(log.contains(entriesPerSegment * 3 + 1));
 
     // Test after compaction
-    log.commit(entriesPerSegment * 3).compactor().majorIndex(entriesPerSegment * 3);
+    log.commit(entriesPerSegment * 3).compactor().minorIndex(entriesPerSegment * 3).majorIndex(entriesPerSegment * 3);
     cleanAndCompact(entriesPerSegment + 1, entriesPerSegment * 2 + 1);
     assertTrue(log.contains(entriesPerSegment));
     for (int i = entriesPerSegment + 1; i <= entriesPerSegment * 2; i++) {
@@ -172,7 +172,7 @@ public abstract class LogTest extends AbstractLogTest {
       assertEquals(log.get(i).getIndex(), i);
 
     // Asserts get() after compaction
-    log.commit(entriesPerSegment * 3).compactor().majorIndex(entriesPerSegment * 3);
+    log.commit(entriesPerSegment * 3).compactor().minorIndex(entriesPerSegment * 3).majorIndex(entriesPerSegment * 3);
     cleanAndCompact(entriesPerSegment + 1, entriesPerSegment * 2 + 1);
     assertCompacted(entriesPerSegment + 1, entriesPerSegment * 2);
   }
@@ -258,7 +258,7 @@ public abstract class LogTest extends AbstractLogTest {
     assertEquals(log.segments.segments().size(), 5);
     assertEquals(log.size(), fullSegmentSize() * 5);
 
-    log.commit(entriesPerSegment * 5).compactor().majorIndex(entriesPerSegment * 5);
+    log.commit(entriesPerSegment * 5).compactor().minorIndex(entriesPerSegment * 5).majorIndex(entriesPerSegment * 5);
 
     // Compact 2nd and 3rd segments
     cleanAndCompact(entriesPerSegment + 1, entriesPerSegment * 3);

--- a/server/src/test/java/io/atomix/copycat/server/storage/LogTest.java
+++ b/server/src/test/java/io/atomix/copycat/server/storage/LogTest.java
@@ -139,7 +139,7 @@ public abstract class LogTest extends AbstractLogTest {
     assertFalse(log.contains(entriesPerSegment * 3 + 1));
 
     // Test after compaction
-    log.commit(entriesPerSegment * 3);
+    log.commit(entriesPerSegment * 3).compactor().majorIndex(entriesPerSegment * 3);
     cleanAndCompact(entriesPerSegment + 1, entriesPerSegment * 2 + 1);
     assertTrue(log.contains(entriesPerSegment));
     for (int i = entriesPerSegment + 1; i <= entriesPerSegment * 2; i++) {
@@ -172,7 +172,7 @@ public abstract class LogTest extends AbstractLogTest {
       assertEquals(log.get(i).getIndex(), i);
 
     // Asserts get() after compaction
-    log.commit(entriesPerSegment * 3);
+    log.commit(entriesPerSegment * 3).compactor().majorIndex(entriesPerSegment * 3);
     cleanAndCompact(entriesPerSegment + 1, entriesPerSegment * 2 + 1);
     assertCompacted(entriesPerSegment + 1, entriesPerSegment * 2);
   }
@@ -258,14 +258,13 @@ public abstract class LogTest extends AbstractLogTest {
     assertEquals(log.segments.segments().size(), 5);
     assertEquals(log.size(), fullSegmentSize() * 5);
 
-    log.commit(entriesPerSegment * 5);
+    log.commit(entriesPerSegment * 5).compactor().majorIndex(entriesPerSegment * 5);
 
     // Compact 2nd and 3rd segments
     cleanAndCompact(entriesPerSegment + 1, entriesPerSegment * 3);
 
     // Asserts that size() is changed after compaction
-    assertEquals(log.size(),
-        (entrySize() * entriesPerSegment * 3) + (log.segments.segments().size() * SegmentDescriptor.BYTES));
+    assertEquals(log.size(), (entrySize() * entriesPerSegment * 3) + (log.segments.segments().size() * SegmentDescriptor.BYTES));
   }
 
   /**

--- a/server/src/test/java/io/atomix/copycat/server/storage/MajorCompactionTest.java
+++ b/server/src/test/java/io/atomix/copycat/server/storage/MajorCompactionTest.java
@@ -51,7 +51,7 @@ public class MajorCompactionTest extends AbstractLogTest {
     for (long index = 21; index < 28; index++) {
       log.clean(index);
     }
-    log.commit(31);
+    log.commit(31).compactor().majorIndex(31);
 
     CountDownLatch latch = new CountDownLatch(1);
     log.compactor().compact(Compaction.MAJOR).thenRun(latch::countDown);

--- a/server/src/test/java/io/atomix/copycat/server/storage/MajorCompactionTest.java
+++ b/server/src/test/java/io/atomix/copycat/server/storage/MajorCompactionTest.java
@@ -51,7 +51,7 @@ public class MajorCompactionTest extends AbstractLogTest {
     for (long index = 21; index < 28; index++) {
       log.clean(index);
     }
-    log.commit(31).compactor().majorIndex(31);
+    log.commit(31).compactor().minorIndex(31).majorIndex(31);
 
     CountDownLatch latch = new CountDownLatch(1);
     log.compactor().compact(Compaction.MAJOR).thenRun(latch::countDown);

--- a/server/src/test/java/io/atomix/copycat/server/storage/MinorCompactionTest.java
+++ b/server/src/test/java/io/atomix/copycat/server/storage/MinorCompactionTest.java
@@ -51,7 +51,7 @@ public class MinorCompactionTest extends AbstractLogTest {
     for (long index = 21; index < 28; index++) {
       log.clean(index);
     }
-    log.commit(31);
+    log.commit(31).compactor().minorIndex(31);
 
     CountDownLatch latch = new CountDownLatch(1);
     log.compactor().compact(Compaction.MINOR).thenRun(latch::countDown);

--- a/test/src/test/java/io/atomix/copycat/test/ClusterTest.java
+++ b/test/src/test/java/io/atomix/copycat/test/ClusterTest.java
@@ -895,7 +895,7 @@ public class ClusterTest extends ConcurrentTestCase {
       resume();
     });
 
-    for (int i = 0; i < 10000; i++) {
+    for (int i = 0; i < 500; i++) {
       String event = UUID.randomUUID().toString();
       value.set(event);
       client.submit(new TestEvent(event, false, Command.ConsistencyLevel.LINEARIZABLE)).thenAccept(result -> {


### PR DESCRIPTION
This PR fixes #38 by recovering the concept of a `globalIndex`. The `globalIndex` is indicative of the highest index stored on all servers. The global index is used to determine when it's safe to remove tombstones from the log during major compaction. If a server is partitioned, failure to replicate a tombstone entry to that server before compaction will result in inconsistent state across the cluster.

This PR also fixes some issues with the previous implementation of `globalIndex`. Previously, only active cluster members were considered in the calculation of the global index. But because passive members maintain state machines while they catch up to the rest of the cluster, it's important that they be included in counts. Similarly, this PR fixes an issue wherein state for passive servers wasn't reset when a leader first transitioned.

Note that this PR does still allow major compaction to operate normally aside from removing tombstones. It stores two compaction indexes in the log: `minorIndex` and `majorIndex`. The `minorIndex` is the highest index for which normal entries can be safely removed from the log (based on events received by clients), and `majorIndex` is the highest index for which tombstones can be safely removed from the log. If the major compaction process is compacting a section of the log with indexes greater than the `majorIndex`, it will simply retain any tombstones.

I'm going very carefully through the entire project to document and verify the algorithms. This is a big step in the right direction. Excited about finding some good potential issues.