### PR TITLE
Fix race condition in candidate state change test

### DIFF
--- a/server/src/test/java/io/atomix/copycat/server/state/CandidateStateTest.java
+++ b/server/src/test/java/io/atomix/copycat/server/state/CandidateStateTest.java
@@ -157,6 +157,11 @@ public class CandidateStateTest extends AbstractStateTest<CandidateState> {
   }
 
   public void testCandidateTransitionsToLeaderOnElection() throws Throwable {
+    serverState.onStateChange(state -> {
+      if (state == RaftServer.State.LEADER)
+        resume();
+    });
+
     runOnServer(() -> {
       for (MemberState member : serverState.getCluster().getActiveMembers()) {
         Server server = transport.server();
@@ -179,11 +184,6 @@ public class CandidateStateTest extends AbstractStateTest<CandidateState> {
 
       assertEquals(serverState.getTerm(), 2L);
       assertEquals(serverState.getLastVotedFor(), self);
-    });
-
-    serverState.onStateChange(state -> {
-      if (state == RaftServer.State.LEADER)
-        resume();
     });
     await();
   }


### PR DESCRIPTION
This PR fixes a race condition in candidate tests that frequently causes other test runs to fail in Travis.