### PR TITLE
Fix race conditions in candidate tests

### DIFF
--- a/server/src/test/java/io/atomix/copycat/server/state/CandidateStateTest.java
+++ b/server/src/test/java/io/atomix/copycat/server/state/CandidateStateTest.java
@@ -157,6 +157,11 @@ public class CandidateStateTest extends AbstractStateTest<CandidateState> {
   }
 
   public void testCandidateTransitionsToLeaderOnElection() throws Throwable {
+    serverState.onStateChange(state -> {
+      if (state == RaftServer.State.LEADER)
+        resume();
+    });
+
     runOnServer(() -> {
       for (MemberState member : serverState.getCluster().getActiveMembers()) {
         Server server = transport.server();
@@ -179,11 +184,6 @@ public class CandidateStateTest extends AbstractStateTest<CandidateState> {
 
       assertEquals(serverState.getTerm(), 2L);
       assertEquals(serverState.getLastVotedFor(), self);
-    });
-
-    serverState.onStateChange(state -> {
-      if (state == RaftServer.State.LEADER)
-        resume();
     });
     await();
   }

--- a/server/src/test/java/io/atomix/copycat/server/state/CandidateStateTest.java
+++ b/server/src/test/java/io/atomix/copycat/server/state/CandidateStateTest.java
@@ -189,6 +189,11 @@ public class CandidateStateTest extends AbstractStateTest<CandidateState> {
   }
 
   public void testCandidateTransitionsToFollowerOnRejection() throws Throwable {
+    serverState.onStateChange(state -> {
+      if (state == RaftServer.State.FOLLOWER)
+        resume();
+    });
+
     runOnServer(() -> {
       for (MemberState member : serverState.getCluster().getActiveMembers()) {
         Server server = transport.server();
@@ -211,11 +216,6 @@ public class CandidateStateTest extends AbstractStateTest<CandidateState> {
 
       assertEquals(serverState.getTerm(), 2L);
       assertEquals(serverState.getLastVotedFor(), self);
-    });
-
-    serverState.onStateChange(state -> {
-      if (state == RaftServer.State.FOLLOWER)
-        resume();
     });
     await();
   }

--- a/server/src/test/java/io/atomix/copycat/server/state/CandidateStateTest.java
+++ b/server/src/test/java/io/atomix/copycat/server/state/CandidateStateTest.java
@@ -185,7 +185,7 @@ public class CandidateStateTest extends AbstractStateTest<CandidateState> {
       assertEquals(serverState.getTerm(), 2L);
       assertEquals(serverState.getLastVotedFor(), self);
     });
-    await();
+    await(1000);
   }
 
   public void testCandidateTransitionsToFollowerOnRejection() throws Throwable {
@@ -217,7 +217,7 @@ public class CandidateStateTest extends AbstractStateTest<CandidateState> {
       assertEquals(serverState.getTerm(), 2L);
       assertEquals(serverState.getLastVotedFor(), self);
     });
-    await();
+    await(1000);
   }
 
 }

--- a/test/src/test/java/io/atomix/copycat/test/ClusterTest.java
+++ b/test/src/test/java/io/atomix/copycat/test/ClusterTest.java
@@ -895,7 +895,7 @@ public class ClusterTest extends ConcurrentTestCase {
       resume();
     });
 
-    for (int i = 0; i < 10000; i++) {
+    for (int i = 0; i < 500; i++) {
       String event = UUID.randomUUID().toString();
       value.set(event);
       client.submit(new TestEvent(event, false, Command.ConsistencyLevel.LINEARIZABLE)).thenAccept(result -> {


### PR DESCRIPTION
This PR fixes race conditions in `CandidateState` tests that frequently cause other tests to fail.