### PR TITLE
Move persistent and volatile server state into the log

### DIFF
--- a/server/src/main/java/io/atomix/copycat/server/CopycatServer.java
+++ b/server/src/main/java/io/atomix/copycat/server/CopycatServer.java
@@ -178,7 +178,7 @@ public class CopycatServer implements RaftServer {
 
   @Override
   public long term() {
-    return state.getTerm();
+    return state.getLog().getTerm();
   }
 
   @Override

--- a/server/src/main/java/io/atomix/copycat/server/state/MemberState.java
+++ b/server/src/main/java/io/atomix/copycat/server/state/MemberState.java
@@ -42,7 +42,7 @@ class MemberState {
    */
   void resetState(Log log) {
     matchIndex = 0;
-    nextIndex = log.lastIndex() + 1;
+    nextIndex = log.getLastIndex() + 1;
     commitTime = 0;
     commitStartTime = 0;
     failures = 0;

--- a/server/src/main/java/io/atomix/copycat/server/state/ServerCommit.java
+++ b/server/src/main/java/io/atomix/copycat/server/state/ServerCommit.java
@@ -20,6 +20,7 @@ import io.atomix.copycat.client.Command;
 import io.atomix.copycat.client.Operation;
 import io.atomix.copycat.client.session.Session;
 import io.atomix.copycat.server.Commit;
+import io.atomix.copycat.server.storage.Log;
 import io.atomix.copycat.server.storage.entry.OperationEntry;
 
 import java.time.Instant;
@@ -31,7 +32,7 @@ import java.time.Instant;
  */
 class ServerCommit implements Commit<Operation<?>> {
   private final ServerCommitPool pool;
-  private final ServerCommitCleaner cleaner;
+  private final Log log;
   private final ServerSessionManager sessions;
   private long index;
   private Session session;
@@ -39,9 +40,9 @@ class ServerCommit implements Commit<Operation<?>> {
   private Operation operation;
   private volatile boolean open;
 
-  public ServerCommit(ServerCommitPool pool, ServerCommitCleaner cleaner, ServerSessionManager sessions) {
+  public ServerCommit(ServerCommitPool pool, Log log, ServerSessionManager sessions) {
     this.pool = pool;
-    this.cleaner = cleaner;
+    this.log = log;
     this.sessions = sessions;
   }
 
@@ -100,7 +101,7 @@ class ServerCommit implements Commit<Operation<?>> {
   public void clean() {
     checkOpen();
     if (operation instanceof Command)
-      cleaner.clean(index);
+      log.cleanEntry(index);
     close();
   }
 

--- a/server/src/main/java/io/atomix/copycat/server/state/ServerCommitPool.java
+++ b/server/src/main/java/io/atomix/copycat/server/state/ServerCommitPool.java
@@ -15,6 +15,7 @@
  */
 package io.atomix.copycat.server.state;
 
+import io.atomix.copycat.server.storage.Log;
 import io.atomix.copycat.server.storage.entry.OperationEntry;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -29,12 +30,12 @@ import java.util.concurrent.ConcurrentLinkedQueue;
  */
 class ServerCommitPool implements AutoCloseable {
   private static final Logger LOGGER = LoggerFactory.getLogger(ServerCommitPool.class);
-  private final ServerCommitCleaner cleaner;
+  private final Log log;
   private final ServerSessionManager sessions;
   private final Queue<ServerCommit> pool = new ConcurrentLinkedQueue<>();
 
-  public ServerCommitPool(ServerCommitCleaner cleaner, ServerSessionManager sessions) {
-    this.cleaner = cleaner;
+  ServerCommitPool(Log log, ServerSessionManager sessions) {
+    this.log = log;
     this.sessions = sessions;
   }
 
@@ -47,7 +48,7 @@ class ServerCommitPool implements AutoCloseable {
   public ServerCommit acquire(OperationEntry entry, long timestamp) {
     ServerCommit commit = pool.poll();
     if (commit == null) {
-      commit = new ServerCommit(this, cleaner, sessions);
+      commit = new ServerCommit(this, log, sessions);
     }
     commit.reset(entry, timestamp);
     return commit;

--- a/server/src/main/java/io/atomix/copycat/server/storage/Log.java
+++ b/server/src/main/java/io/atomix/copycat/server/storage/Log.java
@@ -15,6 +15,8 @@
  */
 package io.atomix.copycat.server.storage;
 
+import io.atomix.catalyst.buffer.FileBuffer;
+import io.atomix.catalyst.buffer.HeapBuffer;
 import io.atomix.catalyst.serializer.Serializer;
 import io.atomix.catalyst.util.Assert;
 import io.atomix.catalyst.util.concurrent.CatalystThreadFactory;
@@ -22,6 +24,7 @@ import io.atomix.copycat.server.storage.compaction.Compactor;
 import io.atomix.copycat.server.storage.entry.Entry;
 import io.atomix.copycat.server.storage.entry.TypedEntryPool;
 
+import java.io.File;
 import java.util.concurrent.Executors;
 
 /**
@@ -33,15 +36,15 @@ import java.util.concurrent.Executors;
  * <p>
  * State changes are written to the log as {@link Entry} objects. Each entry is associated with an {@code index} and
  * {@code term}. The {@code index} is a 1-based entry index from the start of the log. The {@code term} is used for
- * various consistency checks in the Raft algorithm. Raft guarantees that a {@link #commit(long) committed} entry at any
+ * various consistency checks in the Raft algorithm. Raft guarantees that a {@link #setCommitIndex(long) committed} entry at any
  * index {@code i} that has term {@code t} will also be present in the logs on all other servers in the cluster at the
  * same index {@code i} with term {@code t}. However, note that log compaction may break this contract. Considering log
  * compaction, it's more accurate to say that iff committed entry {@code i} is present in another server's log, that
  * entry has term {@code t} and the same value.
  * <p>
- * Entries are written to the log via the {@link #append(Entry)} method. When an entry is appended, it's written to the
- * next sequential index in the log after {@link #lastIndex()}. Entries can be created from a typed entry pool with the
- * {@link #create(Class)} method. <pre>
+ * Entries are written to the log via the {@link #appendEntry(Entry)} method. When an entry is appended, it's written to the
+ * next sequential index in the log after {@link #getLastIndex()}. Entries can be created from a typed entry pool with the
+ * {@link #createEntry(Class)} method. <pre>
  *   {@code
  *   long index;
  *   try (CommandEntry entry = log.create(CommandEntry.class)) {
@@ -66,14 +69,14 @@ import java.util.concurrent.Executors;
  * <p>
  * In order to prevent exhausting disk space, the log manages a set of background threads that periodically rewrite and
  * combine segments to free disk space. This is known as log compaction. As entries are committed to the log and applied
- * to the Raft state machine as {@link io.atomix.copycat.server.Commit} objects, state machines {@link #clean(long)}
+ * to the Raft state machine as {@link io.atomix.copycat.server.Commit} objects, state machines {@link #cleanEntry(long)}
  * entries that no longer apply to the state machine state. Internally, each log {@link Segment} maintains a compact
  * {@link io.atomix.catalyst.buffer.util.BitArray} to track cleaned entries. When an entry is cleaned, the entry's
  * offset is set in the bit array for the associated segment. The bit array represents the state of entries waiting to
  * be compacted from the log.
  * <p>
  * As entries are written to the log, segments reach their capacity and the log rolls over into new segments. Once a
- * segment is full and all of its entries have been {@link #commit(long) committed}, indicating they cannot be removed,
+ * segment is full and all of its entries have been {@link #setCommitIndex(long) committed}, indicating they cannot be removed,
  * the segment becomes eligible for compaction. Log compaction processes come in two forms:
  * {@link io.atomix.copycat.server.storage.compaction.Compaction#MINOR} and
  * {@link io.atomix.copycat.server.storage.compaction.Compaction#MAJOR}, which can be configured in the {@link Storage}
@@ -82,13 +85,13 @@ import java.util.concurrent.Executors;
  * Minor compaction is the more frequent and lightweight process. Periodically, according to the configured
  * {@link Storage#minorCompactionInterval()}, a background thread will evaluate the log for minor compaction. The minor
  * compaction process iterates through segments and selects compactable segments based on the ratio of entries that have
- * been {@link #clean(long) cleaned}. Minor compaction is generational. The
+ * been {@link #cleanEntry(long) cleaned}. Minor compaction is generational. The
  * {@link io.atomix.copycat.server.storage.compaction.MinorCompactionManager} is more likely to select segments that haven't
  * yet been compacted than ones that have. Once a set of segments have been compacted, for each segment a
  * {@link io.atomix.copycat.server.storage.compaction.MinorCompactionTask} rewrites the segment without cleaned entries.
  * This rewriting results in a segment with missing entries, and Copycat's Raft implementation accounts for that. For
  * instance, a segment with entries {@code {1, 2, 3}} can become {@code {1, 3}} after being cleaned, and any attempt to
- * {@link #get(long) read} entry {@code 2} will result in a {@code null} entry.
+ * {@link #getEntry(long) read} entry {@code 2} will result in a {@code null} entry.
  * <p>
  * However, note that minor compaction only applies to non-tombstone entries. Tombstones are entries that represent the
  * removal of state from the system, and that requires a more careful and costly compaction process to ensure consistency
@@ -108,9 +111,9 @@ import java.util.concurrent.Executors;
  * handle. Major compaction works similarly to minor compaction in that the configured
  * {@link Storage#majorCompactionInterval()} dictates the interval at which the major compaction process runs. During
  * major compaction, the {@link io.atomix.copycat.server.storage.compaction.MajorCompactionManager} iterates through
- * <em>all</em> {@link #commit(long) committed} segments and rewrites them sequentially with all cleaned entries
+ * <em>all</em> {@link #setCommitIndex(long) committed} segments and rewrites them sequentially with all cleaned entries
  * removed, including tombstones. This ensures that earlier segments are compacted before later segments, and so
- * stateful entries that were {@link #clean(long) cleaned} prior to related tombstones are guaranteed to be removed
+ * stateful entries that were {@link #cleanEntry(long) cleaned} prior to related tombstones are guaranteed to be removed
  * first.
  * <p>
  * As entries are removed from the log during minor and major compaction, log segment files begin to shrink. Copycat
@@ -123,18 +126,30 @@ import java.util.concurrent.Executors;
  * @author <a href="http://github.com/kuujo">Jordan Halterman</a>
  */
 public class Log implements AutoCloseable {
+  private final LogDescriptor descriptor;
   final SegmentManager segments;
   private final Compactor compactor;
   private final TypedEntryPool entryPool = new TypedEntryPool();
+  private int leader;
+  private long term;
+  private int vote;
+  private long commitIndex;
+  private long compactIndex;
+  private long globalIndex;
+  private long lastCompleted;
+  private long lastApplied;
   private boolean open = true;
 
   /**
    * @throws NullPointerException if {@code name} or {@code storage} is null
    */
   protected Log(String name, Storage storage) {
+    storage.directory().mkdirs();
+    this.descriptor = new LogDescriptor(name, storage.level() == StorageLevel.MEMORY ? HeapBuffer.allocate(1024) : FileBuffer.allocate(new File(storage.directory(), String.format("%s.log", name)), 1024));
     this.segments = new SegmentManager(name, storage);
-    this.compactor = new Compactor(storage, segments, Executors.newScheduledThreadPool(storage.compactionThreads(),
-        new CatalystThreadFactory("copycat-compactor-%d")));
+    this.compactor = new Compactor(storage, this, segments, Executors.newScheduledThreadPool(storage.compactionThreads(), new CatalystThreadFactory("copycat-compactor-%d")));
+    this.term = descriptor.term();
+    this.vote = descriptor.vote();
   }
 
   /**
@@ -227,7 +242,7 @@ public class Log implements AutoCloseable {
    * @return The index of the first entry in the log or {@code 0} if the log is empty.
    * @throws IllegalStateException If the log is not open.
    */
-  public long firstIndex() {
+  public long getFirstIndex() {
     return !isEmpty() ? segments.firstSegment().descriptor().index() : 0;
   }
 
@@ -239,8 +254,156 @@ public class Log implements AutoCloseable {
    * @return The index of the last entry in the log or {@code 0} if the log is empty.
    * @throws IllegalStateException If the log is not open.
    */
-  public long lastIndex() {
+  public long getLastIndex() {
     return !isEmpty() ? segments.lastSegment().lastIndex() : 0;
+  }
+
+  /**
+   * Returns the current leader.
+   *
+   * @return The current leader.
+   */
+  public int getLeader() {
+    return leader;
+  }
+
+  /**
+   * Sets the current leader.
+   *
+   * @param leader The leader.
+   * @return The log.
+   */
+  public Log setLeader(int leader) {
+    this.leader = leader;
+    this.vote = 0;
+    return this;
+  }
+
+  /**
+   * Returns the log term.
+   *
+   * @return The log term.
+   */
+  public long getTerm() {
+    return descriptor.term();
+  }
+
+  /**
+   * Sets the log term.
+   *
+   * @param term The log term.
+   * @return The log.
+   */
+  public Log setTerm(long term) {
+    if (term > this.term) {
+      this.term = term;
+      descriptor.term(this.term);
+      this.leader = 0;
+      this.vote = 0;
+      descriptor.vote(0);
+    }
+    return this;
+  }
+
+  /**
+   * Returns the last candidate voted for.
+   *
+   * @return The last candidate voted for.
+   */
+  public int getLastVote() {
+    return vote;
+  }
+
+  /**
+   * Sets the last candidate voted for.
+   *
+   * @param candidate The last candidate voted for.
+   * @return The log.
+   */
+  public Log setLastVote(int candidate) {
+    this.vote = candidate;
+    descriptor.vote(candidate);
+    return this;
+  }
+
+  /**
+   * Returns the commit index.
+   *
+   * @return The commit index.
+   */
+  public long getCommitIndex() {
+    return commitIndex;
+  }
+
+  /**
+   * Sets the commit index.
+   *
+   * @param commitIndex The commit index.
+   * @return The log.
+   */
+  public Log setCommitIndex(long commitIndex) {
+    this.commitIndex = Math.max(this.commitIndex, commitIndex);
+    return this;
+  }
+
+  /**
+   * Returns the compact index.
+   *
+   * @return The compact index.
+   */
+  public long getCompactIndex() {
+    return compactIndex > 0 ? compactIndex : lastApplied;
+  }
+
+  /**
+   * Sets the compact index.
+   *
+   * @param compactIndex The compact index.
+   * @return The log.
+   */
+  public Log setCompactIndex(long compactIndex) {
+    this.compactIndex = Math.max(this.compactIndex, compactIndex);
+    return this;
+  }
+
+  /**
+   * Returns the global index.
+   *
+   * @return The global index.
+   */
+  public long getGlobalIndex() {
+    return globalIndex;
+  }
+
+  /**
+   * Sets the global index.
+   *
+   * @param globalIndex The global index.
+   * @return The log.
+   */
+  public Log setGlobalIndex(long globalIndex) {
+    this.globalIndex = Math.max(this.globalIndex, globalIndex);
+    return this;
+  }
+
+  /**
+   * Returns the last applied log index.
+   *
+   * @return The last applied log index.
+   */
+  public long getLastApplied() {
+    return lastApplied;
+  }
+
+  /**
+   * Sets the last applied log index.
+   *
+   * @param lastApplied The last applied log index.
+   * @return The log.
+   */
+  public Log setLastApplied(long lastApplied) {
+    this.lastApplied = Math.max(this.lastApplied, lastApplied);
+    return this;
   }
 
   /**
@@ -264,7 +427,7 @@ public class Log implements AutoCloseable {
    * @throws IllegalStateException If the log is not open
    * @throws NullPointerException If the {@code type} is {@code null}
    */
-  public <T extends Entry<T>> T create(Class<T> type) {
+  public <T extends Entry<T>> T createEntry(Class<T> type) {
     Assert.notNull(type, "type");
     assertIsOpen();
     checkRoll();
@@ -280,7 +443,7 @@ public class Log implements AutoCloseable {
    * @throws NullPointerException If {@code entry} is {@code null}
    * @throws IndexOutOfBoundsException If the entry's index does not match the expected next log index.
    */
-  public long append(Entry entry) {
+  public long appendEntry(Entry entry) {
     Assert.notNull(entry, "entry");
     assertIsOpen();
     checkRoll();
@@ -310,7 +473,7 @@ public class Log implements AutoCloseable {
    * @throws IllegalStateException If the log is not open.
    * @throws IndexOutOfBoundsException If the given index is not within the bounds of the log.
    */
-  public <T extends Entry> T get(long index) {
+  public <T extends Entry> T getEntry(long index) {
     assertIsOpen();
     assertValidIndex(index);
 
@@ -326,9 +489,9 @@ public class Log implements AutoCloseable {
     if (entry != null) {
       // If the entry has not been cleaned by the state machine, return it. Note that the call to isClean()
       // on the segment will be done in O(1) time since the search was already done in the get() call.
-      // We also return entries where the index is greater than the server's globalIndex (represented by
-      // the compactor's majorIndex) in order to ensure commands which trigger events are replicated.
-      if (!segment.isClean(index) || index > compactor.majorIndex()) {
+      // We also return entries where the index is greater than the server's globalIndex in order to ensure
+      // commands which trigger events are replicated.
+      if (!segment.isClean(index) || index > globalIndex) {
         return entry;
       }
     }
@@ -338,7 +501,7 @@ public class Log implements AutoCloseable {
   /**
    * Returns a boolean value indicating whether the given index is within the bounds of the log.
    * <p>
-   * If the index is less than {@code 1} or greater than {@link Log#lastIndex()} then this method will return
+   * If the index is less than {@code 1} or greater than {@link Log#getLastIndex()} then this method will return
    * {@code false}, otherwise {@code true}.
    *
    * @param index The index to check.
@@ -346,8 +509,8 @@ public class Log implements AutoCloseable {
    * @throws IllegalStateException If the log is not open.
    */
   private boolean validIndex(long index) {
-    long firstIndex = firstIndex();
-    long lastIndex = lastIndex();
+    long firstIndex = getFirstIndex();
+    long lastIndex = getLastIndex();
     return !isEmpty() && firstIndex <= index && index <= lastIndex;
   }
 
@@ -358,7 +521,7 @@ public class Log implements AutoCloseable {
    * @return Indicates whether the log contains a live entry at the given index.
    * @throws IllegalStateException If the log is not open.
    */
-  public boolean contains(long index) {
+  public boolean containsEntry(long index) {
     if (!validIndex(index))
       return false;
 
@@ -374,7 +537,7 @@ public class Log implements AutoCloseable {
    * @throws IllegalStateException If the log is not open.
    * @throws IndexOutOfBoundsException If the given index is not within the bounds of the log.
    */
-  public Log clean(long index) {
+  public Log cleanEntry(long index) {
     assertIsOpen();
     assertValidIndex(index);
 
@@ -385,22 +548,9 @@ public class Log implements AutoCloseable {
   }
 
   /**
-   * Commits entries up to the given index to the log.
-   *
-   * @param index The index up to which to commit entries.
-   * @return The log.
-   * @throws IllegalStateException If the log is not open.
-   */
-  public Log commit(long index) {
-    assertIsOpen();
-    segments.commitIndex(index);
-    return this;
-  }
-
-  /**
    * Skips the given number of entries.
    * <p>
-   * This method essentially advances the log's {@link Log#lastIndex()} without writing any entries at the interim
+   * This method essentially advances the log's {@link Log#getLastIndex()} without writing any entries at the interim
    * indices. Note that calling {@code Loggable#truncate()} after {@code skip()} will result in the skipped entries
    * being partially or completely reverted.
    *
@@ -430,9 +580,9 @@ public class Log implements AutoCloseable {
     assertIsOpen();
     if (index > 0)
       assertValidIndex(index);
-    Assert.index(index >= segments.commitIndex(), "cannot truncate committed entries");
+    Assert.index(index > commitIndex || commitIndex == 0, "cannot truncate committed entries");
 
-    if (lastIndex() == index)
+    if (getLastIndex() == index)
       return this;
 
     boolean first = true;
@@ -466,6 +616,7 @@ public class Log implements AutoCloseable {
   public void close() {
     assertIsOpen();
     flush();
+    descriptor.close();
     segments.close();
     compactor.close();
     open = false;

--- a/server/src/main/java/io/atomix/copycat/server/storage/LogDescriptor.java
+++ b/server/src/main/java/io/atomix/copycat/server/storage/LogDescriptor.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License
+ */
+package io.atomix.copycat.server.storage;
+
+import io.atomix.catalyst.buffer.Buffer;
+import io.atomix.catalyst.util.Assert;
+
+/**
+ * Log descriptor.
+ *
+ * @author <a href="http://github.com/kuujo>Jordan Halterman</a>
+ */
+public final class LogDescriptor implements AutoCloseable {
+  private final String name;
+  private final Buffer buffer;
+
+  LogDescriptor(String name, Buffer buffer) {
+    this.name = Assert.notNull(name, "name");
+    this.buffer = Assert.notNull(buffer, "buffer");
+  }
+
+  /**
+   * Returns the log name.
+   *
+   * @return The log name.
+   */
+  public String name() {
+    return name;
+  }
+
+  /**
+   * Returns the log term.
+   *
+   * @return The log term.
+   */
+  public long term() {
+    return buffer.readLong(0);
+  }
+
+  /**
+   * Writes the log term.
+   *
+   * @param term The log term.
+   */
+  void term(long term) {
+    buffer.writeLong(0, term);
+  }
+
+  /**
+   * Returns the last vote cast by the log.
+   *
+   * @return The last vote cast.
+   */
+  public int vote() {
+    return buffer.readInt(8);
+  }
+
+  /**
+   * Writes the candidate voted for.
+   *
+   * @param candidate The candidate voted for.
+   */
+  void vote(int candidate) {
+    buffer.writeInt(8, candidate);
+  }
+
+  /**
+   * Flushes the descriptor buffer.
+   */
+  void flush() {
+    buffer.flush();
+  }
+
+  @Override
+  public void close() {
+    buffer.close();
+  }
+
+}

--- a/server/src/main/java/io/atomix/copycat/server/storage/Segment.java
+++ b/server/src/main/java/io/atomix/copycat/server/storage/Segment.java
@@ -56,20 +56,18 @@ public class Segment implements AutoCloseable {
   private final Buffer buffer;
   private final OffsetIndex offsetIndex;
   private final OffsetCleaner cleaner;
-  private final SegmentManager manager;
   private long skip = 0;
   private boolean open = true;
 
   /**
    * @throws NullPointerException if any argument is null
    */
-  Segment(Buffer buffer, SegmentDescriptor descriptor, OffsetIndex offsetIndex, OffsetCleaner cleaner, Serializer serializer, SegmentManager manager) {
+  Segment(Buffer buffer, SegmentDescriptor descriptor, OffsetIndex offsetIndex, OffsetCleaner cleaner, Serializer serializer) {
     this.serializer = Assert.notNull(serializer, "serializer");
     this.buffer = Assert.notNull(buffer, "buffer");
     this.descriptor = Assert.notNull(descriptor, "descriptor");
     this.offsetIndex = Assert.notNull(offsetIndex, "offsetIndex");
     this.cleaner = Assert.notNull(cleaner, "cleaner");
-    this.manager = Assert.notNull(manager, "manager");
 
     // Rebuild the index from the segment data.
     long position = buffer.mark().position();
@@ -425,7 +423,6 @@ public class Segment implements AutoCloseable {
    */
   public Segment truncate(long index) {
     assertSegmentOpen();
-    Assert.index(index >= manager.commitIndex(), "cannot truncate committed index");
 
     long offset = relativeOffset(index);
     long lastOffset = offsetIndex.lastOffset();

--- a/server/src/main/java/io/atomix/copycat/server/storage/SegmentManager.java
+++ b/server/src/main/java/io/atomix/copycat/server/storage/SegmentManager.java
@@ -47,7 +47,6 @@ public class SegmentManager implements AutoCloseable {
   private final Storage storage;
   private final NavigableMap<Long, Segment> segments = new ConcurrentSkipListMap<>();
   private Segment currentSegment;
-  private long commitIndex;
 
   /**
    * @throws NullPointerException if {@code segments} is null
@@ -65,26 +64,6 @@ public class SegmentManager implements AutoCloseable {
    */
   public Serializer serializer() {
     return storage.serializer();
-  }
-
-  /**
-   * Sets the log commit index.
-   *
-   * @param index The log commit index.
-   * @return The segment manager.
-   */
-  SegmentManager commitIndex(long index) {
-    this.commitIndex = Math.max(this.commitIndex, index);
-    return this;
-  }
-
-  /**
-   * Returns the log compact index.
-   *
-   * @return The log compact index.
-   */
-  public long commitIndex() {
-    return commitIndex;
   }
 
   /**
@@ -291,7 +270,7 @@ public class SegmentManager implements AutoCloseable {
     File segmentFile = SegmentFile.createSegmentFile(name, storage.directory(), descriptor.id(), descriptor.version());
     Buffer buffer = FileBuffer.allocate(segmentFile, Math.min(DEFAULT_BUFFER_SIZE, descriptor.maxSegmentSize()), Integer.MAX_VALUE);
     descriptor.copyTo(buffer);
-    Segment segment = new Segment(buffer.slice(), descriptor, createIndex(descriptor), new OffsetCleaner(), storage.serializer().clone(), this);
+    Segment segment = new Segment(buffer.slice(), descriptor, createIndex(descriptor), new OffsetCleaner(), storage.serializer().clone());
     LOGGER.debug("Created segment: {}", segment);
     return segment;
   }
@@ -303,7 +282,7 @@ public class SegmentManager implements AutoCloseable {
     File segmentFile = SegmentFile.createSegmentFile(name, storage.directory(), descriptor.id(), descriptor.version());
     Buffer buffer = MappedBuffer.allocate(segmentFile, Math.min(DEFAULT_BUFFER_SIZE, descriptor.maxSegmentSize()), Integer.MAX_VALUE);
     descriptor.copyTo(buffer);
-    Segment segment = new Segment(buffer.slice(), descriptor, createIndex(descriptor), new OffsetCleaner(), storage.serializer().clone(), this);
+    Segment segment = new Segment(buffer.slice(), descriptor, createIndex(descriptor), new OffsetCleaner(), storage.serializer().clone());
     LOGGER.debug("Created segment: {}", segment);
     return segment;
   }
@@ -314,7 +293,7 @@ public class SegmentManager implements AutoCloseable {
   private Segment createMemorySegment(SegmentDescriptor descriptor) {
     Buffer buffer = HeapBuffer.allocate(Math.min(DEFAULT_BUFFER_SIZE, descriptor.maxSegmentSize()), Integer.MAX_VALUE);
     descriptor.copyTo(buffer);
-    Segment segment = new Segment(buffer.slice(), descriptor, createIndex(descriptor), new OffsetCleaner(), storage.serializer().clone(), this);
+    Segment segment = new Segment(buffer.slice(), descriptor, createIndex(descriptor), new OffsetCleaner(), storage.serializer().clone());
     LOGGER.debug("Created segment: {}", segment);
     return segment;
   }
@@ -342,7 +321,7 @@ public class SegmentManager implements AutoCloseable {
     File file = SegmentFile.createSegmentFile(name, storage.directory(), segmentId, segmentVersion);
     Buffer buffer = FileBuffer.allocate(file, Math.min(DEFAULT_BUFFER_SIZE, storage.maxSegmentSize()), Integer.MAX_VALUE);
     SegmentDescriptor descriptor = new SegmentDescriptor(buffer);
-    Segment segment = new Segment(buffer.position(SegmentDescriptor.BYTES).slice(), descriptor, createIndex(descriptor), new OffsetCleaner(), storage.serializer().clone(), this);
+    Segment segment = new Segment(buffer.position(SegmentDescriptor.BYTES).slice(), descriptor, createIndex(descriptor), new OffsetCleaner(), storage.serializer().clone());
     LOGGER.debug("Loaded file segment: {} ({})", descriptor.id(), file.getName());
     return segment;
   }
@@ -354,7 +333,7 @@ public class SegmentManager implements AutoCloseable {
     File file = SegmentFile.createSegmentFile(name, storage.directory(), segmentId, segmentVersion);
     Buffer buffer = MappedBuffer.allocate(file, Math.min(DEFAULT_BUFFER_SIZE, storage.maxSegmentSize()), Integer.MAX_VALUE);
     SegmentDescriptor descriptor = new SegmentDescriptor(buffer);
-    Segment segment = new Segment(buffer.position(SegmentDescriptor.BYTES).slice(), descriptor, createIndex(descriptor), new OffsetCleaner(), storage.serializer().clone(), this);
+    Segment segment = new Segment(buffer.position(SegmentDescriptor.BYTES).slice(), descriptor, createIndex(descriptor), new OffsetCleaner(), storage.serializer().clone());
     LOGGER.debug("Loaded mapped segment: {} ({})", descriptor.id(), file.getName());
     return segment;
   }
@@ -365,7 +344,7 @@ public class SegmentManager implements AutoCloseable {
   private Segment loadMemorySegment(long segmentId, long segmentVersion) {
     Buffer buffer = HeapBuffer.allocate(Math.min(DEFAULT_BUFFER_SIZE, storage.maxSegmentSize()), Integer.MAX_VALUE);
     SegmentDescriptor descriptor = new SegmentDescriptor(buffer);
-    Segment segment = new Segment(buffer.position(SegmentDescriptor.BYTES).slice(), descriptor, createIndex(descriptor), new OffsetCleaner(), storage.serializer().clone(), this);
+    Segment segment = new Segment(buffer.position(SegmentDescriptor.BYTES).slice(), descriptor, createIndex(descriptor), new OffsetCleaner(), storage.serializer().clone());
     LOGGER.debug("Loaded memory segment: {}", descriptor.id());
     return segment;
   }

--- a/server/src/main/java/io/atomix/copycat/server/storage/compaction/Compaction.java
+++ b/server/src/main/java/io/atomix/copycat/server/storage/compaction/Compaction.java
@@ -35,7 +35,7 @@ public enum Compaction {
    * Represents a minor compaction.
    * <p>
    * Minor compaction is the more efficient of the compaction processes which removes
-   * {@link io.atomix.copycat.server.storage.Log#clean(long) cleaned} non-tombstone entries from individual
+   * {@link io.atomix.copycat.server.storage.Log#cleanEntry(long) cleaned} non-tombstone entries from individual
    * {@link io.atomix.copycat.server.storage.Segment}s. See the {@link MinorCompactionTask} for more information.
    */
   MINOR {
@@ -49,7 +49,7 @@ public enum Compaction {
    * Represents a major compaction.
    * <p>
    * Major compaction is the more heavyweight process of removing all
-   * {@link io.atomix.copycat.server.storage.Log#clean(long) cleaned} entries that have been
+   * {@link io.atomix.copycat.server.storage.Log#cleanEntry(long) cleaned} entries that have been
    * {@link io.atomix.copycat.server.storage.Log#commit(long) committed} to the log and combining segment
    * files wherever possible. See the {@link MajorCompactionTask} for more information.
    */

--- a/server/src/main/java/io/atomix/copycat/server/storage/compaction/CompactionManager.java
+++ b/server/src/main/java/io/atomix/copycat/server/storage/compaction/CompactionManager.java
@@ -15,6 +15,7 @@
  */
 package io.atomix.copycat.server.storage.compaction;
 
+import io.atomix.copycat.server.storage.Log;
 import io.atomix.copycat.server.storage.SegmentManager;
 import io.atomix.copycat.server.storage.Storage;
 
@@ -39,9 +40,10 @@ public interface CompactionManager {
    * individual tasks can be run in parallel by operating on different segments in the log.
    *
    * @param storage The storage configuration.
+   * @param log The log.
    * @param segments The segments for which to build compaction tasks.
    * @return An iterable of compaction tasks.
    */
-  Collection<CompactionTask> buildTasks(Storage storage, SegmentManager segments);
+  Collection<CompactionTask> buildTasks(Storage storage, Log log, SegmentManager segments);
 
 }

--- a/server/src/main/java/io/atomix/copycat/server/storage/compaction/MajorCompactionTask.java
+++ b/server/src/main/java/io/atomix/copycat/server/storage/compaction/MajorCompactionTask.java
@@ -42,7 +42,7 @@ import java.util.function.Predicate;
  * the major compaction task rewrites groups of segments provided by the {@link MajorCompactionManager}. For each group
  * of segments, a single compact segment will be created with the same {@code version} and starting {@code index} as
  * the first segment in the group. All entries from all segments in the group that haven't been
- * {@link io.atomix.copycat.server.storage.Log#clean(long) cleaned} will then be written to the new compact segment.
+ * {@link io.atomix.copycat.server.storage.Log#cleanEntry(long) cleaned} will then be written to the new compact segment.
  * Once the rewrite is complete, the compact segment will be locked and the set of old segments deleted.
  * <p>
  * <b>Removing tombstones</b>

--- a/server/src/main/java/io/atomix/copycat/server/storage/compaction/MinorCompactionTask.java
+++ b/server/src/main/java/io/atomix/copycat/server/storage/compaction/MinorCompactionTask.java
@@ -26,7 +26,7 @@ import org.slf4j.LoggerFactory;
 import java.util.Collections;
 
 /**
- * Removes {@link io.atomix.copycat.server.storage.Log#clean(long) cleaned} entries from an individual
+ * Removes {@link io.atomix.copycat.server.storage.Log#cleanEntry(long) cleaned} entries from an individual
  * log {@link Segment} to reclaim disk space.
  * <p>
  * The minor compaction task is a lightweight process that rewrites an individual segment to remove entries for

--- a/server/src/test/java/io/atomix/copycat/server/state/AbstractStateTest.java
+++ b/server/src/test/java/io/atomix/copycat/server/state/AbstractStateTest.java
@@ -89,9 +89,9 @@ public abstract class AbstractStateTest<T extends AbstractState> extends Concurr
    */
   protected void append(int entries, long term) throws Throwable {
     for (int i = 0; i < entries; i++) {
-      try (TestEntry entry = serverState.getLog().create(TestEntry.class)) {
+      try (TestEntry entry = serverState.getLog().createEntry(TestEntry.class)) {
         entry.setTerm(term).setTombstone(false);
-        serverState.getLog().append(entry);
+        serverState.getLog().appendEntry(entry);
       }
     }
   }
@@ -100,7 +100,7 @@ public abstract class AbstractStateTest<T extends AbstractState> extends Concurr
    * Gets the entry at the given index.
    */
   protected <T extends Entry> T get(long index) throws Throwable {
-    return serverState.getLog().get(index);
+    return serverState.getLog().getEntry(index);
   }
 
   /**
@@ -124,7 +124,7 @@ public abstract class AbstractStateTest<T extends AbstractState> extends Concurr
   protected List<TestEntry> entries(int entries, long term) {
     List<TestEntry> result = new ArrayList<>();
     for (int i = 0; i < entries; i++) {
-      try (TestEntry entry = serverState.getLog().create(TestEntry.class)) {
+      try (TestEntry entry = serverState.getLog().createEntry(TestEntry.class)) {
         result.add(entry.setTerm(term).setTombstone(false));
       }
     }

--- a/server/src/test/java/io/atomix/copycat/server/state/CandidateStateTest.java
+++ b/server/src/test/java/io/atomix/copycat/server/state/CandidateStateTest.java
@@ -45,7 +45,7 @@ public class CandidateStateTest extends AbstractStateTest<CandidateState> {
   public void testCandidateAppendAndTransitionOnTerm() throws Throwable {
     runOnServer(() -> {
       int leader = serverState.getCluster().getActiveMembers().iterator().next().getAddress().hashCode();
-      serverState.setTerm(1);
+      serverState.getLog().setTerm(1);
       AppendRequest request = AppendRequest.builder()
         .withTerm(2)
         .withLeader(leader)
@@ -57,7 +57,7 @@ public class CandidateStateTest extends AbstractStateTest<CandidateState> {
 
       assertEquals(response.status(), Response.Status.OK);
       assertTrue(response.succeeded());
-      assertEquals(serverState.getTerm(), 2L);
+      assertEquals(serverState.getLog().getTerm(), 2L);
       assertEquals(serverState.getLeader().hashCode(), leader);
       assertEquals(response.term(), 2L);
       assertEquals(serverState.getState(), RaftServer.State.FOLLOWER);
@@ -67,23 +67,23 @@ public class CandidateStateTest extends AbstractStateTest<CandidateState> {
   public void testCandidateIncrementsTermVotesForSelfOnElection() throws Throwable {
     runOnServer(() -> {
       int self = serverState.getAddress().hashCode();
-      serverState.setTerm(2);
+      serverState.getLog().setTerm(2);
 
       state.startElection();
 
-      assertEquals(serverState.getTerm(), 3L);
-      assertEquals(serverState.getLastVotedFor(), self);
+      assertEquals(serverState.getLog().getTerm(), 3L);
+      assertEquals(serverState.getLog().getLastVote(), self);
     });
   }
 
   public void testCandidateVotesForSelfOnRequest() throws Throwable {
     runOnServer(() -> {
       int self = serverState.getAddress().hashCode();
-      serverState.setTerm(2);
+      serverState.getLog().setTerm(2);
 
       state.startElection();
 
-      assertEquals(serverState.getTerm(), 3L);
+      assertEquals(serverState.getLog().getTerm(), 3L);
 
       VoteRequest request = VoteRequest.builder()
         .withTerm(3)
@@ -96,8 +96,8 @@ public class CandidateStateTest extends AbstractStateTest<CandidateState> {
 
       assertEquals(response.status(), Response.Status.OK);
       assertTrue(response.voted());
-      assertEquals(serverState.getTerm(), 3L);
-      assertEquals(serverState.getLastVotedFor(), self);
+      assertEquals(serverState.getLog().getTerm(), 3L);
+      assertEquals(serverState.getLog().getLastVote(), self);
       assertEquals(response.term(), 3L);
     });
   }
@@ -105,11 +105,11 @@ public class CandidateStateTest extends AbstractStateTest<CandidateState> {
   public void testCandidateVotesAndTransitionsOnTerm() throws Throwable {
     runOnServer(() -> {
       int candidate = serverState.getCluster().getActiveMembers().iterator().next().getAddress().hashCode();
-      serverState.setTerm(1);
+      serverState.getLog().setTerm(1);
 
       state.startElection();
 
-      assertEquals(serverState.getTerm(), 2L);
+      assertEquals(serverState.getLog().getTerm(), 2L);
 
       VoteRequest request = VoteRequest.builder()
         .withTerm(3)
@@ -122,8 +122,8 @@ public class CandidateStateTest extends AbstractStateTest<CandidateState> {
 
       assertEquals(response.status(), Response.Status.OK);
       assertTrue(response.voted());
-      assertEquals(serverState.getTerm(), 3L);
-      assertEquals(serverState.getLastVotedFor(), candidate);
+      assertEquals(serverState.getLog().getTerm(), 3L);
+      assertEquals(serverState.getLog().getLastVote(), candidate);
       assertEquals(response.term(), 3L);
       assertEquals(serverState.getState(), RaftServer.State.FOLLOWER);
     });
@@ -132,13 +132,13 @@ public class CandidateStateTest extends AbstractStateTest<CandidateState> {
   public void testCandidateRejectsVoteAndTransitionsOnTerm() throws Throwable {
     runOnServer(() -> {
       int candidate = serverState.getCluster().getActiveMembers().iterator().next().getAddress().hashCode();
-      serverState.setTerm(1);
+      serverState.getLog().setTerm(1);
 
       append(2, 1);
 
       state.startElection();
 
-      assertEquals(serverState.getTerm(), 2L);
+      assertEquals(serverState.getLog().getTerm(), 2L);
 
       VoteRequest request = VoteRequest.builder()
         .withTerm(3)
@@ -151,8 +151,8 @@ public class CandidateStateTest extends AbstractStateTest<CandidateState> {
 
       assertEquals(response.status(), Response.Status.OK);
       assertFalse(response.voted());
-      assertEquals(serverState.getTerm(), 3L);
-      assertEquals(serverState.getLastVotedFor(), 0);
+      assertEquals(serverState.getLog().getTerm(), 3L);
+      assertEquals(serverState.getLog().getLastVote(), 0);
       assertEquals(response.term(), 3L);
       assertEquals(serverState.getState(), RaftServer.State.FOLLOWER);
     });
@@ -180,12 +180,12 @@ public class CandidateStateTest extends AbstractStateTest<CandidateState> {
 
     runOnServer(() -> {
       int self = serverState.getAddress().hashCode();
-      serverState.setTerm(1);
+      serverState.getLog().setTerm(1);
 
       state.startElection();
 
-      assertEquals(serverState.getTerm(), 2L);
-      assertEquals(serverState.getLastVotedFor(), self);
+      assertEquals(serverState.getLog().getTerm(), 2L);
+      assertEquals(serverState.getLog().getLastVote(), self);
     });
     await(1000);
   }
@@ -212,12 +212,12 @@ public class CandidateStateTest extends AbstractStateTest<CandidateState> {
 
     runOnServer(() -> {
       int self = serverState.getAddress().hashCode();
-      serverState.setTerm(1);
+      serverState.getLog().setTerm(1);
 
       state.startElection();
 
-      assertEquals(serverState.getTerm(), 2L);
-      assertEquals(serverState.getLastVotedFor(), self);
+      assertEquals(serverState.getLog().getTerm(), 2L);
+      assertEquals(serverState.getLog().getLastVote(), self);
     });
     await(1000);
   }

--- a/server/src/test/java/io/atomix/copycat/server/state/PassiveStateTest.java
+++ b/server/src/test/java/io/atomix/copycat/server/state/PassiveStateTest.java
@@ -67,7 +67,7 @@ public class PassiveStateTest extends AbstractStateTest<PassiveState> {
       state.applyCommits(3);
 
       // TODO more assertions
-      threadAssertEquals(serverState.getCommitIndex(), 3L);
+      threadAssertEquals(serverState.getLog().getCommitIndex(), 3L);
     });
   }
 
@@ -81,7 +81,7 @@ public class PassiveStateTest extends AbstractStateTest<PassiveState> {
 
   public void testAppendUpdatesLeaderAndTerm() throws Throwable {
     runOnServer(() -> {
-      serverState.setTerm(1);
+      serverState.getLog().setTerm(1);
       AppendRequest request = AppendRequest.builder()
           .withTerm(2)
           .withLeader(members.get(1).hashCode())
@@ -93,9 +93,9 @@ public class PassiveStateTest extends AbstractStateTest<PassiveState> {
 
       AppendResponse response = state.append(request).get();
       
-      threadAssertEquals(serverState.getTerm(), 2L);
+      threadAssertEquals(serverState.getLog().getTerm(), 2L);
       threadAssertEquals(serverState.getLeader(), members.get(1));
-      threadAssertEquals(serverState.getLastVotedFor(), 0);
+      threadAssertEquals(serverState.getLog().getLastVote(), 0);
       threadAssertEquals(response.term(), 2L);
       threadAssertTrue(response.succeeded());
     });
@@ -104,7 +104,7 @@ public class PassiveStateTest extends AbstractStateTest<PassiveState> {
   public void testAppendTermAndLeaderUpdated() throws Throwable {
     runOnServer(() -> {
       int leader = serverState.getCluster().getActiveMembers().iterator().next().getAddress().hashCode();
-      serverState.setTerm(1);
+      serverState.getLog().setTerm(1);
       AppendRequest request = AppendRequest.builder()
         .withTerm(2)
         .withLeader(leader)
@@ -116,7 +116,7 @@ public class PassiveStateTest extends AbstractStateTest<PassiveState> {
 
       assertEquals(response.status(), Status.OK);
       assertTrue(response.succeeded());
-      assertEquals(serverState.getTerm(), 2L);
+      assertEquals(serverState.getLog().getTerm(), 2L);
       assertEquals(serverState.getLeader().hashCode(), leader);
       assertEquals(response.term(), 2L);
     });
@@ -124,7 +124,7 @@ public class PassiveStateTest extends AbstractStateTest<PassiveState> {
 
   public void testRejectAppendOnTerm() throws Throwable {
     runOnServer(() -> {
-      serverState.setTerm(2);
+      serverState.getLog().setTerm(2);
       append(2, 2);
 
       AppendRequest request = AppendRequest.builder()
@@ -147,7 +147,7 @@ public class PassiveStateTest extends AbstractStateTest<PassiveState> {
 
   public void testRejectAppendOnMissingLogIndex() throws Throwable {
     runOnServer(() -> {
-      serverState.setTerm(2);
+      serverState.getLog().setTerm(2);
       append(1, 2);
 
       AppendRequest request = AppendRequest.builder()
@@ -170,7 +170,7 @@ public class PassiveStateTest extends AbstractStateTest<PassiveState> {
 
   public void testRejectAppendOnSkippedLogIndex() throws Throwable {
     runOnServer(() -> {
-      serverState.setTerm(1);
+      serverState.getLog().setTerm(1);
       serverState.getLog().skip(1);
 
       AppendRequest request = AppendRequest.builder()
@@ -194,7 +194,7 @@ public class PassiveStateTest extends AbstractStateTest<PassiveState> {
 
   public void testRejectAppendOnInconsistentLogTerm() throws Throwable {
     runOnServer(() -> {
-      serverState.setTerm(2);
+      serverState.getLog().setTerm(2);
       append(2, 1);
 
       AppendRequest request = AppendRequest.builder()
@@ -217,7 +217,7 @@ public class PassiveStateTest extends AbstractStateTest<PassiveState> {
 
   public void testAppendOnEmptyLog() throws Throwable {
     runOnServer(() -> {
-      serverState.setTerm(1);
+      serverState.getLog().setTerm(1);
 
       AppendRequest request = AppendRequest.builder()
         .withTerm(1)
@@ -243,7 +243,7 @@ public class PassiveStateTest extends AbstractStateTest<PassiveState> {
 
   public void testAppendOnNonEmptyLog() throws Throwable {
     runOnServer(() -> {
-      serverState.setTerm(1);
+      serverState.getLog().setTerm(1);
       append(1, 1);
 
       AppendRequest request = AppendRequest.builder()
@@ -270,7 +270,7 @@ public class PassiveStateTest extends AbstractStateTest<PassiveState> {
 
   public void testAppendOnPartiallyConflictingEntries() throws Throwable {
     runOnServer(() -> {
-      serverState.setTerm(1);
+      serverState.getLog().setTerm(1);
       append(1, 1);
       append(2, 2);
 
@@ -300,7 +300,7 @@ public class PassiveStateTest extends AbstractStateTest<PassiveState> {
 
   public void testAppendSkippedEntries() throws Throwable {
     runOnServer(() -> {
-      serverState.setTerm(1);
+      serverState.getLog().setTerm(1);
       append(1, 1);
 
       AppendRequest request = AppendRequest.builder()

--- a/server/src/test/java/io/atomix/copycat/server/storage/AbstractLogTest.java
+++ b/server/src/test/java/io/atomix/copycat/server/storage/AbstractLogTest.java
@@ -146,9 +146,9 @@ public abstract class AbstractLogTest {
   protected List<Long> appendEntries(int numEntries, int startingId, boolean tombstone) {
     List<Integer> entryIds = IntStream.range(startingId, startingId + numEntries).boxed().collect(Collectors.toList());
     return entryIds.stream().map(entryId -> {
-      try (TestEntry entry = log.create(TestEntry.class)) {
+      try (TestEntry entry = log.createEntry(TestEntry.class)) {
         entry.setTerm(1).setTombstone(tombstone).setPadding(entryPadding);
-        return log.append(entry);
+        return log.appendEntry(entry);
       }
     }).collect(Collectors.toList());
   }
@@ -160,7 +160,7 @@ public abstract class AbstractLogTest {
 
   protected void cleanAndCompact(int startIndex, int endIndex) {
     for (int i = startIndex; i <= endIndex; i++) {
-      log.clean(i);
+      log.cleanEntry(i);
     }
 
     log.compactor().compact(Compaction.MAJOR).join();
@@ -168,13 +168,13 @@ public abstract class AbstractLogTest {
 
   protected void assertCompacted(int startIndex, int endIndex) {
     for (int i = startIndex; i <= endIndex; i++) {
-      assertNull(log.get(i));
+      assertNull(log.getEntry(i));
     }
   }
   
   protected void printLog() {
     for (int i = 1; i < log.length(); i++) {
-      System.out.println(log.get(i).toString());
+      System.out.println(log.getEntry(i).toString());
     }
   }
 }

--- a/server/src/test/java/io/atomix/copycat/server/storage/FileLogTest.java
+++ b/server/src/test/java/io/atomix/copycat/server/storage/FileLogTest.java
@@ -50,8 +50,8 @@ public class FileLogTest extends LogTest {
     try (Log log = createLog()) {
       assertEquals(log.length(), entriesPerSegment * 5);
 
-      for (long i = log.firstIndex(); i <= log.lastIndex(); i++) {
-        try (Entry entry = log.get(i)) {
+      for (long i = log.getFirstIndex(); i <= log.getLastIndex(); i++) {
+        try (Entry entry = log.getEntry(i)) {
           assertEquals(entry.getIndex(), i);
         }
       }
@@ -65,18 +65,18 @@ public class FileLogTest extends LogTest {
     appendEntries(entriesPerSegment * 5);
     for (long i = 1; i <= entriesPerSegment * 5; i++) {
       if (i % 3 == 0 || i % 3 == 1) {
-        log.clean(i);
+        log.cleanEntry(i);
       }
     }
 
     for (long i = 1; i <= entriesPerSegment * 5; i++) {
       if (i % 3 == 0 || i % 3 == 1) {
-        assertTrue(log.lastIndex() >= i);
-        assertTrue(log.contains(i));
+        assertTrue(log.getLastIndex() >= i);
+        assertTrue(log.containsEntry(i));
       }
     }
 
-    log.commit(entriesPerSegment * 5).compactor().minorIndex(entriesPerSegment * 5).compact().join();
+    log.setCommitIndex(entriesPerSegment * 5).setCompactIndex(entriesPerSegment * 5).compactor().compact().join();
     log.close();
 
     try (Log log = createLog()) {
@@ -84,10 +84,10 @@ public class FileLogTest extends LogTest {
       
       for (long i = 1; i <= entriesPerSegment * 5; i++) {
         if (i % 3 == 0 || i % 3 == 1) {
-          assertTrue(log.lastIndex() >= i);
+          assertTrue(log.getLastIndex() >= i);
           if (i <= entriesPerSegment * 4) {
-            assertFalse(log.contains(i));
-            assertNull(log.get(i));
+            assertFalse(log.containsEntry(i));
+            assertNull(log.getEntry(i));
           }
         }
       }

--- a/server/src/test/java/io/atomix/copycat/server/storage/MajorCompactionTest.java
+++ b/server/src/test/java/io/atomix/copycat/server/storage/MajorCompactionTest.java
@@ -49,9 +49,9 @@ public class MajorCompactionTest extends AbstractLogTest {
     assertEquals(log.length(), 31L);
 
     for (long index = 21; index < 28; index++) {
-      log.clean(index);
+      log.cleanEntry(index);
     }
-    log.commit(31).compactor().minorIndex(31).majorIndex(31);
+    log.setCommitIndex(31).setCompactIndex(31).setGlobalIndex(31);
 
     CountDownLatch latch = new CountDownLatch(1);
     log.compactor().compact(Compaction.MAJOR).thenRun(latch::countDown);
@@ -60,9 +60,9 @@ public class MajorCompactionTest extends AbstractLogTest {
     assertEquals(log.length(), 31L);
 
     for (long index = 21; index < 28; index++) {
-      assertTrue(log.lastIndex() >= index);
-      assertFalse(log.contains(index));
-      try (TestEntry entry = log.get(index)) {
+      assertTrue(log.getLastIndex() >= index);
+      assertFalse(log.containsEntry(index));
+      try (TestEntry entry = log.getEntry(index)) {
         assertNull(entry);
       }
     }
@@ -73,14 +73,14 @@ public class MajorCompactionTest extends AbstractLogTest {
    */
   private void writeEntries(int entries) {
     for (int i = 0; i < entries; i++) {
-      try (TestEntry entry = log.create(TestEntry.class)) {
+      try (TestEntry entry = log.createEntry(TestEntry.class)) {
         entry.setTerm(1);
         if (entry.getIndex() % 2 == 0) {
           entry.setTombstone(true);
         } else {
           entry.setTombstone(false);
         }
-        log.append(entry);
+        log.appendEntry(entry);
       }
     }
   }

--- a/server/src/test/java/io/atomix/copycat/server/storage/MinorCompactionTest.java
+++ b/server/src/test/java/io/atomix/copycat/server/storage/MinorCompactionTest.java
@@ -49,9 +49,9 @@ public class MinorCompactionTest extends AbstractLogTest {
     assertEquals(log.length(), 31L);
 
     for (long index = 21; index < 28; index++) {
-      log.clean(index);
+      log.cleanEntry(index);
     }
-    log.commit(31).compactor().minorIndex(31);
+    log.setCommitIndex(31).setCompactIndex(31);
 
     CountDownLatch latch = new CountDownLatch(1);
     log.compactor().compact(Compaction.MINOR).thenRun(latch::countDown);
@@ -60,15 +60,15 @@ public class MinorCompactionTest extends AbstractLogTest {
     assertEquals(log.length(), 31L);
 
     for (long index = 21; index < 28; index++) {
-      assertTrue(log.lastIndex() >= index);
+      assertTrue(log.getLastIndex() >= index);
       if (index % 2 != 0) {
-        assertFalse(log.contains(index));
-        try (TestEntry entry = log.get(index)) {
+        assertFalse(log.containsEntry(index));
+        try (TestEntry entry = log.getEntry(index)) {
           assertNull(entry);
         }
       } else {
-        assertTrue(log.contains(index));
-        try (TestEntry entry = log.get(index)) {
+        assertTrue(log.containsEntry(index));
+        try (TestEntry entry = log.getEntry(index)) {
           assertNotNull(entry);
         }
       }
@@ -80,7 +80,7 @@ public class MinorCompactionTest extends AbstractLogTest {
    */
   private void writeEntries(int entries) {
     for (int i = 0; i < entries; i++) {
-      try (TestEntry entry = log.create(TestEntry.class)) {
+      try (TestEntry entry = log.createEntry(TestEntry.class)) {
         entry.setTerm(1);
         entry.setPadding(1);
         if (entry.getIndex() % 2 == 0) {
@@ -88,7 +88,7 @@ public class MinorCompactionTest extends AbstractLogTest {
         } else {
           entry.setTombstone(false);
         }
-        log.append(entry);
+        log.appendEntry(entry);
       }
     }
   }


### PR DESCRIPTION
This PR moves persistent and volatile server state into the log. The reasoning behind this is because the Raft algorithm specifies that `term` and `votedFor` should both be written to disk. So, we add a `LogDescriptor` to the log and write term and election information to that file. In order to ensure the API isn't spread around too much, I decided to simply move all the state for a server into the `Log`. This doesn't totally feel right, but there's bound to be some awkwardness since only *some* server state is persisted and some is held in memory only.

I don't intend to merge this pull request immediately, but I want to start some discussion on the design since it feels a bit dirty, but maybe that's all in my head. The new `Log` methods need more tests, and tests for recovering `term` and `vote` should be added to recovery tests as well.