### PR TITLE
Truncate segments in reverse order to prevent gaps in the log

### DIFF
--- a/server/src/main/java/io/atomix/copycat/server/storage/Log.java
+++ b/server/src/main/java/io/atomix/copycat/server/storage/Log.java
@@ -435,12 +435,11 @@ public class Log implements AutoCloseable {
     if (lastIndex() == index)
       return this;
 
-    boolean first = true;
-    for (Segment segment : segments.segments()) {
-      if (first && index == 0 || segment.validIndex(index)) {
+    for (Segment segment : segments.reverseSegments()) {
+      if (segment.validIndex(index)) {
         segment.truncate(index);
-        first = false;
-      } else if (segment.descriptor().index() > index) {
+        break;
+      } else if (segment.index() > index) {
         segments.removeSegment(segment);
       }
     }

--- a/server/src/main/java/io/atomix/copycat/server/storage/SegmentManager.java
+++ b/server/src/main/java/io/atomix/copycat/server/storage/SegmentManager.java
@@ -215,6 +215,15 @@ public class SegmentManager implements AutoCloseable {
   }
 
   /**
+   * Returns the collection of segments in reverse order.
+   *
+   * @return A reverse ordered collection of segments.
+   */
+  public Collection<Segment> reverseSegments() {
+    return segments.descendingMap().values();
+  }
+
+  /**
    * Returns the segment for the given index.
    *
    * @param index The index for which to return the segment.


### PR DESCRIPTION
This PR modifies the `Log.truncate` method to truncate segments in reverse order. This is necessary in order to prevent gaps in the log if a failure occurs while truncating the log. If multiple segments are truncated from the log starting at the first truncated segment, a gap can exists, and in that case the log will interpret the gap as compacted entries. So, this ensures that only segments from the end of the log will have been removed in the event of a failure during `truncate`.