### PR TITLE
Make no-op entries tombstones

### DIFF
--- a/server/src/main/java/io/atomix/copycat/server/storage/entry/NoOpEntry.java
+++ b/server/src/main/java/io/atomix/copycat/server/storage/entry/NoOpEntry.java
@@ -34,6 +34,11 @@ public class NoOpEntry extends TimestampedEntry<NoOpEntry> {
   }
 
   @Override
+  public boolean isTombstone() {
+    return true;
+  }
+
+  @Override
   public String toString() {
     return String.format("%s[index=%d, term=%d, timestamp=%s]", getClass().getSimpleName(), getIndex(), getTerm(), getTimestamp());
   }


### PR DESCRIPTION
This PR marks `NoOpEntry` as a tombstone. This is necessary to ensure that no-op entries are stored and applied on *all* servers. The reason that's critical is because no-op entries now reset session timeouts at the beginning of the leader's term. If a no-op entry is cleaned from the log and not sent to some follower, that follower's session state can become inconsistent if a session expires immediately after the no-op entry.