### PR TITLE
Ensure OffsetIndex position cache does not exceed size of index

### DIFF
--- a/server/src/main/java/io/atomix/copycat/server/storage/OffsetIndex.java
+++ b/server/src/main/java/io/atomix/copycat/server/storage/OffsetIndex.java
@@ -153,7 +153,7 @@ final class OffsetIndex implements AutoCloseable {
 
     if (offset == currentOffset) {
       return currentMatch;
-    } else if (currentOffset != -1 && buffer.readLong((currentMatch + 1) * ENTRY_SIZE) == offset) {
+    } else if (currentOffset != -1 && currentMatch + 1 < size && buffer.readLong((currentMatch + 1) * ENTRY_SIZE) == offset) {
       currentOffset = offset;
       return ++currentMatch;
     }

--- a/server/src/test/java/io/atomix/copycat/server/storage/OffsetIndexTest.java
+++ b/server/src/test/java/io/atomix/copycat/server/storage/OffsetIndexTest.java
@@ -54,6 +54,19 @@ public class OffsetIndexTest {
   }
 
   /**
+   * Tests that the position cache works properly.
+   */
+  public void testPositionCache() {
+    OffsetIndex index = new OffsetIndex(HeapBuffer.allocate(1024 * 8));
+    index.index(2, 0);
+    index.index(3, 40);
+    index.index(4, 80);
+    index.index(5, 120);
+    index.position(5);
+    assertEquals(index.position(0), -1);
+  }
+
+  /**
    * Tests reading the position and length of an offset.
    */
   public void testIndexPositionAndLength() {


### PR DESCRIPTION
I discovered this bug when testing the new implementation of dynamic membership changes. The `OffsetIndex` implementation is optimized for sequential reads which are common in Raft. Essentially, what it does is stores the last index and offset looked up in the `OffsetIndex`. Then, when the log looks up the next index (during sequential reads), the `OffsetIndex` doesn't have to do binary search and instead just checks whether the next index in the `OffsetIndex` matches the requested index and, if so, returns the position of that index. But there was no limitation on the incrementing of the cached index. Thus, when reading a segment sequentially, once the last index was read the cached offset would be incremented and read a `0` value (empty bytes) and interpret that as the position of the `0` index. This resulted in inaccurate information if the entry at index `0` was not at position `0` in the log (which can happen after log compaction). This may be confusing because of the overuse of the terms `index` and `offset` (we're just running out of names for things), but the test case I added illustrates the bug.

The fix is to limit the range of the cached offset such that it can't read beyond the bounds of the index. This only required the addition of a `currentMatch + 1 < size` condition.

@madjam this could also be related to #29 as I was able to get it to consistently reproduce the ISE at https://github.com/atomix/copycat/blob/index-cache/server/src/main/java/io/atomix/copycat/server/storage/Segment.java#L319