### PR TITLE
Ensure one committed entry is always accessible in the log

### DIFF
--- a/server/src/main/java/io/atomix/copycat/server/state/LeaderState.java
+++ b/server/src/main/java/io/atomix/copycat/server/state/LeaderState.java
@@ -1006,16 +1006,7 @@ final class LeaderState extends ActiveState {
       // important to ensure that tombstones are applied to their state machines.
       // If the members list is empty, use the local server's last log index as the global index.
       long globalMatchIndex = context.getCluster().getMembers().stream().mapToLong(MemberState::getMatchIndex).min().orElse(context.getLog().lastIndex());
-
-      // The globalIndex should always be one less than the highest index that is replicated to all members.
-      // This is to ensure prevEntry checks can always be performed for AppendRequests.
-      // Consider the following scenario:
-      // - Entry at index i is a NoOpEntry and it is fully replicated to all members. (NoOpEntries can be garbage collected
-      // as soon as they are replicated to all cluster members.)
-      // - A leadership change occurs and the new leader sends an AppendRequest with logIndex == i.
-      // Any follower should be able to validate that they have this entry in their log with a term that matches
-      // what the new leader is advertising.
-      context.setGlobalIndex(Math.max(globalMatchIndex - 1, 0));
+      context.setGlobalIndex(globalMatchIndex);
 
       // Sort the list of replicas, order by the last index that was replicated to the replica. This will allow
       // us to determine the median index for all known replicated entries across all cluster members.

--- a/server/src/main/java/io/atomix/copycat/server/storage/compaction/MajorCompactionManager.java
+++ b/server/src/main/java/io/atomix/copycat/server/storage/compaction/MajorCompactionManager.java
@@ -22,6 +22,7 @@ import io.atomix.copycat.server.storage.Storage;
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Iterator;
 import java.util.List;
 
 /**
@@ -50,19 +51,19 @@ public final class MajorCompactionManager implements CompactionManager {
 
   @Override
   public List<CompactionTask> buildTasks(Storage storage, SegmentManager segments) {
-    List<List<Segment>> groups = getCleanableGroups(storage, segments);
+    List<List<Segment>> groups = getCompactableGroups(storage, segments);
     return !groups.isEmpty() ? Collections.singletonList(new MajorCompactionTask(segments, groups, compactor.majorIndex())) : Collections.emptyList();
   }
 
   /**
-   * Returns a list of segments lists to clean, where segments are grouped according to how they will be merged during 
-   * cleaning.
+   * Returns a list of segments lists to compact, where segments are grouped according to how they will be merged during
+   * compaction.
    */
-  public List<List<Segment>> getCleanableGroups(Storage storage, SegmentManager manager) {
+  public List<List<Segment>> getCompactableGroups(Storage storage, SegmentManager manager) {
     List<List<Segment>> clean = new ArrayList<>();
     List<Segment> segments = null;
     Segment previousSegment = null;
-    for (Segment segment : getCleanableSegments(manager)) {
+    for (Segment segment : getCompactableSegments(manager)) {
       // If this is the first segment in a segments list, add the segment.
       if (segments == null) {
         segments = new ArrayList<>();
@@ -96,20 +97,28 @@ public final class MajorCompactionManager implements CompactionManager {
   }
 
   /**
-   * Returns a list of cleanable log segments.
+   * Returns a list of compactable log segments.
    *
    * @param manager The segment manager.
-   * @return A list of cleanable log segments.
+   * @return A list of compactable log segments.
    */
-  private List<Segment> getCleanableSegments(SegmentManager manager) {
+  private List<Segment> getCompactableSegments(SegmentManager manager) {
     List<Segment> segments = new ArrayList<>(manager.segments().size());
-    Segment lastSegment = manager.lastSegment();
-    for (Segment segment : manager.segments()) {
-      if ((segment.isFull() || segment.isCompacted()) && segment.lastIndex() < compactor.minorIndex() && lastSegment.firstIndex() <= compactor.minorIndex() && !lastSegment.isEmpty()) {
+    Iterator<Segment> iterator = manager.segments().iterator();
+    Segment segment = iterator.next();
+    while (iterator.hasNext()) {
+      Segment nextSegment = iterator.next();
+
+      // Segments that have already been compacted are eligible for compaction. For uncompacted segments, the segment must be full, consist
+      // of entries less than the minorIndex, and a later segment with at least one committed entry must exist in the log. This ensures that
+      // a non-empty entry always remains at the end of the log.
+      if (segment.isCompacted() || (segment.isFull() && segment.lastIndex() < compactor.minorIndex() && nextSegment.firstIndex() <= manager.commitIndex() && !nextSegment.isEmpty())) {
         segments.add(segment);
       } else {
         break;
       }
+
+      segment = nextSegment;
     }
     return segments;
   }

--- a/server/src/test/java/io/atomix/copycat/server/storage/AbstractLogTest.java
+++ b/server/src/test/java/io/atomix/copycat/server/storage/AbstractLogTest.java
@@ -84,7 +84,8 @@ public abstract class AbstractLogTest {
   @AfterMethod
   protected void deleteLog() {
     try {
-      log.close();
+      if (log.isOpen())
+        log.close();
     } catch (Exception ignore) {
     } finally {
       assertFalse(log.isOpen());

--- a/server/src/test/java/io/atomix/copycat/server/storage/LogTest.java
+++ b/server/src/test/java/io/atomix/copycat/server/storage/LogTest.java
@@ -115,10 +115,11 @@ public abstract class LogTest extends AbstractLogTest {
     for (int i = entriesPerSegment; i <= entriesPerSegment * 2 + 1; i++) {
       assertFalse(log.segments.segment(i).isClean(i));
       log.clean(i);
+      assertTrue(log.segments.segment(i).isClean(i));
       assertNotNull(log.get(i));
     }
-    log.compactor().majorIndex(entriesPerSegment * 2);
-    for (int i = entriesPerSegment; i <= entriesPerSegment * 2; i++) {
+    log.commit(entriesPerSegment * 2).compactor().minorIndex(entriesPerSegment * 2);
+    for (int i = entriesPerSegment; i < entriesPerSegment * 2; i++) {
       assertNull(log.get(i));
     }
   }
@@ -131,10 +132,11 @@ public abstract class LogTest extends AbstractLogTest {
     for (int i = entriesPerSegment; i <= entriesPerSegment * 2 + 1; i++) {
       assertFalse(log.segments.segment(i).isClean(i));
       log.clean(i);
+      assertTrue(log.segments.segment(i).isClean(i));
       assertNotNull(log.get(i));
     }
-    log.compactor().majorIndex(entriesPerSegment * 2);
-    for (int i = entriesPerSegment; i <= entriesPerSegment * 2; i++) {
+    log.commit(entriesPerSegment * 2).compactor().majorIndex(entriesPerSegment * 2);
+    for (int i = entriesPerSegment; i < entriesPerSegment * 2; i++) {
       assertNull(log.get(i));
     }
   }


### PR DESCRIPTION
This PR fixes #60 to ensure that at least one committed entry is always retained in the log and made accessible during `AppendRequest` handling.