### PR TITLE
Persist server term and vote

### DIFF
--- a/server/src/main/java/io/atomix/copycat/server/storage/MetaStore.java
+++ b/server/src/main/java/io/atomix/copycat/server/storage/MetaStore.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License
+ */
+package io.atomix.copycat.server.storage;
+
+import io.atomix.catalyst.buffer.Buffer;
+import io.atomix.catalyst.buffer.FileBuffer;
+import io.atomix.catalyst.buffer.HeapBuffer;
+
+import java.io.File;
+
+/**
+ * Persists server state via the {@link Storage} module.
+ * <p>
+ * The server metastore is responsible for persisting server state according to the configured
+ * {@link Storage#level() storage level}. Each server persists their current {@link #loadTerm() term}
+ * and last {@link #loadVote() vote} as is dictated by the Raft consensus algorithm.
+ *
+ * @author <a href="http://github.com/kuujo>Jordan Halterman</a>
+ */
+public class MetaStore implements AutoCloseable {
+  private final Buffer buffer;
+
+  MetaStore(String name, Storage storage) {
+    if (storage.level() == StorageLevel.MEMORY) {
+      buffer = HeapBuffer.allocate(12);
+    } else {
+      storage.directory().mkdirs();
+      File file = new File(storage.directory(), String.format("%s.meta", name));
+      buffer = FileBuffer.allocate(file, 12);
+    }
+  }
+
+  /**
+   * Stores the current server term.
+   *
+   * @param term The current server term.
+   * @return The metastore.
+   */
+  public MetaStore storeTerm(long term) {
+    buffer.writeLong(0, term);
+    return this;
+  }
+
+  /**
+   * Loads the stored server term.
+   *
+   * @return The stored server term.
+   */
+  public long loadTerm() {
+    return buffer.readLong(0);
+  }
+
+  /**
+   * Stores the last voted server.
+   *
+   * @param vote The server vote.
+   * @return The metastore.
+   */
+  public MetaStore storeVote(int vote) {
+    buffer.writeInt(8, vote);
+    return this;
+  }
+
+  /**
+   * Loads the last vote for the server.
+   *
+   * @return The last vote for the server.
+   */
+  public int loadVote() {
+    return buffer.readInt(8);
+  }
+
+  @Override
+  public void close() {
+    buffer.close();
+  }
+
+  /**
+   * Deletes the metastore.
+   */
+  public void delete() {
+    if (buffer instanceof FileBuffer) {
+      ((FileBuffer) buffer).delete();
+    }
+  }
+
+  @Override
+  public String toString() {
+    if (buffer instanceof FileBuffer) {
+      return String.format("%s[%s]", getClass().getSimpleName(), ((FileBuffer) buffer).file());
+    } else {
+      return getClass().getSimpleName();
+    }
+  }
+
+}

--- a/server/src/main/java/io/atomix/copycat/server/storage/Storage.java
+++ b/server/src/main/java/io/atomix/copycat/server/storage/Storage.java
@@ -174,7 +174,7 @@ public class Storage {
    * <p>
    * The storage directory is the directory to which all {@link Log}s write {@link Segment} files. Segment files
    * for multiple logs may be stored in the storage directory, and files for each log instance will be identified
-   * by the {@code name} provided when the log is {@link #open(String) opened}.
+   * by the {@code name} provided when the log is {@link #openLog(String) opened}.
    *
    * @return The storage directory.
    */
@@ -268,6 +268,16 @@ public class Storage {
   }
 
   /**
+   * Opens a new {@link MetaStore}.
+   *
+   * @param name The metastore name.
+   * @return The metastore.
+   */
+  public MetaStore openMetaStore(String name) {
+    return new MetaStore(name, this);
+  }
+
+  /**
    * Opens a new {@link Log}.
    * <p>
    * When a log is opened, the log will attempt to load {@link Segment}s from the storage {@link #directory()}
@@ -276,7 +286,7 @@ public class Storage {
    *
    * @return The opened log.
    */
-  public Log open(String name) {
+  public Log openLog(String name) {
     return new Log(name, this);
   }
 

--- a/server/src/test/java/io/atomix/copycat/server/state/AbstractStateTest.java
+++ b/server/src/test/java/io/atomix/copycat/server/state/AbstractStateTest.java
@@ -27,10 +27,7 @@ import io.atomix.copycat.client.response.AbstractResponse;
 import io.atomix.copycat.client.response.Response;
 import io.atomix.copycat.server.TestStateMachine;
 import io.atomix.copycat.server.Testing.ThrowableRunnable;
-import io.atomix.copycat.server.storage.Log;
-import io.atomix.copycat.server.storage.Storage;
-import io.atomix.copycat.server.storage.StorageLevel;
-import io.atomix.copycat.server.storage.TestEntry;
+import io.atomix.copycat.server.storage.*;
 import io.atomix.copycat.server.storage.entry.Entry;
 import net.jodah.concurrentunit.ConcurrentTestCase;
 import org.testng.annotations.AfterMethod;
@@ -48,6 +45,7 @@ public abstract class AbstractStateTest<T extends AbstractState> extends Concurr
   protected T state;
   protected Serializer serializer;
   protected Storage storage;
+  protected MetaStore meta;
   protected Log log;
   protected TestStateMachine stateMachine;
   protected ThreadContext serverCtx;
@@ -66,13 +64,14 @@ public abstract class AbstractStateTest<T extends AbstractState> extends Concurr
     storage = new Storage(StorageLevel.MEMORY);
     storage.serializer().resolve(new ServiceLoaderTypeResolver());
 
-    log = storage.open("test");
+    meta = storage.openMetaStore("test");
+    log = storage.openLog("test");
     stateMachine = new TestStateMachine();
     members = createMembers(3);
     transport = new LocalTransport(new LocalServerRegistry());
 
     serverCtx = new SingleThreadContext("test-server", serializer);
-    serverState = new ServerState(members.get(0), members, log, stateMachine, new ConnectionManager(transport.client()), serverCtx);
+    serverState = new ServerState(members.get(0), members, meta, log, stateMachine, new ConnectionManager(transport.client()), serverCtx);
   }
 
   /**

--- a/server/src/test/java/io/atomix/copycat/server/storage/LogTest.java
+++ b/server/src/test/java/io/atomix/copycat/server/storage/LogTest.java
@@ -48,7 +48,7 @@ public abstract class LogTest extends AbstractLogTest {
         .withStorageLevel(storageLevel())
         .withSerializer(new Serializer(new ServiceLoaderTypeResolver()))
         .build()
-        .open("copycat");
+        .openLog("copycat");
   }
 
   /**

--- a/server/src/test/java/io/atomix/copycat/server/storage/MajorCompactionTest.java
+++ b/server/src/test/java/io/atomix/copycat/server/storage/MajorCompactionTest.java
@@ -37,7 +37,7 @@ public class MajorCompactionTest extends AbstractLogTest {
       .withMaxEntriesPerSegment(10)
       .withSerializer(new Serializer(new ServiceLoaderTypeResolver()))
       .build()
-      .open("copycat");
+      .openLog("copycat");
   }
 
   /**

--- a/server/src/test/java/io/atomix/copycat/server/storage/MetaStoreTest.java
+++ b/server/src/test/java/io/atomix/copycat/server/storage/MetaStoreTest.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License
+ */
+package io.atomix.copycat.server.storage;
+
+import io.atomix.catalyst.serializer.Serializer;
+import io.atomix.catalyst.serializer.ServiceLoaderTypeResolver;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.*;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.util.UUID;
+
+import static org.testng.Assert.assertEquals;
+
+/**
+ * Metastore test.
+ *
+ * @author <a href="http://github.com/kuujo>Jordan Halterman</a>
+ */
+@Test
+public class MetaStoreTest {
+  private String testId;
+
+  /**
+   * Returns a new metastore.
+   */
+  protected MetaStore createMetaStore() {
+    return Storage.builder()
+      .withSerializer(new Serializer(new ServiceLoaderTypeResolver()))
+      .withDirectory(new File(String.format("target/test-logs/%s", testId)))
+      .build()
+      .openMetaStore("test");
+  }
+
+  /**
+   * Tests storing and loading data from the metastore.
+   */
+  @SuppressWarnings("unchecked")
+  public void testMetaStore() {
+    MetaStore meta = createMetaStore();
+    assertEquals(meta.loadTerm(), 0);
+    assertEquals(meta.loadVote(), 0);
+    meta.storeTerm(1);
+    meta.storeVote(2);
+    assertEquals(meta.loadTerm(), 1);
+    assertEquals(meta.loadVote(), 2);
+  }
+
+  /**
+   * Tests deleting a metastore.
+   */
+  public void testDeleteMetaStore() throws Throwable {
+    MetaStore meta = createMetaStore();
+    assertEquals(meta.loadTerm(), 0);
+    assertEquals(meta.loadVote(), 0);
+    meta.storeTerm(1);
+    meta.storeVote(2);
+    assertEquals(meta.loadTerm(), 1);
+    assertEquals(meta.loadVote(), 2);
+    meta = createMetaStore();
+    assertEquals(meta.loadTerm(), 1);
+    assertEquals(meta.loadVote(), 2);
+    meta.delete();
+    meta = createMetaStore();
+    assertEquals(meta.loadTerm(), 0);
+    assertEquals(meta.loadVote(), 0);
+  }
+
+  @BeforeMethod
+  @AfterMethod
+  protected void cleanupStorage() throws IOException {
+    Path directory = Paths.get("target/test-logs/");
+    if (Files.exists(directory)) {
+      Files.walkFileTree(directory, new SimpleFileVisitor<Path>() {
+        @Override
+        public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException {
+          Files.delete(file);
+          return FileVisitResult.CONTINUE;
+        }
+
+        @Override
+        public FileVisitResult postVisitDirectory(Path dir, IOException exc) throws IOException {
+          Files.delete(dir);
+          return FileVisitResult.CONTINUE;
+        }
+      });
+    }
+    testId = UUID.randomUUID().toString();
+  }
+
+}

--- a/server/src/test/java/io/atomix/copycat/server/storage/MinorCompactionTest.java
+++ b/server/src/test/java/io/atomix/copycat/server/storage/MinorCompactionTest.java
@@ -37,7 +37,7 @@ public class MinorCompactionTest extends AbstractLogTest {
         .withMaxEntriesPerSegment(10)
         .withSerializer(new Serializer(new ServiceLoaderTypeResolver()))
         .build()
-        .open("copycat");
+        .openLog("copycat");
   }
   
   /**


### PR DESCRIPTION
This PR implements a persistence layer for storing server term and last voted for according to the Raft spec. It adds a `MetaStore` class which is managed the `Storage` object. The `MetaStore` is a small file that stores server-related state.