### PR TITLE
LeaderState#Replicator#commit() might return null if connection fails

### DIFF
--- a/server/src/main/java/io/atomix/copycat/server/state/LeaderState.java
+++ b/server/src/main/java/io/atomix/copycat/server/state/LeaderState.java
@@ -886,12 +886,13 @@ final class LeaderState extends ActiveState {
       // If no commit future already exists, that indicates there's no heartbeat currently under way.
       // Create a new commit future and commit to all members in the cluster.
       if (commitFuture == null) {
-        commitFuture = new CompletableFuture<>();
+        CompletableFuture<Long> newCommitFuture = new CompletableFuture<>();
+        commitFuture = newCommitFuture;
         commitTime = System.currentTimeMillis();
         for (MemberState member : context.getCluster().getMembers()) {
           commit(member);
         }
-        return commitFuture;
+        return newCommitFuture;
       }
       // If a commit future already exists, that indicates there is a heartbeat currently underway.
       // We don't want to allow callers to be completed by a heartbeat that may already almost be done.


### PR DESCRIPTION
`LeaderState#Replicator#commit()` might return null if connection fails in `#commit(MemberState, AppendRequest, boolean)`, or also if the `send(..)` call on the connection fails in `#commit(Connection,MemberState, AppendRequest, boolean)`. In that case the `commitFuture` might be completed in `commitTime(...)` and the `commitFuture` field might be reset to null (if `nextCommitFuture` is null) - in which case `#commit()` would return null.
Seems to be meaningful to return the (perhaps already completed) CompletableFuture.