### PR TITLE
Separate client/server transports

### DIFF
--- a/client/src/main/java/io/atomix/copycat/client/session/ClientSession.java
+++ b/client/src/main/java/io/atomix/copycat/client/session/ClientSession.java
@@ -38,6 +38,7 @@ import io.atomix.copycat.client.response.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.net.ConnectException;
 import java.time.Duration;
 import java.util.*;
 import java.util.concurrent.CompletableFuture;
@@ -526,18 +527,26 @@ public class ClientSession implements Session, Managed<Session> {
     });
     connection.handler(PublishRequest.class, this::handlePublish);
 
+    // When we first connect to a new server, first send a ConnectRequest to the server if the
+    // session has already been registered. Once the connection has been established, send a KeepAlive
+    // request to the new server. This will allow the new server to immediately provide membership info
+    // to the client.
     if (id != 0) {
       ConnectRequest request = ConnectRequest.builder()
         .withSession(id)
         .build();
 
       CompletableFuture<Connection> future = new CompletableFuture<>();
-      connection.send(request).whenComplete((response, error) -> {
+      connection.<ConnectRequest, ConnectResponse>send(request).whenComplete((connectResponse, connectError) -> {
         if (isOpen()) {
-          if (error == null) {
-            future.complete(connection);
+          if (connectError == null && connectResponse.status() == Response.Status.OK) {
+            keepAlive().whenComplete((keepAliveResult, keepAliveError) -> {
+              future.complete(connection);
+            });
+          } else if (connectError == null) {
+            future.completeExceptionally(new ConnectException("failed to connect"));
           } else {
-            future.completeExceptionally(error);
+            future.completeExceptionally(connectError);
           }
         }
       });
@@ -627,9 +636,10 @@ public class ClientSession implements Session, Managed<Session> {
   }
 
   /**
-   * Sends and reschedules keep alive request.
+   * Sends a keep alive request.
    */
-  private void keepAlive(Duration interval) {
+  private CompletableFuture<Void> keepAlive() {
+    CompletableFuture<Void> future = new CompletableFuture<>();
     KeepAliveRequest request = KeepAliveRequest.builder()
       .withSession(id)
       .withCommandSequence(commandResponse)
@@ -642,33 +652,31 @@ public class ClientSession implements Session, Managed<Session> {
           setLeader(response.leader());
           setMembers(response.members());
           resetMembers();
-
-          keepAliveFuture = context.schedule(interval, () -> {
-            if (isOpen()) {
-              context.checkThread();
-              keepAlive(interval);
-            }
-          });
+          future.complete(null);
         } else if (isOpen()) {
           if (setLeader(response.leader())) {
             resetMembers();
           }
-
-          keepAliveFuture = context.schedule(interval, () -> {
-            if (isOpen()) {
-              context.checkThread();
-              keepAlive(interval);
-            }
-          });
+          future.complete(null);
         }
       } else if (isOpen()) {
-        keepAliveFuture = context.schedule(interval, () -> {
-          if (isOpen()) {
-            context.checkThread();
-            keepAlive(interval);
-          }
-        });
+        future.completeExceptionally(error);
       }
+    });
+    return future;
+  }
+
+  /**
+   * Sends and reschedules keep alive request.
+   */
+  private void keepAlive(Duration interval) {
+    keepAlive().whenComplete((result, error) -> {
+      keepAliveFuture = context.schedule(interval, () -> {
+        if (isOpen()) {
+          context.checkThread();
+          keepAlive(interval);
+        }
+      });
     });
   }
 

--- a/examples/value-state-machine/src/main/java/io/atomix/copycat/examples/ValueStateMachineExample.java
+++ b/examples/value-state-machine/src/main/java/io/atomix/copycat/examples/ValueStateMachineExample.java
@@ -24,7 +24,6 @@ import java.net.InetAddress;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.UUID;
 
 /**
  * Value state machine example.
@@ -40,9 +39,11 @@ public class ValueStateMachineExample {
     if (args.length < 2)
       throw new IllegalArgumentException("must supply a local port and at least one remote host:port tuple");
 
-    int port = Integer.valueOf(args[0]);
+    int clientPort = Integer.valueOf(args[0]);
+    int serverPort = Integer.valueOf(args[1]);
 
-    Address address = new Address(InetAddress.getLocalHost().getHostName(), port);
+    Address clientAddress = new Address(InetAddress.getLocalHost().getHostName(), clientPort);
+    Address serverAddress = new Address(InetAddress.getLocalHost().getHostName(), serverPort);
 
     List<Address> members = new ArrayList<>();
     for (int i = 1; i < args.length; i++) {
@@ -50,11 +51,11 @@ public class ValueStateMachineExample {
       members.add(new Address(parts[0], Integer.valueOf(parts[1])));
     }
 
-    CopycatServer server = CopycatServer.builder(address, members)
+    CopycatServer server = CopycatServer.builder(clientAddress, serverAddress, members)
       .withStateMachine(new ValueStateMachine())
       .withTransport(new NettyTransport())
       .withStorage(Storage.builder()
-        .withDirectory(System.getProperty("user.dir") + "/logs/" + port)
+        .withDirectory(System.getProperty("user.dir") + "/logs/" + serverPort)
         // Limit the number of entries per segment and compaction intervals to demonstrate compaction.
         .withMaxEntriesPerSegment(1024)
         .withMinorCompactionInterval(Duration.ofSeconds(27))

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
     <java.version>1.8</java.version>
     <slf4j.version>1.7.7</slf4j.version>
     <logback.version>1.1.2</logback.version>
-    <catalyst.version>1.0.0-rc4</catalyst.version>
+    <catalyst.version>1.0.0-SNAPSHOT</catalyst.version>
 
     <maven.source.plugin.version>2.2.1</maven.source.plugin.version>
     <maven.compiler.plugin.version>3.0</maven.compiler.plugin.version>

--- a/server/src/main/java/io/atomix/copycat/server/CopycatServer.java
+++ b/server/src/main/java/io/atomix/copycat/server/CopycatServer.java
@@ -131,12 +131,13 @@ public class CopycatServer implements RaftServer {
    * add a {@link io.atomix.catalyst.serializer.Serializer} or {@link io.atomix.catalyst.serializer.CatalystSerializable}
    * file to your {@code META-INF/services} folder on the classpath.
    *
-   * @param address The local server member ID. This must be the ID of a member listed in the provided members list.
+   * @param clientAddress The address through which clients connect to the server.
+   * @param serverAddress The local server member address.
    * @param cluster The cluster members to which to connect.
    * @return The server builder.
    */
-  public static Builder builder(Address address, Address... cluster) {
-    return builder(address, Arrays.asList(cluster));
+  public static Builder builder(Address clientAddress, Address serverAddress, Address... cluster) {
+    return builder(clientAddress, serverAddress, Arrays.asList(cluster));
   }
 
   /**
@@ -151,12 +152,13 @@ public class CopycatServer implements RaftServer {
    * add a {@link io.atomix.catalyst.serializer.Serializer} or {@link io.atomix.catalyst.serializer.CatalystSerializable}
    * file to your {@code META-INF/services} folder on the classpath.
    *
-   * @param address The local server member ID. This must be the ID of a member listed in the provided members list.
+   * @param clientAddress The address through which clients connect to the server.
+   * @param serverAddress The local server member address.
    * @param cluster The cluster members to which to connect.
    * @return The server builder.
    */
-  public static Builder builder(Address address, Collection<Address> cluster) {
-    return new Builder(address, cluster);
+  public static Builder builder(Address clientAddress, Address serverAddress, Collection<Address> cluster) {
+    return new Builder(clientAddress, serverAddress, cluster);
   }
 
   private final ServerContext context;
@@ -346,16 +348,18 @@ public class CopycatServer implements RaftServer {
     private Storage storage;
     private Serializer serializer;
     private StateMachine stateMachine;
-    private Address address;
+    private Address clientAddress;
+    private Address serverAddress;
     private Set<Address> cluster;
     private Duration electionTimeout = DEFAULT_RAFT_ELECTION_TIMEOUT;
     private Duration heartbeatInterval = DEFAULT_RAFT_HEARTBEAT_INTERVAL;
     private Duration sessionTimeout = DEFAULT_RAFT_SESSION_TIMEOUT;
 
-    private Builder(Address address, Collection<Address> cluster) {
-      this.address = Assert.notNull(address, "address");
+    private Builder(Address clientAddress, Address serverAddress, Collection<Address> cluster) {
+      this.clientAddress = Assert.notNull(clientAddress, "clientAddress");
+      this.serverAddress = Assert.notNull(serverAddress, "serverAddress");
       this.cluster = new HashSet<>(Assert.notNull(cluster, "cluster"));
-      this.cluster.add(address);
+      this.cluster.add(serverAddress);
     }
 
     /**
@@ -483,7 +487,7 @@ public class CopycatServer implements RaftServer {
           .build();
       }
 
-      ServerContext context = new ServerContext(address, cluster, stateMachine, transport, storage, serializer);
+      ServerContext context = new ServerContext(clientAddress, serverAddress, cluster, stateMachine, transport, storage, serializer);
       return new CopycatServer(context, electionTimeout, heartbeatInterval, sessionTimeout);
     }
   }

--- a/server/src/main/java/io/atomix/copycat/server/CopycatServer.java
+++ b/server/src/main/java/io/atomix/copycat/server/CopycatServer.java
@@ -26,6 +26,7 @@ import io.atomix.catalyst.util.Listener;
 import io.atomix.catalyst.util.concurrent.ThreadContext;
 import io.atomix.copycat.client.Command;
 import io.atomix.copycat.client.Query;
+import io.atomix.copycat.server.state.Member;
 import io.atomix.copycat.server.state.ServerContext;
 import io.atomix.copycat.server.state.ServerState;
 import io.atomix.copycat.server.storage.Log;
@@ -225,7 +226,8 @@ public class CopycatServer implements RaftServer {
 
   @Override
   public Address leader() {
-    return state.getLeader();
+    Member leader = state.getLeader();
+    return leader != null ? leader.serverAddress() : null;
   }
 
   /**

--- a/server/src/main/java/io/atomix/copycat/server/CopycatServer.java
+++ b/server/src/main/java/io/atomix/copycat/server/CopycatServer.java
@@ -402,7 +402,6 @@ public class CopycatServer implements RaftServer {
       this.clientAddress = Assert.notNull(clientAddress, "clientAddress");
       this.serverAddress = Assert.notNull(serverAddress, "serverAddress");
       this.cluster = new HashSet<>(Assert.notNull(cluster, "cluster"));
-      this.cluster.add(serverAddress);
     }
 
     /**

--- a/server/src/main/java/io/atomix/copycat/server/CopycatServer.java
+++ b/server/src/main/java/io/atomix/copycat/server/CopycatServer.java
@@ -131,6 +131,46 @@ public class CopycatServer implements RaftServer {
    * add a {@link io.atomix.catalyst.serializer.Serializer} or {@link io.atomix.catalyst.serializer.CatalystSerializable}
    * file to your {@code META-INF/services} folder on the classpath.
    *
+   * @param address The address through which clients and servers connect to this server.
+   * @param cluster The cluster members to which to connect.
+   * @return The server builder.
+   */
+  public static Builder builder(Address address, Address... cluster) {
+    return builder(address, address, Arrays.asList(cluster));
+  }
+
+  /**
+   * Returns a new Raft server builder.
+   * <p>
+   * The provided {@link Address} is the address to which to bind the server being constructed. The provided set of
+   * members will be used to connect to the other members in the Raft cluster. The local server {@link Address} does
+   * not have to be present in the address list.
+   * <p>
+   * The returned server builder will use the {@code NettyTransport} by default. Additionally, serializable types will
+   * be registered using the {@link ServiceLoaderTypeResolver}. To register serializable types for the server, simply
+   * add a {@link io.atomix.catalyst.serializer.Serializer} or {@link io.atomix.catalyst.serializer.CatalystSerializable}
+   * file to your {@code META-INF/services} folder on the classpath.
+   *
+   * @param address The address through which clients and servers connect to this server.
+   * @param cluster The cluster members to which to connect.
+   * @return The server builder.
+   */
+  public static Builder builder(Address address, Collection<Address> cluster) {
+    return new Builder(address, address, cluster);
+  }
+
+  /**
+   * Returns a new Raft server builder.
+   * <p>
+   * The provided {@link Address} is the address to which to bind the server being constructed. The provided set of
+   * members will be used to connect to the other members in the Raft cluster. The local server {@link Address} does
+   * not have to be present in the address list.
+   * <p>
+   * The returned server builder will use the {@code NettyTransport} by default. Additionally, serializable types will
+   * be registered using the {@link ServiceLoaderTypeResolver}. To register serializable types for the server, simply
+   * add a {@link io.atomix.catalyst.serializer.Serializer} or {@link io.atomix.catalyst.serializer.CatalystSerializable}
+   * file to your {@code META-INF/services} folder on the classpath.
+   *
    * @param clientAddress The address through which clients connect to the server.
    * @param serverAddress The local server member address.
    * @param cluster The cluster members to which to connect.

--- a/server/src/main/java/io/atomix/copycat/server/request/ConfigurationRequest.java
+++ b/server/src/main/java/io/atomix/copycat/server/request/ConfigurationRequest.java
@@ -18,9 +18,9 @@ package io.atomix.copycat.server.request;
 import io.atomix.catalyst.buffer.BufferInput;
 import io.atomix.catalyst.buffer.BufferOutput;
 import io.atomix.catalyst.serializer.Serializer;
-import io.atomix.catalyst.transport.Address;
 import io.atomix.catalyst.util.Assert;
 import io.atomix.copycat.client.request.AbstractRequest;
+import io.atomix.copycat.server.state.Member;
 
 import java.util.Objects;
 
@@ -30,14 +30,14 @@ import java.util.Objects;
  * @author <a href="http://github.com/kuujo">Jordan Halterman</a>
  */
 public class ConfigurationRequest<T extends ConfigurationRequest<T>> extends AbstractRequest<T> {
-  protected Address member;
+  protected Member member;
 
   /**
    * Returns the joining member.
    *
    * @return The joining member.
    */
-  public Address member() {
+  public Member member() {
     return member;
   }
 
@@ -82,7 +82,7 @@ public class ConfigurationRequest<T extends ConfigurationRequest<T>> extends Abs
      * @throws NullPointerException if {@code member} is null
      */
     @SuppressWarnings("unchecked")
-    public T withMember(Address member) {
+    public T withMember(Member member) {
       request.member = Assert.notNull(member, "member");
       return (T) this;
     }

--- a/server/src/main/java/io/atomix/copycat/server/request/ConfigureRequest.java
+++ b/server/src/main/java/io/atomix/copycat/server/request/ConfigureRequest.java
@@ -1,0 +1,201 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License
+ */
+package io.atomix.copycat.server.request;
+
+import io.atomix.catalyst.buffer.BufferInput;
+import io.atomix.catalyst.buffer.BufferOutput;
+import io.atomix.catalyst.serializer.SerializeWith;
+import io.atomix.catalyst.serializer.Serializer;
+import io.atomix.catalyst.util.Assert;
+import io.atomix.copycat.client.request.AbstractRequest;
+import io.atomix.copycat.server.state.Member;
+
+import java.util.Collection;
+import java.util.Objects;
+
+/**
+ * Configuration installation request.
+ *
+ * @author <a href="http://github.com/kuujo">Jordan Halterman</a>
+ */
+@SerializeWith(id=219)
+public class ConfigureRequest extends AbstractRequest<ConfigureRequest> {
+
+  /**
+   * Returns a new configuration request builder.
+   *
+   * @return A new configuration request builder.
+   */
+  public static Builder builder() {
+    return new Builder(new ConfigureRequest());
+  }
+
+  /**
+   * Returns an configuration request builder for an existing request.
+   *
+   * @param request The request to build.
+   * @return The configuration request builder.
+   */
+  public static Builder builder(ConfigureRequest request) {
+    return new Builder(request);
+  }
+
+  private long term;
+  private int leader;
+  protected long version;
+  protected Collection<Member> members;
+
+  /**
+   * Returns the requesting node's current term.
+   *
+   * @return The requesting node's current term.
+   */
+  public long term() {
+    return term;
+  }
+
+  /**
+   * Returns the requesting leader address.
+   *
+   * @return The leader's address.
+   */
+  public int leader() {
+    return leader;
+  }
+
+  /**
+   * Returns the configuration version.
+   *
+   * @return The configuration version.
+   */
+  public long version() {
+    return version;
+  }
+
+  /**
+   * Returns the configuration members.
+   *
+   * @return The configuration members.
+   */
+  public Collection<Member> members() {
+    return members;
+  }
+
+  @Override
+  public void writeObject(BufferOutput<?> buffer, Serializer serializer) {
+    buffer.writeLong(term).writeInt(leader).writeLong(version);
+    serializer.writeObject(members, buffer);
+  }
+
+  @Override
+  public void readObject(BufferInput<?> buffer, Serializer serializer) {
+    term = buffer.readLong();
+    leader = buffer.readInt();
+    version = buffer.readLong();
+    members = serializer.readObject(buffer);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(getClass(), term, leader, version, members);
+  }
+
+  @Override
+  public boolean equals(Object object) {
+    if (object instanceof ConfigureRequest) {
+      ConfigureRequest request = (ConfigureRequest) object;
+      return request.term == term
+        && request.leader == leader
+        && request.version == version
+        && request.members.equals(members);
+    }
+    return false;
+  }
+
+  @Override
+  public String toString() {
+    return String.format("%s[term=%d, leader=%d, version=%d, members=%s]", getClass().getSimpleName(), term, leader, version, members);
+  }
+
+  /**
+   * Heartbeat request builder.
+   */
+  public static class Builder extends AbstractRequest.Builder<Builder, ConfigureRequest> {
+    protected Builder(ConfigureRequest request) {
+      super(request);
+    }
+
+    /**
+     * Sets the request term.
+     *
+     * @param term The request term.
+     * @return The append request builder.
+     * @throws IllegalArgumentException if the {@code term} is not positive
+     */
+    public Builder withTerm(long term) {
+      request.term = Assert.arg(term, term > 0, "term must be positive");
+      return this;
+    }
+
+    /**
+     * Sets the request leader.
+     *
+     * @param leader The request leader.
+     * @return The append request builder.
+     * @throws IllegalArgumentException if the {@code leader} is not positive
+     */
+    public Builder withLeader(int leader) {
+      request.leader = leader;
+      return this;
+    }
+
+    /**
+     * Sets the request version.
+     *
+     * @param version The request version.
+     * @return The request builder.
+     */
+    public Builder withVersion(long version) {
+      request.version = Assert.argNot(version, version < 0, "version must be positive");
+      return this;
+    }
+
+    /**
+     * Sets the request members.
+     *
+     * @param members The request members.
+     * @return The request builder.
+     * @throws NullPointerException if {@code member} is null
+     */
+    public Builder withMembers(Collection<Member> members) {
+      request.members = Assert.notNull(members, "members");
+      return this;
+    }
+
+    /**
+     * @throws IllegalStateException if member is null
+     */
+    @Override
+    public ConfigureRequest build() {
+      super.build();
+      Assert.stateNot(request.term <= 0, "term must be positive");
+      Assert.argNot(request.version < 0, "version must be positive");
+      Assert.notNull(request.members, "members");
+      return request;
+    }
+  }
+
+}

--- a/server/src/main/java/io/atomix/copycat/server/response/ConfigurationResponse.java
+++ b/server/src/main/java/io/atomix/copycat/server/response/ConfigurationResponse.java
@@ -18,10 +18,10 @@ package io.atomix.copycat.server.response;
 import io.atomix.catalyst.buffer.BufferInput;
 import io.atomix.catalyst.buffer.BufferOutput;
 import io.atomix.catalyst.serializer.Serializer;
-import io.atomix.catalyst.transport.Address;
 import io.atomix.catalyst.util.Assert;
 import io.atomix.copycat.client.error.RaftError;
 import io.atomix.copycat.client.response.AbstractResponse;
+import io.atomix.copycat.server.state.Member;
 
 import java.util.Collection;
 import java.util.Objects;
@@ -33,8 +33,8 @@ import java.util.Objects;
  */
 public class ConfigurationResponse<T extends ConfigurationResponse<T>> extends AbstractResponse<T> {
   protected long version;
-  protected Collection<Address> activeMembers;
-  protected Collection<Address> passiveMembers;
+  protected Collection<Member> activeMembers;
+  protected Collection<Member> passiveMembers;
 
   /**
    * Returns the response version.
@@ -50,7 +50,7 @@ public class ConfigurationResponse<T extends ConfigurationResponse<T>> extends A
    *
    * @return The configuration members list.
    */
-  public Collection<Address> activeMembers() {
+  public Collection<Member> activeMembers() {
     return activeMembers;
   }
 
@@ -59,7 +59,7 @@ public class ConfigurationResponse<T extends ConfigurationResponse<T>> extends A
    *
    * @return The configuration members list.
    */
-  public Collection<Address> passiveMembers() {
+  public Collection<Member> passiveMembers() {
     return passiveMembers;
   }
 
@@ -139,7 +139,7 @@ public class ConfigurationResponse<T extends ConfigurationResponse<T>> extends A
      * @throws NullPointerException if {@code members} is null
      */
     @SuppressWarnings("unchecked")
-    public T withActiveMembers(Collection<Address> members) {
+    public T withActiveMembers(Collection<Member> members) {
       response.activeMembers = Assert.notNull(members, "members");
       return (T) this;
     }
@@ -152,7 +152,7 @@ public class ConfigurationResponse<T extends ConfigurationResponse<T>> extends A
      * @throws NullPointerException if {@code members} is null
      */
     @SuppressWarnings("unchecked")
-    public T withPassiveMembers(Collection<Address> members) {
+    public T withPassiveMembers(Collection<Member> members) {
       response.passiveMembers = Assert.notNull(members, "members");
       return (T) this;
     }

--- a/server/src/main/java/io/atomix/copycat/server/response/ConfigurationResponse.java
+++ b/server/src/main/java/io/atomix/copycat/server/response/ConfigurationResponse.java
@@ -33,8 +33,7 @@ import java.util.Objects;
  */
 public class ConfigurationResponse<T extends ConfigurationResponse<T>> extends AbstractResponse<T> {
   protected long version;
-  protected Collection<Member> activeMembers;
-  protected Collection<Member> passiveMembers;
+  protected Collection<Member> members;
 
   /**
    * Returns the response version.
@@ -50,17 +49,8 @@ public class ConfigurationResponse<T extends ConfigurationResponse<T>> extends A
    *
    * @return The configuration members list.
    */
-  public Collection<Member> activeMembers() {
-    return activeMembers;
-  }
-
-  /**
-   * Returns the configuration members list.
-   *
-   * @return The configuration members list.
-   */
-  public Collection<Member> passiveMembers() {
-    return passiveMembers;
+  public Collection<Member> members() {
+    return members;
   }
 
   @Override
@@ -69,8 +59,7 @@ public class ConfigurationResponse<T extends ConfigurationResponse<T>> extends A
     if (status == Status.OK) {
       error = null;
       version = buffer.readLong();
-      activeMembers = serializer.readObject(buffer);
-      passiveMembers = serializer.readObject(buffer);
+      members = serializer.readObject(buffer);
     } else {
       error = RaftError.forId(buffer.readByte());
     }
@@ -81,8 +70,7 @@ public class ConfigurationResponse<T extends ConfigurationResponse<T>> extends A
     buffer.writeByte(status.id());
     if (status == Status.OK) {
       buffer.writeLong(version);
-      serializer.writeObject(activeMembers, buffer);
-      serializer.writeObject(passiveMembers, buffer);
+      serializer.writeObject(members, buffer);
     } else {
       buffer.writeByte(error.id());
     }
@@ -90,7 +78,7 @@ public class ConfigurationResponse<T extends ConfigurationResponse<T>> extends A
 
   @Override
   public int hashCode() {
-    return Objects.hash(getClass(), status, version, activeMembers, passiveMembers);
+    return Objects.hash(getClass(), status, version, members);
   }
 
   @Override
@@ -99,15 +87,14 @@ public class ConfigurationResponse<T extends ConfigurationResponse<T>> extends A
       ConfigurationResponse response = (ConfigurationResponse) object;
       return response.status == status
         && response.version == version
-        && response.activeMembers.equals(activeMembers)
-        && response.passiveMembers.equals(passiveMembers);
+        && response.members.equals(members);
     }
     return false;
   }
 
   @Override
   public String toString() {
-    return String.format("%s[status=%s, version=%d, activeMembers=%s, passiveMembers=%s]", getClass().getSimpleName(), status, version, activeMembers, passiveMembers);
+    return String.format("%s[status=%s, version=%d, members=%s]", getClass().getSimpleName(), status, version, members);
   }
 
   /**
@@ -139,21 +126,8 @@ public class ConfigurationResponse<T extends ConfigurationResponse<T>> extends A
      * @throws NullPointerException if {@code members} is null
      */
     @SuppressWarnings("unchecked")
-    public T withActiveMembers(Collection<Member> members) {
-      response.activeMembers = Assert.notNull(members, "members");
-      return (T) this;
-    }
-
-    /**
-     * Sets the response members.
-     *
-     * @param members The response members.
-     * @return The response builder.
-     * @throws NullPointerException if {@code members} is null
-     */
-    @SuppressWarnings("unchecked")
-    public T withPassiveMembers(Collection<Member> members) {
-      response.passiveMembers = Assert.notNull(members, "members");
+    public T withMembers(Collection<Member> members) {
+      response.members = Assert.notNull(members, "members");
       return (T) this;
     }
 
@@ -174,8 +148,7 @@ public class ConfigurationResponse<T extends ConfigurationResponse<T>> extends A
     public U build() {
       super.build();
       if (response.status == Status.OK) {
-        Assert.state(response.activeMembers != null, "activeMembers members cannot be null");
-        Assert.state(response.passiveMembers != null, "passiveMembers members cannot be null");
+        Assert.state(response.members != null, "activeMembers members cannot be null");
       }
       return response;
     }

--- a/server/src/main/java/io/atomix/copycat/server/response/ConfigureResponse.java
+++ b/server/src/main/java/io/atomix/copycat/server/response/ConfigureResponse.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License
+ */
+package io.atomix.copycat.server.response;
+
+import io.atomix.catalyst.buffer.BufferInput;
+import io.atomix.catalyst.buffer.BufferOutput;
+import io.atomix.catalyst.serializer.SerializeWith;
+import io.atomix.catalyst.serializer.Serializer;
+import io.atomix.copycat.client.error.RaftError;
+import io.atomix.copycat.client.response.AbstractResponse;
+
+import java.util.Objects;
+
+/**
+ * Configuration installation response.
+ *
+ * @author <a href="http://github.com/kuujo">Jordan Halterman</a>
+ */
+@SerializeWith(id=220)
+public class ConfigureResponse extends AbstractResponse<ConfigureResponse> {
+
+  /**
+   * Returns a new configure response builder.
+   *
+   * @return A new configure response builder.
+   */
+  public static Builder builder() {
+    return new Builder(new ConfigureResponse());
+  }
+
+  /**
+   * Returns a configure response builder for an existing response.
+   *
+   * @param response The response to build.
+   * @return The configure response builder.
+   */
+  public static Builder builder(ConfigureResponse response) {
+    return new Builder(response);
+  }
+
+  @Override
+  public void readObject(BufferInput buffer, Serializer serializer) {
+    status = Status.forId(buffer.readByte());
+    if (status == Status.OK) {
+      error = null;
+    } else {
+      error = RaftError.forId(buffer.readByte());
+    }
+  }
+
+  @Override
+  public void writeObject(BufferOutput buffer, Serializer serializer) {
+    buffer.writeByte(status.id());
+    if (status == Status.ERROR) {
+      buffer.writeByte(error.id());
+    }
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(getClass(), status);
+  }
+
+  @Override
+  public boolean equals(Object object) {
+    if (object instanceof ConfigureResponse) {
+      ConfigureResponse response = (ConfigureResponse) object;
+      return response.status == status;
+    }
+    return false;
+  }
+
+  @Override
+  public String toString() {
+    return String.format("%s[status=%s]", getClass().getSimpleName(), status);
+  }
+
+  /**
+   * Heartbeat response builder.
+   */
+  public static class Builder extends AbstractResponse.Builder<Builder, ConfigureResponse> {
+    protected Builder(ConfigureResponse response) {
+      super(response);
+    }
+  }
+
+}

--- a/server/src/main/java/io/atomix/copycat/server/state/AbstractAppender.java
+++ b/server/src/main/java/io/atomix/copycat/server/state/AbstractAppender.java
@@ -1,0 +1,272 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License
+ */
+package io.atomix.copycat.server.state;
+
+import io.atomix.catalyst.transport.Connection;
+import io.atomix.copycat.server.request.AppendRequest;
+import io.atomix.copycat.server.request.ConfigureRequest;
+import io.atomix.copycat.server.response.AppendResponse;
+import io.atomix.copycat.server.response.ConfigureResponse;
+import io.atomix.copycat.server.storage.entry.Entry;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * Entries appenders handle sending {@link AppendRequest}s from leaders to followers and from
+ * followers to passive/reserve members.
+ *
+ * @author <a href="http://github.com/kuujo>Jordan Halterman</a>
+ */
+abstract class AbstractAppender implements AutoCloseable {
+  protected final Logger LOGGER = LoggerFactory.getLogger(getClass());
+  protected final ServerState context;
+  private final Set<MemberState> appending = new HashSet<>();
+  private final Set<MemberState> configuring = new HashSet<>();
+  private boolean open = true;
+
+  AbstractAppender(ServerState context) {
+    this.context = context;
+  }
+
+  /**
+   * Sends a configuration to the given member.
+   */
+  protected void configure(MemberState member) {
+    if (!configuring.contains(member)) {
+      ConfigureRequest request = buildConfigureRequest(member);
+      if (request != null) {
+        sendConfigureRequest(member, request);
+      }
+    }
+  }
+
+  /**
+   * Connects to the member and sends a configure request.
+   */
+  protected void sendConfigureRequest(MemberState member, ConfigureRequest request) {
+    configuring.add(member);
+
+    LOGGER.debug("{} - Sent {} to {}", context.getCluster().getMember().serverAddress(), request, member.getMember().serverAddress());
+    context.getConnections().getConnection(member.getMember().serverAddress()).whenComplete((connection, error) -> {
+      context.checkThread();
+
+      if (open) {
+        if (error == null) {
+          sendConfigureRequest(connection, member, request);
+        } else {
+          LOGGER.warn("{} - Failed to configure {}", context.getCluster().getMember().serverAddress(), member.getMember().serverAddress());
+          configuring.remove(member);
+        }
+      }
+    });
+  }
+
+  /**
+   * Sends a commit message.
+   */
+  protected void sendConfigureRequest(Connection connection, MemberState member, ConfigureRequest request) {
+    connection.<ConfigureRequest, ConfigureResponse>send(request).whenComplete((response, error) -> {
+      context.checkThread();
+      configuring.remove(member);
+
+      if (open) {
+        if (error == null) {
+          LOGGER.debug("{} - Received {} from {}", context.getCluster().getMember().serverAddress(), response, member.getMember().serverAddress());
+          member.setTerm(request.term()).setVersion(request.version());
+          appendEntries(member);
+        } else {
+          LOGGER.warn("{} - Failed to configure {}", context.getCluster().getMember().serverAddress(), member.getMember().serverAddress());
+        }
+      }
+    });
+  }
+
+  /**
+   * Sends append entries requests to the given member.
+   */
+  protected void appendEntries(MemberState member) {
+    // Prevent recursive, asynchronous appends from being executed if the appender has been closed.
+    if (!open)
+      return;
+
+    // If the member term is less than the current term or the member's configuration version is less
+    // than the local configuration version, send a configuration update to the member.
+    // Ensure that only one configuration attempt per member is attempted at any given time by storing the
+    // member state in a set of configuring members.
+    // Once the configuration is complete sendAppendRequest will be called recursively.
+    if (member.getTerm() < context.getTerm() || member.getVersion() < context.getCluster().getVersion() && !configuring.contains(member)) {
+      configure(member);
+    }
+    // If no AppendRequest is already being sent, send an AppendRequest.
+    else if (!appending.contains(member)) {
+      AppendRequest request = buildAppendRequest(member);
+      if (request != null) {
+        sendAppendRequest(member, request);
+      }
+    }
+  }
+
+  /**
+   * Builds a configure request for the given member.
+   */
+  protected ConfigureRequest buildConfigureRequest(MemberState member) {
+    Member leader = context.getLeader();
+    return ConfigureRequest.builder()
+      .withTerm(context.getTerm())
+      .withLeader(leader != null ? leader.id() : 0)
+      .withVersion(context.getCluster().getVersion())
+      .withMembers(context.getCluster().getMembers())
+      .build();
+  }
+
+  /**
+   * Builds an append request for the given member.
+   */
+  protected abstract AppendRequest buildAppendRequest(MemberState member);
+
+  /**
+   * Gets the previous index.
+   */
+  protected long getPrevIndex(MemberState member) {
+    return member.getNextIndex() - 1;
+  }
+
+  /**
+   * Gets the previous entry.
+   */
+  protected Entry getPrevEntry(MemberState member, long prevIndex) {
+    if (prevIndex > 0) {
+      return context.getLog().get(prevIndex);
+    }
+    return null;
+  }
+
+  /**
+   * Starts sending a request.
+   */
+  protected void startAppendRequest(MemberState member, AppendRequest request) {
+    appending.add(member);
+  }
+
+  /**
+   * Ends sending a request.
+   */
+  protected void endAppendRequest(MemberState member, AppendRequest request, Throwable error) {
+    appending.remove(member);
+  }
+
+  /**
+   * Connects to the member and sends a commit message.
+   */
+  protected void sendAppendRequest(MemberState member, AppendRequest request) {
+    startAppendRequest(member, request);
+
+    LOGGER.debug("{} - Sent {} to {}", context.getCluster().getMember().serverAddress(), request, member.getMember().serverAddress());
+    context.getConnections().getConnection(member.getMember().serverAddress()).whenComplete((connection, error) -> {
+      context.checkThread();
+
+      if (open) {
+        if (error == null) {
+          sendAppendRequest(connection, member, request);
+        } else {
+          endAppendRequest(member, request, error);
+          handleAppendError(member, request, error);
+        }
+      }
+    });
+  }
+
+  /**
+   * Sends a commit message.
+   */
+  protected void sendAppendRequest(Connection connection, MemberState member, AppendRequest request) {
+    connection.<AppendRequest, AppendResponse>send(request).whenComplete((response, error) -> {
+      endAppendRequest(member, request, error);
+      context.checkThread();
+
+      if (open) {
+        if (error == null) {
+          LOGGER.debug("{} - Received {} from {}", context.getCluster().getMember().serverAddress(), response, member.getMember().serverAddress());
+          handleAppendResponse(member, request, response);
+        } else {
+          handleAppendError(member, request, error);
+        }
+      }
+    });
+  }
+
+  /**
+   * Handles an append response.
+   */
+  protected abstract void handleAppendResponse(MemberState member, AppendRequest request, AppendResponse response);
+
+  /**
+   * Handles an append error.
+   */
+  protected abstract void handleAppendError(MemberState member, AppendRequest request, Throwable error);
+
+  /**
+   * Returns a boolean value indicating whether there are more entries to send.
+   */
+  protected boolean hasMoreEntries(MemberState member) {
+    return member.getNextIndex() < context.getLog().lastIndex();
+  }
+
+  /**
+   * Updates the match index when a response is received.
+   */
+  protected void updateMatchIndex(MemberState member, AppendResponse response) {
+    // If the replica returned a valid match index then update the existing match index.
+    member.setMatchIndex(response.logIndex());
+  }
+
+  /**
+   * Updates the next index when the match index is updated.
+   */
+  protected void updateNextIndex(MemberState member) {
+    // If the match index was set, update the next index to be greater than the match index if necessary.
+    member.setNextIndex(Math.max(member.getNextIndex(), Math.max(member.getMatchIndex() + 1, 1)));
+  }
+
+  /**
+   * Resets the match index when a response fails.
+   */
+  protected void resetMatchIndex(MemberState member, AppendResponse response) {
+    member.setMatchIndex(response.logIndex());
+    LOGGER.debug("{} - Reset match index for {} to {}", context.getCluster().getMember().serverAddress(), member, member.getMatchIndex());
+  }
+
+  /**
+   * Resets the next index when a response fails.
+   */
+  protected void resetNextIndex(MemberState member) {
+    if (member.getMatchIndex() != 0) {
+      member.setNextIndex(member.getMatchIndex() + 1);
+    } else {
+      member.setNextIndex(context.getLog().firstIndex());
+    }
+    LOGGER.debug("{} - Reset next index for {} to {}", context.getCluster().getMember().serverAddress(), member, member.getNextIndex());
+  }
+
+  @Override
+  public void close() {
+    open = false;
+  }
+
+}

--- a/server/src/main/java/io/atomix/copycat/server/state/AbstractAppender.java
+++ b/server/src/main/java/io/atomix/copycat/server/state/AbstractAppender.java
@@ -62,7 +62,6 @@ abstract class AbstractAppender implements AutoCloseable {
   protected void sendConfigureRequest(MemberState member, ConfigureRequest request) {
     configuring.add(member);
 
-    LOGGER.debug("{} - Sent {} to {}", context.getCluster().getMember().serverAddress(), request, member.getMember().serverAddress());
     context.getConnections().getConnection(member.getMember().serverAddress()).whenComplete((connection, error) -> {
       context.checkThread();
 
@@ -81,6 +80,7 @@ abstract class AbstractAppender implements AutoCloseable {
    * Sends a commit message.
    */
   protected void sendConfigureRequest(Connection connection, MemberState member, ConfigureRequest request) {
+    LOGGER.debug("{} - Sent {} to {}", context.getCluster().getMember().serverAddress(), request, member.getMember().serverAddress());
     connection.<ConfigureRequest, ConfigureResponse>send(request).whenComplete((response, error) -> {
       context.checkThread();
       configuring.remove(member);

--- a/server/src/main/java/io/atomix/copycat/server/state/AbstractState.java
+++ b/server/src/main/java/io/atomix/copycat/server/state/AbstractState.java
@@ -114,6 +114,11 @@ abstract class AbstractState implements Managed<AbstractState> {
   protected abstract CompletableFuture<PublishResponse> publish(PublishRequest request);
 
   /**
+   * Handles a configure request.
+   */
+  protected abstract CompletableFuture<ConfigureResponse> configure(ConfigureRequest request);
+
+  /**
    * Handles a join request.
    */
   protected abstract CompletableFuture<JoinResponse> join(JoinRequest request);

--- a/server/src/main/java/io/atomix/copycat/server/state/AbstractState.java
+++ b/server/src/main/java/io/atomix/copycat/server/state/AbstractState.java
@@ -52,7 +52,7 @@ abstract class AbstractState implements Managed<AbstractState> {
    * Logs a request.
    */
   protected final <R extends Request> R logRequest(R request) {
-    LOGGER.debug("{} - Received {}", context.getAddress(), request);
+    LOGGER.debug("{} - Received {}", context.getMember().serverAddress(), request);
     return request;
   }
 
@@ -60,7 +60,7 @@ abstract class AbstractState implements Managed<AbstractState> {
    * Logs a response.
    */
   protected final <R extends Response> R logResponse(R response) {
-    LOGGER.debug("{} - Sent {}", context.getAddress(), response);
+    LOGGER.debug("{} - Sent {}", context.getMember().serverAddress(), response);
     return response;
   }
 

--- a/server/src/main/java/io/atomix/copycat/server/state/AbstractState.java
+++ b/server/src/main/java/io/atomix/copycat/server/state/AbstractState.java
@@ -52,7 +52,7 @@ abstract class AbstractState implements Managed<AbstractState> {
    * Logs a request.
    */
   protected final <R extends Request> R logRequest(R request) {
-    LOGGER.debug("{} - Received {}", context.getMember().serverAddress(), request);
+    LOGGER.debug("{} - Received {}", context.getCluster().getMember().serverAddress(), request);
     return request;
   }
 
@@ -60,7 +60,7 @@ abstract class AbstractState implements Managed<AbstractState> {
    * Logs a response.
    */
   protected final <R extends Response> R logResponse(R response) {
-    LOGGER.debug("{} - Sent {}", context.getMember().serverAddress(), response);
+    LOGGER.debug("{} - Sent {}", context.getCluster().getMember().serverAddress(), response);
     return response;
   }
 

--- a/server/src/main/java/io/atomix/copycat/server/state/ActiveState.java
+++ b/server/src/main/java/io/atomix/copycat/server/state/ActiveState.java
@@ -91,7 +91,7 @@ abstract class ActiveState extends PassiveState {
     // vote for the candidate. We want to vote for candidates that are at least
     // as up to date as us.
     if (request.term() < context.getTerm()) {
-      LOGGER.debug("{} - Rejected {}: candidate's term is less than the current term", context.getMember().serverAddress(), request);
+      LOGGER.debug("{} - Rejected {}: candidate's term is less than the current term", context.getCluster().getMember().serverAddress(), request);
       return PollResponse.builder()
         .withStatus(Response.Status.OK)
         .withTerm(context.getTerm())
@@ -139,7 +139,7 @@ abstract class ActiveState extends PassiveState {
     // vote for the candidate. We want to vote for candidates that are at least
     // as up to date as us.
     if (request.term() < context.getTerm()) {
-      LOGGER.debug("{} - Rejected {}: candidate's term is less than the current term", context.getMember().serverAddress(), request);
+      LOGGER.debug("{} - Rejected {}: candidate's term is less than the current term", context.getCluster().getMember().serverAddress(), request);
       return VoteResponse.builder()
         .withStatus(Response.Status.OK)
         .withTerm(context.getTerm())
@@ -148,8 +148,8 @@ abstract class ActiveState extends PassiveState {
     }
     // If the requesting candidate is not a known member of the cluster (to this
     // node) then don't vote for it. Only vote for candidates that we know about.
-    else if (!context.getCluster().getActiveMembers().stream().<Integer>map(m -> m.getServerAddress().hashCode()).collect(Collectors.toSet()).contains(request.candidate())) {
-      LOGGER.debug("{} - Rejected {}: candidate is not known to the local member", context.getMember().serverAddress(), request);
+    else if (!context.getCluster().getMembers().stream().<Integer>map(Member::id).collect(Collectors.toSet()).contains(request.candidate())) {
+      LOGGER.debug("{} - Rejected {}: candidate is not known to the local member", context.getCluster().getMember().serverAddress(), request);
       return VoteResponse.builder()
         .withStatus(Response.Status.OK)
         .withTerm(context.getTerm())
@@ -175,7 +175,7 @@ abstract class ActiveState extends PassiveState {
     }
     // In this case, we've already voted for someone else.
     else {
-      LOGGER.debug("{} - Rejected {}: already voted for {}", context.getMember().serverAddress(), request, context.getLastVotedFor());
+      LOGGER.debug("{} - Rejected {}: already voted for {}", context.getCluster().getMember().serverAddress(), request, context.getLastVotedFor());
       return VoteResponse.builder()
         .withStatus(Response.Status.OK)
         .withTerm(context.getTerm())
@@ -190,7 +190,7 @@ abstract class ActiveState extends PassiveState {
   boolean isLogUpToDate(long index, long term, Request request) {
     // If the log is empty then vote for the candidate.
     if (context.getLog().isEmpty()) {
-      LOGGER.debug("{} - Accepted {}: candidate's log is up-to-date", context.getMember().serverAddress(), request);
+      LOGGER.debug("{} - Accepted {}: candidate's log is up-to-date", context.getCluster().getMember().serverAddress(), request);
       return true;
     } else {
       // Otherwise, load the last entry in the log. The last entry should be
@@ -198,21 +198,21 @@ abstract class ActiveState extends PassiveState {
       long lastIndex = context.getLog().lastIndex();
       Entry entry = context.getLog().get(lastIndex);
       if (entry == null) {
-        LOGGER.debug("{} - Accepted {}: candidate's log is up-to-date", context.getMember().serverAddress(), request);
+        LOGGER.debug("{} - Accepted {}: candidate's log is up-to-date", context.getCluster().getMember().serverAddress(), request);
         return true;
       }
 
       try {
         if (index != 0 && index >= lastIndex) {
           if (term >= entry.getTerm()) {
-            LOGGER.debug("{} - Accepted {}: candidate's log is up-to-date", context.getMember().serverAddress(), request);
+            LOGGER.debug("{} - Accepted {}: candidate's log is up-to-date", context.getCluster().getMember().serverAddress(), request);
             return true;
           } else {
-            LOGGER.debug("{} - Rejected {}: candidate's last log term ({}) is in conflict with local log ({})", context.getMember().serverAddress(), request, term, entry.getTerm());
+            LOGGER.debug("{} - Rejected {}: candidate's last log term ({}) is in conflict with local log ({})", context.getCluster().getMember().serverAddress(), request, term, entry.getTerm());
             return false;
           }
         } else {
-          LOGGER.debug("{} - Rejected {}: candidate's last log entry ({}) is at a lower index than the local log ({})", context.getMember().serverAddress(), request, index, lastIndex);
+          LOGGER.debug("{} - Rejected {}: candidate's last log entry ({}) is at a lower index than the local log ({})", context.getCluster().getMember().serverAddress(), request, index, lastIndex);
           return false;
         }
       } finally {
@@ -254,7 +254,7 @@ abstract class ActiveState extends PassiveState {
         .build()));
     }
 
-    LOGGER.debug("{} - Forwarded {}", context.getMember().serverAddress(), request);
+    LOGGER.debug("{} - Forwarded {}", context.getCluster().getMember().serverAddress(), request);
     return this.<QueryRequest, QueryResponse>forward(request).thenApply(this::logResponse);
   }
 

--- a/server/src/main/java/io/atomix/copycat/server/state/ActiveState.java
+++ b/server/src/main/java/io/atomix/copycat/server/state/ActiveState.java
@@ -91,7 +91,7 @@ abstract class ActiveState extends PassiveState {
     // vote for the candidate. We want to vote for candidates that are at least
     // as up to date as us.
     if (request.term() < context.getTerm()) {
-      LOGGER.debug("{} - Rejected {}: candidate's term is less than the current term", context.getAddress(), request);
+      LOGGER.debug("{} - Rejected {}: candidate's term is less than the current term", context.getMember().serverAddress(), request);
       return PollResponse.builder()
         .withStatus(Response.Status.OK)
         .withTerm(context.getTerm())
@@ -139,7 +139,7 @@ abstract class ActiveState extends PassiveState {
     // vote for the candidate. We want to vote for candidates that are at least
     // as up to date as us.
     if (request.term() < context.getTerm()) {
-      LOGGER.debug("{} - Rejected {}: candidate's term is less than the current term", context.getAddress(), request);
+      LOGGER.debug("{} - Rejected {}: candidate's term is less than the current term", context.getMember().serverAddress(), request);
       return VoteResponse.builder()
         .withStatus(Response.Status.OK)
         .withTerm(context.getTerm())
@@ -148,8 +148,8 @@ abstract class ActiveState extends PassiveState {
     }
     // If the requesting candidate is not a known member of the cluster (to this
     // node) then don't vote for it. Only vote for candidates that we know about.
-    else if (!context.getCluster().getActiveMembers().stream().<Integer>map(m -> m.getAddress().hashCode()).collect(Collectors.toSet()).contains(request.candidate())) {
-      LOGGER.debug("{} - Rejected {}: candidate is not known to the local member", context.getAddress(), request);
+    else if (!context.getCluster().getActiveMembers().stream().<Integer>map(m -> m.getServerAddress().hashCode()).collect(Collectors.toSet()).contains(request.candidate())) {
+      LOGGER.debug("{} - Rejected {}: candidate is not known to the local member", context.getMember().serverAddress(), request);
       return VoteResponse.builder()
         .withStatus(Response.Status.OK)
         .withTerm(context.getTerm())
@@ -175,7 +175,7 @@ abstract class ActiveState extends PassiveState {
     }
     // In this case, we've already voted for someone else.
     else {
-      LOGGER.debug("{} - Rejected {}: already voted for {}", context.getAddress(), request, context.getLastVotedFor());
+      LOGGER.debug("{} - Rejected {}: already voted for {}", context.getMember().serverAddress(), request, context.getLastVotedFor());
       return VoteResponse.builder()
         .withStatus(Response.Status.OK)
         .withTerm(context.getTerm())
@@ -190,7 +190,7 @@ abstract class ActiveState extends PassiveState {
   boolean isLogUpToDate(long index, long term, Request request) {
     // If the log is empty then vote for the candidate.
     if (context.getLog().isEmpty()) {
-      LOGGER.debug("{} - Accepted {}: candidate's log is up-to-date", context.getAddress(), request);
+      LOGGER.debug("{} - Accepted {}: candidate's log is up-to-date", context.getMember().serverAddress(), request);
       return true;
     } else {
       // Otherwise, load the last entry in the log. The last entry should be
@@ -198,21 +198,21 @@ abstract class ActiveState extends PassiveState {
       long lastIndex = context.getLog().lastIndex();
       Entry entry = context.getLog().get(lastIndex);
       if (entry == null) {
-        LOGGER.debug("{} - Accepted {}: candidate's log is up-to-date", context.getAddress(), request);
+        LOGGER.debug("{} - Accepted {}: candidate's log is up-to-date", context.getMember().serverAddress(), request);
         return true;
       }
 
       try {
         if (index != 0 && index >= lastIndex) {
           if (term >= entry.getTerm()) {
-            LOGGER.debug("{} - Accepted {}: candidate's log is up-to-date", context.getAddress(), request);
+            LOGGER.debug("{} - Accepted {}: candidate's log is up-to-date", context.getMember().serverAddress(), request);
             return true;
           } else {
-            LOGGER.debug("{} - Rejected {}: candidate's last log term ({}) is in conflict with local log ({})", context.getAddress(), request, term, entry.getTerm());
+            LOGGER.debug("{} - Rejected {}: candidate's last log term ({}) is in conflict with local log ({})", context.getMember().serverAddress(), request, term, entry.getTerm());
             return false;
           }
         } else {
-          LOGGER.debug("{} - Rejected {}: candidate's last log entry ({}) is at a lower index than the local log ({})", context.getAddress(), request, index, lastIndex);
+          LOGGER.debug("{} - Rejected {}: candidate's last log entry ({}) is at a lower index than the local log ({})", context.getMember().serverAddress(), request, index, lastIndex);
           return false;
         }
       } finally {
@@ -254,7 +254,7 @@ abstract class ActiveState extends PassiveState {
         .build()));
     }
 
-    LOGGER.debug("{} - Forwarded {}", context.getAddress(), request);
+    LOGGER.debug("{} - Forwarded {}", context.getMember().serverAddress(), request);
     return this.<QueryRequest, QueryResponse>forward(request).thenApply(this::logResponse);
   }
 

--- a/server/src/main/java/io/atomix/copycat/server/state/CandidateState.java
+++ b/server/src/main/java/io/atomix/copycat/server/state/CandidateState.java
@@ -61,7 +61,7 @@ final class CandidateState extends ActiveState {
    * Starts the election.
    */
   void startElection() {
-    LOGGER.info("{} - Starting election", context.getAddress());
+    LOGGER.info("{} - Starting election", context.getMember().serverAddress());
     sendVoteRequests();
   }
 
@@ -82,19 +82,19 @@ final class CandidateState extends ActiveState {
 
     // When the election timer is reset, increment the current term and
     // restart the election.
-    context.setTerm(context.getTerm() + 1).setLastVotedFor(context.getAddress().hashCode());
+    context.setTerm(context.getTerm() + 1).setLastVotedFor(context.getMember().serverAddress().hashCode());
 
     Duration delay = context.getElectionTimeout().plus(Duration.ofMillis(random.nextInt((int) context.getElectionTimeout().toMillis())));
     currentTimer = context.getThreadContext().schedule(delay, () -> {
       // When the election times out, clear the previous majority vote
       // check and restart the election.
-      LOGGER.debug("{} - Election timed out", context.getAddress());
+      LOGGER.debug("{} - Election timed out", context.getMember().serverAddress());
       if (quorum != null) {
         quorum.cancel();
         quorum = null;
       }
       sendVoteRequests();
-      LOGGER.debug("{} - Restarted election", context.getAddress());
+      LOGGER.debug("{} - Restarted election", context.getMember().serverAddress());
     });
 
     final AtomicBoolean complete = new AtomicBoolean();
@@ -102,7 +102,7 @@ final class CandidateState extends ActiveState {
 
     // If there are no other members in the cluster, immediately transition to leader.
     if (votingMembers.isEmpty()) {
-      LOGGER.debug("{} - Single member cluster. Transitioning directly to leader.", context.getAddress());
+      LOGGER.debug("{} - Single member cluster. Transitioning directly to leader.", context.getMember().serverAddress());
       transition(CopycatServer.State.LEADER);
       return;
     }
@@ -133,20 +133,20 @@ final class CandidateState extends ActiveState {
       lastTerm = 0;
     }
 
-    LOGGER.info("{} - Requesting votes from {}", context.getAddress(), votingMembers);
+    LOGGER.info("{} - Requesting votes from {}", context.getMember().serverAddress(), votingMembers);
 
     // Once we got the last log term, iterate through each current member
     // of the cluster and vote each member for a vote.
     for (MemberState member : votingMembers) {
-      LOGGER.debug("{} - Requesting vote from {} for term {}", context.getAddress(), member, context.getTerm());
+      LOGGER.debug("{} - Requesting vote from {} for term {}", context.getMember().serverAddress(), member, context.getTerm());
       VoteRequest request = VoteRequest.builder()
         .withTerm(context.getTerm())
-        .withCandidate(context.getAddress().hashCode())
+        .withCandidate(context.getMember().serverAddress().hashCode())
         .withLogIndex(lastIndex)
         .withLogTerm(lastTerm)
         .build();
 
-      context.getConnections().getConnection(member.getAddress()).thenAccept(connection -> {
+      context.getConnections().getConnection(member.getServerAddress()).thenAccept(connection -> {
         connection.<VoteRequest, VoteResponse>send(request).whenCompleteAsync((response, error) -> {
           context.checkThread();
           if (isOpen() && !complete.get()) {
@@ -155,18 +155,18 @@ final class CandidateState extends ActiveState {
               quorum.fail();
             } else {
               if (response.term() > context.getTerm()) {
-                LOGGER.debug("{} - Received greater term from {}", context.getAddress(), member);
+                LOGGER.debug("{} - Received greater term from {}", context.getMember().serverAddress(), member);
                 context.setTerm(response.term());
                 complete.set(true);
                 transition(CopycatServer.State.FOLLOWER);
               } else if (!response.voted()) {
-                LOGGER.debug("{} - Received rejected vote from {}", context.getAddress(), member);
+                LOGGER.debug("{} - Received rejected vote from {}", context.getMember().serverAddress(), member);
                 quorum.fail();
               } else if (response.term() != context.getTerm()) {
-                LOGGER.debug("{} - Received successful vote for a different term from {}", context.getAddress(), member);
+                LOGGER.debug("{} - Received successful vote for a different term from {}", context.getMember().serverAddress(), member);
                 quorum.fail();
               } else {
-                LOGGER.debug("{} - Received successful vote from {}", context.getAddress(), member);
+                LOGGER.debug("{} - Received successful vote from {}", context.getMember().serverAddress(), member);
                 quorum.succeed();
               }
             }
@@ -202,7 +202,7 @@ final class CandidateState extends ActiveState {
     }
 
     // If the vote request is not for this candidate then reject the vote.
-    if (request.candidate() == context.getAddress().hashCode()) {
+    if (request.candidate() == context.getMember().serverAddress().hashCode()) {
       return CompletableFuture.completedFuture(logResponse(VoteResponse.builder()
         .withStatus(Response.Status.OK)
         .withTerm(context.getTerm())
@@ -223,7 +223,7 @@ final class CandidateState extends ActiveState {
   private void cancelElection() {
     context.checkThread();
     if (currentTimer != null) {
-      LOGGER.debug("{} - Cancelling election", context.getAddress());
+      LOGGER.debug("{} - Cancelling election", context.getMember().serverAddress());
       currentTimer.cancel();
     }
     if (quorum != null) {

--- a/server/src/main/java/io/atomix/copycat/server/state/CandidateState.java
+++ b/server/src/main/java/io/atomix/copycat/server/state/CandidateState.java
@@ -98,7 +98,7 @@ final class CandidateState extends ActiveState {
     });
 
     final AtomicBoolean complete = new AtomicBoolean();
-    final Set<MemberState> votingMembers = new HashSet<>(context.getCluster().getRemoteMemberStates(RaftMemberType.ACTIVE));
+    final Set<MemberState> votingMembers = new HashSet<>(context.getCluster().getVotingMemberStates());
 
     // If there are no other members in the cluster, immediately transition to leader.
     if (votingMembers.isEmpty()) {

--- a/server/src/main/java/io/atomix/copycat/server/state/ClusterState.java
+++ b/server/src/main/java/io/atomix/copycat/server/state/ClusterState.java
@@ -18,6 +18,7 @@ package io.atomix.copycat.server.state;
 import io.atomix.catalyst.util.Assert;
 
 import java.util.*;
+import java.util.stream.Collectors;
 
 /**
  * Cluster state.
@@ -26,22 +27,12 @@ import java.util.*;
  */
 class ClusterState {
   private final ServerState context;
-  private final Member member;
-  private Type type = Type.PASSIVE;
+  private Member member;
+  private MemberType type = RaftMemberType.PASSIVE;
   private long version = -1;
   private final Map<Integer, MemberState> membersMap = new HashMap<>();
-  private final Map<Integer, Type> types = new HashMap<>();
   private final List<MemberState> members = new ArrayList<>();
-  private final List<MemberState> activeMembers = new ArrayList<>();
-  private final List<MemberState> passiveMembers = new ArrayList<>();
-
-  /**
-   * Member state type.
-   */
-  private enum Type {
-    ACTIVE,
-    PASSIVE
-  }
+  private final Map<MemberType, List<MemberState>> memberTypes = new HashMap<>();
 
   ClusterState(ServerState context, Member member) {
     this.context = Assert.notNull(context, "context");
@@ -53,47 +44,18 @@ class ClusterState {
    *
    * @return The local cluster member.
    */
-  Member getMember() {
+  public Member getMember() {
     return member;
   }
 
   /**
-   * Returns a boolean value indicating whether the local member is active.
+   * Sets the local cluster member.
    *
-   * @return Indicates whether the local member is active.
-   */
-  boolean isActive() {
-    return type == Type.ACTIVE;
-  }
-
-  /**
-   * Sets whether the local member is active.
-   *
-   * @param active Whether the local member is active.
+   * @param member The local cluster member.
    * @return The cluster state.
    */
-  ClusterState setActive(boolean active) {
-    type = active ? Type.ACTIVE : Type.PASSIVE;
-    return this;
-  }
-
-  /**
-   * Returns a boolean value indicating whether the local member is passive.
-   *
-   * @return Indicates whether the local member is passive.
-   */
-  boolean isPassive() {
-    return type == Type.PASSIVE;
-  }
-
-  /**
-   * Sets whether the local member is passive.
-   *
-   * @param passive Whether the local member is passive.
-   * @return The cluster state.
-   */
-  ClusterState setPassive(boolean passive) {
-    type = passive ? Type.PASSIVE : Type.ACTIVE;
+  ClusterState setMember(Member member) {
+    this.member = member;
     return this;
   }
 
@@ -103,7 +65,7 @@ class ClusterState {
    * @return The remote quorum count.
    */
   int getQuorum() {
-    return (int) Math.floor((activeMembers.size() + 1) / 2.0) + 1;
+    return (int) Math.floor((getRemoteMemberStates(RaftMemberType.ACTIVE).size() + 1) / 2.0) + 1;
   }
 
   /**
@@ -116,17 +78,27 @@ class ClusterState {
   }
 
   /**
-   * Clears all members from the cluster state.
+   * Returns a member by ID.
    *
-   * @return The cluster state.
+   * @param id The member ID.
+   * @return The member.
    */
-  private ClusterState clearMembers() {
-    members.clear();
-    activeMembers.clear();
-    passiveMembers.clear();
-    membersMap.clear();
-    types.clear();
-    return this;
+  public Member getMember(int id) {
+    if (member.id() == id) {
+      return member;
+    }
+    return getRemoteMember(id);
+  }
+
+  /**
+   * Returns a member by ID.
+   *
+   * @param id The member ID.
+   * @return The member.
+   */
+  public Member getRemoteMember(int id) {
+    MemberState member = membersMap.get(id);
+    return member != null ? member.getMember() : null;
   }
 
   /**
@@ -135,68 +107,37 @@ class ClusterState {
    * @param id The member ID.
    * @return The member state.
    */
-  MemberState getMember(int id) {
+  MemberState getRemoteMemberState(int id) {
     return membersMap.get(id);
   }
 
   /**
-   * Returns a boolean value indicating whether the given member is active.
+   * Returns the current cluster members.
    *
-   * @param member The member state.
-   * @return Indicates whether the member is active.
+   * @return The current cluster members.
    */
-  boolean isActiveMember(MemberState member) {
-    return types.get(member.getServerAddress().hashCode()) == Type.ACTIVE;
+  public List<Member> getMembers() {
+    // Add all members to a list. The "members" field is only remote members, so we must separately
+    // add the local member to the list if necessary.
+    List<Member> members = new ArrayList<>(this.members.size() + 1);
+    for (MemberState member : this.members) {
+      members.add(member.getMember());
+    }
+
+    // If the local member type is null, that indicates it's not a member of the current configuration.
+    if (member.type() != null) {
+      members.add(member);
+    }
+    return members;
   }
 
   /**
-   * Returns a boolean value indicating whether the given member is passive.
+   * Returns a list of all remote members.
    *
-   * @param member The member state.
-   * @return Indicates whether the member is passive.
+   * @return A list of all remote members.
    */
-  boolean isPassiveMember(MemberState member) {
-    return types.get(member.getServerAddress().hashCode()) == Type.PASSIVE;
-  }
-
-  /**
-   * Returns a list of passive members.
-   *
-   * @return A list of passive members.
-   */
-  List<MemberState> getPassiveMembers() {
-    return passiveMembers;
-  }
-
-  /**
-   * Returns a list of passive members.
-   *
-   * @param comparator A comparator with which to sort the members list.
-   * @return The sorted members list.
-   */
-  List<MemberState> getPassiveMembers(Comparator<MemberState> comparator) {
-    Collections.sort(passiveMembers, comparator);
-    return passiveMembers;
-  }
-
-  /**
-   * Returns a list of active members.
-   *
-   * @return A list of active members.
-   */
-  List<MemberState> getActiveMembers() {
-    return activeMembers;
-  }
-
-  /**
-   * Returns a list of active members.
-   *
-   * @param comparator A comparator with which to sort the members list.
-   * @return The sorted members list.
-   */
-  List<MemberState> getActiveMembers(Comparator<MemberState> comparator) {
-    Collections.sort(activeMembers, comparator);
-    return activeMembers;
+  public List<Member> getRemoteMembers() {
+    return members.stream().map(MemberState::getMember).collect(Collectors.toList());
   }
 
   /**
@@ -204,119 +145,118 @@ class ClusterState {
    *
    * @return A list of all members.
    */
-  List<MemberState> getMembers() {
+  List<MemberState> getRemoteMemberStates() {
     return members;
+  }
+
+  /**
+   * Returns a list of remote members of the given type.
+   *
+   * @param type The type of members to return.
+   * @return A list of the given members.
+   */
+  public List<Member> getRemoteMembers(MemberType type) {
+    return getRemoteMemberStates(type).stream().map(MemberState::getMember).collect(Collectors.toList());
+  }
+
+  /**
+   * Returns a list of passive members.
+   *
+   * @param type The member type.
+   * @return A list of passive members.
+   */
+  List<MemberState> getRemoteMemberStates(MemberType type) {
+    List<MemberState> memberType = memberTypes.get(type);
+    return memberType != null ? memberType : Collections.EMPTY_LIST;
+  }
+
+  /**
+   * Returns a list of passive members.
+   *
+   * @param type The member type.
+   * @param comparator A comparator with which to sort the members list.
+   * @return The sorted members list.
+   */
+  List<MemberState> getRemoteMemberStates(MemberType type, Comparator<MemberState> comparator) {
+    List<MemberState> memberType = getRemoteMemberStates(type);
+    Collections.sort(memberType, comparator);
+    return memberType;
   }
 
   /**
    * Configures the cluster state.
    *
    * @param version The cluster state version.
-   * @param activeMembers The active members.
-   * @param passiveMembers The passive members.
+   * @param members The cluster members.
    * @return The cluster state.
    */
-  ClusterState configure(long version, Collection<Member> activeMembers, Collection<Member> passiveMembers) {
+  ClusterState configure(long version, Collection<Member> members) {
     if (version <= this.version)
       return this;
 
-    List<MemberState> newActiveMembers = buildMembers(activeMembers);
-    List<MemberState> newPassiveMembers = buildMembers(passiveMembers);
+    // If the configuration version is less than the currently configured version, ignore it.
+    // Configurations can be persisted and applying old configurations can revert newer configurations.
+    if (version <= this.version)
+      return this;
 
-    clearMembers();
+    // Iterate through members in the new configuration, add any missing members, and update existing members.
+    for (Member member : members) {
+      if (member.equals(this.member)) {
+        this.member = member;
+      } else {
+        // If the member state doesn't already exist, create it.
+        MemberState state = membersMap.get(member.id());
+        if (state == null) {
+          state = new MemberState(new Member(member.type(), member.serverAddress(), member.clientAddress()));
+          state.resetState(context.getLog());
+          this.members.add(state);
+          membersMap.put(member.id(), state);
+        }
 
-    for (MemberState member : newActiveMembers) {
-      membersMap.put(member.getServerAddress().hashCode(), member);
-      members.add(member);
-      this.activeMembers.add(member);
-      types.put(member.getServerAddress().hashCode(), Type.ACTIVE);
+        // If the member type has changed, update the member type and reset its state.
+        state.getMember().update(member.clientAddress());
+        if (state.getMember().type() != member.type()) {
+          state.getMember().update(member.type());
+          state.resetState(context.getLog());
+        }
+
+        // Update the optimized member collections according to the member type.
+        for (List<MemberState> memberType : memberTypes.values()) {
+          memberType.remove(state);
+        }
+
+        if (member.type() != null) {
+          List<MemberState> memberType = memberTypes.get(member.type());
+          if (memberType == null) {
+            memberType = new ArrayList<>();
+            memberTypes.put(member.type(), memberType);
+          }
+          memberType.add(state);
+        }
+      }
     }
 
-    for (MemberState member : newPassiveMembers) {
-      membersMap.put(member.getServerAddress().hashCode(), member);
-      members.add(member);
-      this.passiveMembers.add(member);
-      types.put(member.getServerAddress().hashCode(), Type.PASSIVE);
+    // If the local member is not part of the configuration, set its type to null.
+    if (!members.contains(this.member)) {
+      this.member.update((MemberType) null);
     }
 
-    if (activeMembers.contains(member)) {
-      type = Type.ACTIVE;
-    } else if (passiveMembers.contains(member)) {
-      type = Type.PASSIVE;
-    } else {
-      type = null;
+    // Iterate through configured members and remove any that no longer exist in the configuration.
+    Iterator<MemberState> iterator = this.members.iterator();
+    while (iterator.hasNext()) {
+      MemberState member = iterator.next();
+      if (!members.contains(member.getMember())) {
+        iterator.remove();
+        for (List<MemberState> memberType : memberTypes.values()) {
+          memberType.remove(member);
+        }
+        membersMap.remove(member.getMember().id());
+      }
     }
 
     this.version = version;
 
     return this;
-  }
-
-  /**
-   * Builds a list of all members.
-   */
-  Collection<Member> buildMembers() {
-    List<Member> members = new ArrayList<>();
-    for (MemberState member : activeMembers) {
-      members.add(new Member(member.getServerAddress(), member.getClientAddress()));
-    }
-    for (MemberState member : passiveMembers) {
-      members.add(new Member(member.getServerAddress(), member.getClientAddress()));
-    }
-
-    if (type != null) {
-      members.add(member);
-    }
-    return members;
-  }
-
-  /**
-   * Builds a list of active members.
-   */
-  Collection<Member> buildActiveMembers() {
-    List<Member> members = new ArrayList<>();
-    for (MemberState member : activeMembers) {
-      members.add(new Member(member.getServerAddress(), member.getClientAddress()));
-    }
-
-    if (type == Type.ACTIVE) {
-      members.add(member);
-    }
-    return members;
-  }
-
-  /**
-   * Builds a list of passive members.
-   */
-  Collection<Member> buildPassiveMembers() {
-    List<Member> members = new ArrayList<>();
-    for (MemberState member : passiveMembers) {
-      members.add(new Member(member.getServerAddress(), member.getClientAddress()));
-    }
-
-    if (type == Type.PASSIVE) {
-      members.add(member);
-    }
-    return members;
-  }
-
-  /**
-   * Builds a members list.
-   */
-  private List<MemberState> buildMembers(Collection<Member> members) {
-    List<MemberState> states = new ArrayList<>(members.size());
-    for (Member member : members) {
-      if (!member.equals(this.member)) {
-        // If the member doesn't already exist, create a new MemberState and initialize the state.
-        MemberState state = membersMap.get(member.hashCode());
-        if (state == null) {
-          state = new MemberState(member.serverAddress());
-          state.resetState(context.getLog());
-        }
-        states.add(state.setClientAddress(member.clientAddress()));
-      }
-    }
-    return states;
   }
 
 }

--- a/server/src/main/java/io/atomix/copycat/server/state/ClusterState.java
+++ b/server/src/main/java/io/atomix/copycat/server/state/ClusterState.java
@@ -155,7 +155,7 @@ class ClusterState {
    * @return A list of voting members.
    */
   public List<Member> getVotingMembers() {
-    return members.stream().filter(m -> m.getMember().type().isVoting()).map(MemberState::getMember).collect(Collectors.toList());
+    return members.stream().filter(m -> m.getMember().type() != null && m.getMember().type().isVoting()).map(MemberState::getMember).collect(Collectors.toList());
   }
 
   /**
@@ -164,7 +164,7 @@ class ClusterState {
    * @return A list of voting members.
    */
   List<MemberState> getVotingMemberStates() {
-    return members.stream().filter(m -> m.getMember().type().isVoting()).collect(Collectors.toList());
+    return members.stream().filter(m -> m.getMember().type() != null && m.getMember().type().isVoting()).collect(Collectors.toList());
   }
 
   /**
@@ -185,7 +185,7 @@ class ClusterState {
    * @return A list of stateful members.
    */
   public List<Member> getStatefulMembers() {
-    return members.stream().filter(m -> m.getMember().type().isStateful()).map(MemberState::getMember).collect(Collectors.toList());
+    return members.stream().filter(m -> m.getMember().type() != null && m.getMember().type().isStateful()).map(MemberState::getMember).collect(Collectors.toList());
   }
 
   /**
@@ -194,7 +194,7 @@ class ClusterState {
    * @return A list of stateful members.
    */
   List<MemberState> getStatefulMemberStates() {
-    return members.stream().filter(m -> m.getMember().type().isStateful()).collect(Collectors.toList());
+    return members.stream().filter(m -> m.getMember().type() != null && m.getMember().type().isStateful()).collect(Collectors.toList());
   }
 
   /**

--- a/server/src/main/java/io/atomix/copycat/server/state/ClusterState.java
+++ b/server/src/main/java/io/atomix/copycat/server/state/ClusterState.java
@@ -65,7 +65,7 @@ class ClusterState {
    * @return The remote quorum count.
    */
   int getQuorum() {
-    return (int) Math.floor((getRemoteMemberStates(RaftMemberType.ACTIVE).size() + 1) / 2.0) + 1;
+    return (int) Math.floor((getVotingMemberStates().size() + 1) / 2.0) + 1;
   }
 
   /**
@@ -150,37 +150,51 @@ class ClusterState {
   }
 
   /**
-   * Returns a list of remote members of the given type.
+   * Returns a list of voting members.
    *
-   * @param type The type of members to return.
-   * @return A list of the given members.
+   * @return A list of voting members.
    */
-  public List<Member> getRemoteMembers(MemberType type) {
-    return getRemoteMemberStates(type).stream().map(MemberState::getMember).collect(Collectors.toList());
+  public List<Member> getVotingMembers() {
+    return members.stream().filter(m -> m.getMember().type().isVoting()).map(MemberState::getMember).collect(Collectors.toList());
   }
 
   /**
-   * Returns a list of passive members.
+   * Returns a list of voting members.
    *
-   * @param type The member type.
-   * @return A list of passive members.
+   * @return A list of voting members.
    */
-  List<MemberState> getRemoteMemberStates(MemberType type) {
-    List<MemberState> memberType = memberTypes.get(type);
-    return memberType != null ? memberType : Collections.EMPTY_LIST;
+  List<MemberState> getVotingMemberStates() {
+    return members.stream().filter(m -> m.getMember().type().isVoting()).collect(Collectors.toList());
   }
 
   /**
-   * Returns a list of passive members.
+   * Returns a list of voting members.
    *
-   * @param type The member type.
-   * @param comparator A comparator with which to sort the members list.
-   * @return The sorted members list.
+   * @param comparator A comparator with which to sort the members.
+   * @return A list of voting members.
    */
-  List<MemberState> getRemoteMemberStates(MemberType type, Comparator<MemberState> comparator) {
-    List<MemberState> memberType = getRemoteMemberStates(type);
-    Collections.sort(memberType, comparator);
-    return memberType;
+  List<MemberState> getVotingMemberStates(Comparator<MemberState> comparator) {
+    List<MemberState> members = getVotingMemberStates();
+    Collections.sort(members, comparator);
+    return members;
+  }
+
+  /**
+   * Returns a list of stateful members.
+   *
+   * @return A list of stateful members.
+   */
+  public List<Member> getStatefulMembers() {
+    return members.stream().filter(m -> m.getMember().type().isStateful()).map(MemberState::getMember).collect(Collectors.toList());
+  }
+
+  /**
+   * Returns a list of stateful members.
+   *
+   * @return A list of stateful members.
+   */
+  List<MemberState> getStatefulMemberStates() {
+    return members.stream().filter(m -> m.getMember().type().isStateful()).collect(Collectors.toList());
   }
 
   /**

--- a/server/src/main/java/io/atomix/copycat/server/state/ClusterState.java
+++ b/server/src/main/java/io/atomix/copycat/server/state/ClusterState.java
@@ -16,6 +16,7 @@
 package io.atomix.copycat.server.state;
 
 import io.atomix.catalyst.util.Assert;
+import io.atomix.copycat.server.storage.MetaStore;
 
 import java.util.*;
 import java.util.stream.Collectors;
@@ -28,7 +29,6 @@ import java.util.stream.Collectors;
 class ClusterState {
   private final ServerState context;
   private Member member;
-  private MemberType type = RaftMemberType.PASSIVE;
   private long version = -1;
   private final Map<Integer, MemberState> membersMap = new HashMap<>();
   private final List<MemberState> members = new ArrayList<>();
@@ -255,6 +255,9 @@ class ClusterState {
     }
 
     this.version = version;
+
+    // Store the configuration to ensure it can be easily loaded on server restart.
+    context.getMetaStore().storeConfiguration(new MetaStore.Configuration(version, members));
 
     return this;
   }

--- a/server/src/main/java/io/atomix/copycat/server/state/ClusterState.java
+++ b/server/src/main/java/io/atomix/copycat/server/state/ClusterState.java
@@ -28,7 +28,7 @@ import java.util.stream.Collectors;
  */
 class ClusterState {
   private final ServerState context;
-  private Member member;
+  private final Member member;
   private long version = -1;
   private final Map<Integer, MemberState> membersMap = new HashMap<>();
   private final List<MemberState> members = new ArrayList<>();
@@ -46,17 +46,6 @@ class ClusterState {
    */
   public Member getMember() {
     return member;
-  }
-
-  /**
-   * Sets the local cluster member.
-   *
-   * @param member The local cluster member.
-   * @return The cluster state.
-   */
-  ClusterState setMember(Member member) {
-    this.member = member;
-    return this;
   }
 
   /**
@@ -216,7 +205,7 @@ class ClusterState {
     // Iterate through members in the new configuration, add any missing members, and update existing members.
     for (Member member : members) {
       if (member.equals(this.member)) {
-        this.member = member;
+        this.member.update(member.type()).update(member.clientAddress());
       } else {
         // If the member state doesn't already exist, create it.
         MemberState state = membersMap.get(member.id());

--- a/server/src/main/java/io/atomix/copycat/server/state/FollowerState.java
+++ b/server/src/main/java/io/atomix/copycat/server/state/FollowerState.java
@@ -93,7 +93,7 @@ final class FollowerState extends ActiveState {
 
       AcceptRequest acceptRequest = AcceptRequest.builder()
         .withSession(request.session())
-        .withAddress(context.getMember().serverAddress())
+        .withAddress(context.getCluster().getMember().serverAddress())
         .build();
       return this.<AcceptRequest, AcceptResponse>forward(acceptRequest)
         .thenApply(acceptResponse -> ConnectResponse.builder().withStatus(Response.Status.OK).build())
@@ -151,7 +151,7 @@ final class FollowerState extends ActiveState {
    * Starts the heartbeat timer.
    */
   private void startHeartbeatTimeout() {
-    LOGGER.debug("{} - Starting heartbeat timer", context.getMember().serverAddress());
+    LOGGER.debug("{} - Starting heartbeat timer", context.getCluster().getMember().serverAddress());
     resetHeartbeatTimeout();
   }
 
@@ -165,7 +165,7 @@ final class FollowerState extends ActiveState {
 
     // If a timer is already set, cancel the timer.
     if (heartbeatTimer != null) {
-      LOGGER.debug("{} - Reset heartbeat timeout", context.getMember().serverAddress());
+      LOGGER.debug("{} - Reset heartbeat timeout", context.getCluster().getMember().serverAddress());
       heartbeatTimer.cancel();
     }
 
@@ -177,7 +177,7 @@ final class FollowerState extends ActiveState {
       if (isOpen()) {
         context.setLeader(0);
         if (context.getLastVotedFor() == 0) {
-          LOGGER.debug("{} - Heartbeat timed out in {}", context.getMember().serverAddress(), delay);
+          LOGGER.debug("{} - Heartbeat timed out in {}", context.getCluster().getMember().serverAddress(), delay);
           sendPollRequests();
         } else {
           // If the node voted for a candidate then reset the election timer.
@@ -193,17 +193,17 @@ final class FollowerState extends ActiveState {
   private void sendPollRequests() {
     // Set a new timer within which other nodes must respond in order for this node to transition to candidate.
     heartbeatTimer = context.getThreadContext().schedule(context.getElectionTimeout(), () -> {
-      LOGGER.debug("{} - Failed to poll a majority of the cluster in {}", context.getMember().serverAddress(), context.getElectionTimeout());
+      LOGGER.debug("{} - Failed to poll a majority of the cluster in {}", context.getCluster().getMember().serverAddress(), context.getElectionTimeout());
       resetHeartbeatTimeout();
     });
 
     // Create a quorum that will track the number of nodes that have responded to the poll request.
     final AtomicBoolean complete = new AtomicBoolean();
-    final Set<MemberState> votingMembers = new HashSet<>(context.getCluster().getActiveMembers());
+    final Set<Member> votingMembers = new HashSet<>(context.getCluster().getRemoteMembers(RaftMemberType.ACTIVE));
 
     // If there are no other members in the cluster, immediately transition to leader.
     if (votingMembers.isEmpty()) {
-      LOGGER.debug("{} - Single member cluster. Transitioning directly to leader.", context.getMember().serverAddress());
+      LOGGER.debug("{} - Single member cluster. Transitioning directly to leader.", context.getCluster().getMember().serverAddress());
       transition(CopycatServer.State.LEADER);
       return;
     }
@@ -231,24 +231,24 @@ final class FollowerState extends ActiveState {
       lastTerm = 0;
     }
 
-    LOGGER.info("{} - Polling members {}", context.getMember().serverAddress(), votingMembers);
+    LOGGER.info("{} - Polling members {}", context.getCluster().getMember().serverAddress(), votingMembers);
 
     // Once we got the last log term, iterate through each current member
     // of the cluster and vote each member for a vote.
-    for (MemberState member : votingMembers) {
-      LOGGER.debug("{} - Polling {} for next term {}", context.getMember().serverAddress(), member, context.getTerm() + 1);
+    for (Member member : votingMembers) {
+      LOGGER.debug("{} - Polling {} for next term {}", context.getCluster().getMember().serverAddress(), member, context.getTerm() + 1);
       PollRequest request = PollRequest.builder()
         .withTerm(context.getTerm())
-        .withCandidate(context.getMember().serverAddress().hashCode())
+        .withCandidate(context.getCluster().getMember().serverAddress().hashCode())
         .withLogIndex(lastIndex)
         .withLogTerm(lastTerm)
         .build();
-      context.getConnections().getConnection(member.getServerAddress()).thenAccept(connection -> {
+      context.getConnections().getConnection(member.serverAddress()).thenAccept(connection -> {
         connection.<PollRequest, PollResponse>send(request).whenCompleteAsync((response, error) -> {
           context.checkThread();
           if (isOpen() && !complete.get()) {
             if (error != null) {
-              LOGGER.warn("{} - {}", context.getMember().serverAddress(), error.getMessage());
+              LOGGER.warn("{} - {}", context.getCluster().getMember().serverAddress(), error.getMessage());
               quorum.fail();
             } else {
               if (response.term() > context.getTerm()) {
@@ -256,13 +256,13 @@ final class FollowerState extends ActiveState {
               }
 
               if (!response.accepted()) {
-                LOGGER.debug("{} - Received rejected poll from {}", context.getMember().serverAddress(), member);
+                LOGGER.debug("{} - Received rejected poll from {}", context.getCluster().getMember().serverAddress(), member);
                 quorum.fail();
               } else if (response.term() != context.getTerm()) {
-                LOGGER.debug("{} - Received accepted poll for a different term from {}", context.getMember().serverAddress(), member);
+                LOGGER.debug("{} - Received accepted poll for a different term from {}", context.getCluster().getMember().serverAddress(), member);
                 quorum.fail();
               } else {
-                LOGGER.debug("{} - Received accepted poll from {}", context.getMember().serverAddress(), member);
+                LOGGER.debug("{} - Received accepted poll from {}", context.getCluster().getMember().serverAddress(), member);
                 quorum.succeed();
               }
             }
@@ -295,7 +295,7 @@ final class FollowerState extends ActiveState {
    */
   private void cancelHeartbeatTimeout() {
     if (heartbeatTimer != null) {
-      LOGGER.debug("{} - Cancelling heartbeat timer", context.getMember().serverAddress());
+      LOGGER.debug("{} - Cancelling heartbeat timer", context.getCluster().getMember().serverAddress());
       heartbeatTimer.cancel();
     }
   }

--- a/server/src/main/java/io/atomix/copycat/server/state/FollowerState.java
+++ b/server/src/main/java/io/atomix/copycat/server/state/FollowerState.java
@@ -93,7 +93,7 @@ final class FollowerState extends ActiveState {
 
       AcceptRequest acceptRequest = AcceptRequest.builder()
         .withSession(request.session())
-        .withAddress(context.getAddress())
+        .withAddress(context.getMember().serverAddress())
         .build();
       return this.<AcceptRequest, AcceptResponse>forward(acceptRequest)
         .thenApply(acceptResponse -> ConnectResponse.builder().withStatus(Response.Status.OK).build())
@@ -151,7 +151,7 @@ final class FollowerState extends ActiveState {
    * Starts the heartbeat timer.
    */
   private void startHeartbeatTimeout() {
-    LOGGER.debug("{} - Starting heartbeat timer", context.getAddress());
+    LOGGER.debug("{} - Starting heartbeat timer", context.getMember().serverAddress());
     resetHeartbeatTimeout();
   }
 
@@ -165,7 +165,7 @@ final class FollowerState extends ActiveState {
 
     // If a timer is already set, cancel the timer.
     if (heartbeatTimer != null) {
-      LOGGER.debug("{} - Reset heartbeat timeout", context.getAddress());
+      LOGGER.debug("{} - Reset heartbeat timeout", context.getMember().serverAddress());
       heartbeatTimer.cancel();
     }
 
@@ -177,7 +177,7 @@ final class FollowerState extends ActiveState {
       if (isOpen()) {
         context.setLeader(0);
         if (context.getLastVotedFor() == 0) {
-          LOGGER.debug("{} - Heartbeat timed out in {}", context.getAddress(), delay);
+          LOGGER.debug("{} - Heartbeat timed out in {}", context.getMember().serverAddress(), delay);
           sendPollRequests();
         } else {
           // If the node voted for a candidate then reset the election timer.
@@ -193,7 +193,7 @@ final class FollowerState extends ActiveState {
   private void sendPollRequests() {
     // Set a new timer within which other nodes must respond in order for this node to transition to candidate.
     heartbeatTimer = context.getThreadContext().schedule(context.getElectionTimeout(), () -> {
-      LOGGER.debug("{} - Failed to poll a majority of the cluster in {}", context.getAddress(), context.getElectionTimeout());
+      LOGGER.debug("{} - Failed to poll a majority of the cluster in {}", context.getMember().serverAddress(), context.getElectionTimeout());
       resetHeartbeatTimeout();
     });
 
@@ -203,7 +203,7 @@ final class FollowerState extends ActiveState {
 
     // If there are no other members in the cluster, immediately transition to leader.
     if (votingMembers.isEmpty()) {
-      LOGGER.debug("{} - Single member cluster. Transitioning directly to leader.", context.getAddress());
+      LOGGER.debug("{} - Single member cluster. Transitioning directly to leader.", context.getMember().serverAddress());
       transition(CopycatServer.State.LEADER);
       return;
     }
@@ -231,24 +231,24 @@ final class FollowerState extends ActiveState {
       lastTerm = 0;
     }
 
-    LOGGER.info("{} - Polling members {}", context.getAddress(), votingMembers);
+    LOGGER.info("{} - Polling members {}", context.getMember().serverAddress(), votingMembers);
 
     // Once we got the last log term, iterate through each current member
     // of the cluster and vote each member for a vote.
     for (MemberState member : votingMembers) {
-      LOGGER.debug("{} - Polling {} for next term {}", context.getAddress(), member, context.getTerm() + 1);
+      LOGGER.debug("{} - Polling {} for next term {}", context.getMember().serverAddress(), member, context.getTerm() + 1);
       PollRequest request = PollRequest.builder()
         .withTerm(context.getTerm())
-        .withCandidate(context.getAddress().hashCode())
+        .withCandidate(context.getMember().serverAddress().hashCode())
         .withLogIndex(lastIndex)
         .withLogTerm(lastTerm)
         .build();
-      context.getConnections().getConnection(member.getAddress()).thenAccept(connection -> {
+      context.getConnections().getConnection(member.getServerAddress()).thenAccept(connection -> {
         connection.<PollRequest, PollResponse>send(request).whenCompleteAsync((response, error) -> {
           context.checkThread();
           if (isOpen() && !complete.get()) {
             if (error != null) {
-              LOGGER.warn("{} - {}", context.getAddress(), error.getMessage());
+              LOGGER.warn("{} - {}", context.getMember().serverAddress(), error.getMessage());
               quorum.fail();
             } else {
               if (response.term() > context.getTerm()) {
@@ -256,13 +256,13 @@ final class FollowerState extends ActiveState {
               }
 
               if (!response.accepted()) {
-                LOGGER.debug("{} - Received rejected poll from {}", context.getAddress(), member);
+                LOGGER.debug("{} - Received rejected poll from {}", context.getMember().serverAddress(), member);
                 quorum.fail();
               } else if (response.term() != context.getTerm()) {
-                LOGGER.debug("{} - Received accepted poll for a different term from {}", context.getAddress(), member);
+                LOGGER.debug("{} - Received accepted poll for a different term from {}", context.getMember().serverAddress(), member);
                 quorum.fail();
               } else {
-                LOGGER.debug("{} - Received accepted poll from {}", context.getAddress(), member);
+                LOGGER.debug("{} - Received accepted poll from {}", context.getMember().serverAddress(), member);
                 quorum.succeed();
               }
             }
@@ -295,7 +295,7 @@ final class FollowerState extends ActiveState {
    */
   private void cancelHeartbeatTimeout() {
     if (heartbeatTimer != null) {
-      LOGGER.debug("{} - Cancelling heartbeat timer", context.getAddress());
+      LOGGER.debug("{} - Cancelling heartbeat timer", context.getMember().serverAddress());
       heartbeatTimer.cancel();
     }
   }

--- a/server/src/main/java/io/atomix/copycat/server/state/FollowerState.java
+++ b/server/src/main/java/io/atomix/copycat/server/state/FollowerState.java
@@ -199,7 +199,7 @@ final class FollowerState extends ActiveState {
 
     // Create a quorum that will track the number of nodes that have responded to the poll request.
     final AtomicBoolean complete = new AtomicBoolean();
-    final Set<Member> votingMembers = new HashSet<>(context.getCluster().getRemoteMembers(RaftMemberType.ACTIVE));
+    final Set<Member> votingMembers = new HashSet<>(context.getCluster().getVotingMembers());
 
     // If there are no other members in the cluster, immediately transition to leader.
     if (votingMembers.isEmpty()) {

--- a/server/src/main/java/io/atomix/copycat/server/state/InactiveState.java
+++ b/server/src/main/java/io/atomix/copycat/server/state/InactiveState.java
@@ -72,6 +72,11 @@ class InactiveState extends AbstractState {
   }
 
   @Override
+  protected CompletableFuture<ConfigureResponse> configure(ConfigureRequest request) {
+    return Futures.exceptionalFuture(new IllegalStateException("inactive state"));
+  }
+
+  @Override
   protected CompletableFuture<JoinResponse> join(JoinRequest request) {
     return Futures.exceptionalFuture(new IllegalStateException("inactive state"));
   }

--- a/server/src/main/java/io/atomix/copycat/server/state/LeaderAppender.java
+++ b/server/src/main/java/io/atomix/copycat/server/state/LeaderAppender.java
@@ -1,0 +1,485 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License
+ */
+package io.atomix.copycat.server.state;
+
+import io.atomix.catalyst.util.Assert;
+import io.atomix.copycat.client.error.InternalException;
+import io.atomix.copycat.client.response.Response;
+import io.atomix.copycat.server.CopycatServer;
+import io.atomix.copycat.server.request.AppendRequest;
+import io.atomix.copycat.server.response.AppendResponse;
+import io.atomix.copycat.server.storage.entry.Entry;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * The leader appender is responsible for sending {@link AppendRequest}s on behalf of a leader to followers.
+ * Append requests are sent by the leader only to other active members of the cluster.
+ *
+ * @author <a href="http://github.com/kuujo>Jordan Halterman</a>
+ */
+final class LeaderAppender extends AbstractAppender {
+  private static final int MAX_BATCH_SIZE = 1024 * 32;
+  private final LeaderState leader;
+  private final long leaderTime;
+  private final long leaderIndex;
+  private long commitTime;
+  private int commitFailures;
+  private CompletableFuture<Long> commitFuture;
+  private CompletableFuture<Long> nextCommitFuture;
+  private final Map<Long, CompletableFuture<Long>> commitFutures = new HashMap<>();
+
+  LeaderAppender(LeaderState leader) {
+    super(leader.context);
+    this.leader = Assert.notNull(leader, "leader");
+    this.leaderTime = System.currentTimeMillis();
+    this.leaderIndex = context.getLog().nextIndex();
+    this.commitTime = leaderTime;
+  }
+
+  /**
+   * Returns the current commit time.
+   *
+   * @return The current commit time.
+   */
+  public long time() {
+    return commitTime;
+  }
+
+  /**
+   * Returns the leader index.
+   *
+   * @return The leader index.
+   */
+  public long index() {
+    return leaderIndex;
+  }
+
+  /**
+   * Returns the current quorum index.
+   *
+   * @return The current quorum index.
+   */
+  private int quorumIndex() {
+    return context.getCluster().getQuorum() - 2;
+  }
+
+  /**
+   * Triggers a heartbeat to a majority of the cluster.
+   * <p>
+   * For followers to which no AppendRequest is currently being sent, a new empty AppendRequest will be
+   * created and sent. For followers to which an AppendRequest is already being sent, the appendEntries()
+   * call will piggyback on the *next* AppendRequest. Thus, multiple calls to this method will only ever
+   * result in a single AppendRequest to each follower at any given time, and the returned future will be
+   * shared by all concurrent calls.
+   *
+   * @return A completable future to be completed the next time a heartbeat is received by a majority of the cluster.
+   */
+  public CompletableFuture<Long> appendEntries() {
+    // If there are no other active members in the cluster, simply complete the append operation.
+    if (context.getCluster().getMembers().size() == 0)
+      return CompletableFuture.completedFuture(null);
+
+    // If no commit future already exists, that indicates there's no heartbeat currently under way.
+    // Create a new commit future and commit to all members in the cluster.
+    if (commitFuture == null) {
+      commitFuture = new CompletableFuture<>();
+      commitTime = System.currentTimeMillis();
+      for (MemberState member : context.getCluster().getRemoteMemberStates()) {
+        appendEntries(member);
+      }
+      return commitFuture;
+    }
+    // If a commit future already exists, that indicates there is a heartbeat currently underway.
+    // We don't want to allow callers to be completed by a heartbeat that may already almost be done.
+    // So, we create the next commit future if necessary and return that. Once the current heartbeat
+    // completes the next future will be used to do another heartbeat. This ensures that only one
+    // heartbeat can be outstanding at any given point in time.
+    else if (nextCommitFuture == null) {
+      nextCommitFuture = new CompletableFuture<>();
+      return nextCommitFuture;
+    } else {
+      return nextCommitFuture;
+    }
+  }
+
+  /**
+   * Registers a commit handler for the given commit index.
+   *
+   * @param index The index for which to register the handler.
+   * @return A completable future to be completed once the given log index has been committed.
+   */
+  public CompletableFuture<Long> appendEntries(long index) {
+    if (index == 0)
+      return appendEntries();
+
+    // If there are no other servers in the cluster, immediately commit the index.
+    if (context.getCluster().getRemoteMemberStates().isEmpty()) {
+      context.setCommitIndex(index);
+      context.setGlobalIndex(index);
+      return CompletableFuture.completedFuture(index);
+    }
+    // If there are no other active members in the cluster, update the commit index and complete
+    // the commit but ensure append entries requests are sent to passive members.
+    else if (context.getCluster().getVotingMemberStates().isEmpty()) {
+      context.setCommitIndex(index);
+      for (MemberState member : context.getCluster().getRemoteMemberStates()) {
+        appendEntries(member);
+      }
+      return CompletableFuture.completedFuture(index);
+    }
+
+    // Ensure append requests are being sent to all members, including passive members.
+    return commitFutures.computeIfAbsent(index, i -> {
+      for (MemberState member : context.getCluster().getRemoteMemberStates()) {
+        appendEntries(member);
+      }
+      return new CompletableFuture<>();
+    });
+  }
+
+  /**
+   * Returns the last time a majority of the cluster was contacted.
+   * <p>
+   * This is calculated by sorting the list of active members and getting the last time the majority of
+   * the cluster was contacted based on the index of a majority of the members. So, in a list of 3 ACTIVE
+   * members, index 1 (the second member) will be used to determine the commit time in a sorted members list.
+   */
+  private long commitTime() {
+    int quorumIndex = quorumIndex();
+    if (quorumIndex >= 0) {
+      return context.getCluster().getVotingMemberStates((m1, m2) -> Long.compare(m2.getCommitTime(), m1.getCommitTime())).get(quorumIndex).getCommitTime();
+    }
+    return System.currentTimeMillis();
+  }
+
+  /**
+   * Sets a commit time or fails the commit if a quorum of successful responses cannot be achieved.
+   */
+  private void commitTime(MemberState member, Throwable error) {
+    if (commitFuture == null) {
+      return;
+    }
+
+    if (error != null && member.getCommitStartTime() == this.commitTime) {
+      int votingMemberSize = context.getCluster().getVotingMemberStates().size() + (context.getCluster().getMember().type().isVoting() ? 1 : 0);
+      int quorumSize = context.getCluster().getQuorum();
+      // If a quorum of successful responses cannot be achieved, fail this commit.
+      if (votingMemberSize - quorumSize + 1 <= ++commitFailures) {
+        commitFuture.completeExceptionally(new InternalException("Failed to reach consensus"));
+        completeCommit();
+      }
+    } else {
+      member.setCommitTime(System.currentTimeMillis());
+
+      // Sort the list of commit times. Use the quorum index to get the last time the majority of the cluster
+      // was contacted. If the current commitFuture's time is less than the commit time then trigger the
+      // commit future and reset it to the next commit future.
+      if (this.commitTime <= commitTime()) {
+        commitFuture.complete(null);
+        completeCommit();
+      }
+    }
+  }
+
+  /**
+   * Completes a heartbeat by replacing the current commitFuture with the nextCommitFuture, updating the
+   * current commitTime, and starting a new {@link AppendRequest} to all active members.
+   */
+  private void completeCommit() {
+    commitFailures = 0;
+    commitFuture = nextCommitFuture;
+    nextCommitFuture = null;
+    if (commitFuture != null) {
+      this.commitTime = System.currentTimeMillis();
+      for (MemberState replica : context.getCluster().getRemoteMemberStates()) {
+        appendEntries(replica);
+      }
+    }
+  }
+
+  /**
+   * Checks whether any futures can be completed.
+   */
+  private void commitEntries() {
+    context.checkThread();
+
+    // The global index may have increased even if the commit index didn't. Update the global index.
+    // The global index is calculated by the minimum matchIndex for *all* servers in the cluster, including
+    // passive members. This is critical since passive members still have state machines and thus it's still
+    // important to ensure that tombstones are applied to their state machines.
+    // If the members list is empty, use the local server's last log index as the global index.
+    long globalMatchIndex = context.getCluster().getRemoteMemberStates().stream().mapToLong(MemberState::getMatchIndex).min().orElse(context.getLog().lastIndex());
+    context.setGlobalIndex(globalMatchIndex);
+
+    // Sort the list of replicas, order by the last index that was replicated
+    // to the replica. This will allow us to determine the median index
+    // for all known replicated entries across all cluster members.
+    List<MemberState> members = context.getCluster().getVotingMemberStates((m1, m2)->
+      Long.compare(m2.getMatchIndex() != 0 ? m2.getMatchIndex() : 0l, m1.getMatchIndex() != 0 ? m1.getMatchIndex() : 0l));
+
+    // If the active members list is empty (a configuration change occurred between an append request/response)
+    // ensure all commit futures are completed and cleared.
+    if (members.isEmpty()) {
+      context.setCommitIndex(context.getLog().lastIndex());
+      for (Map.Entry<Long, CompletableFuture<Long>> entry : commitFutures.entrySet()) {
+        entry.getValue().complete(entry.getKey());
+      }
+      commitFutures.clear();
+      return;
+    }
+
+    // Calculate the current commit index as the median matchIndex.
+    long commitIndex = members.get(quorumIndex()).getMatchIndex();
+
+    // If the commit index has increased then update the commit index. Note that in order to ensure
+    // the leader completeness property holds, verify that the commit index is greater than or equal to
+    // the index of the leader's no-op entry. Update the commit index and trigger commit futures.
+    long previousCommitIndex = context.getCommitIndex();
+    if (commitIndex > 0 && commitIndex > previousCommitIndex && (leaderIndex > 0 && commitIndex >= leaderIndex)) {
+      context.setCommitIndex(commitIndex);
+
+      // Iterate from the previous commitIndex to the updated commitIndex and remove and complete futures.
+      for (long i = previousCommitIndex + 1; i <= commitIndex; i++) {
+        CompletableFuture<Long> future = commitFutures.remove(i);
+        if (future != null) {
+          future.complete(i);
+        }
+      }
+    }
+  }
+
+  @Override
+  protected AppendRequest buildAppendRequest(MemberState member) {
+    // If the log is empty then send an empty commit.
+    // If the member is not stateful then send an empty commit if two election timeouts have passed.
+    // If the next index hasn't yet been set then we send an empty commit first.
+    // If the next index is greater than the last index then send an empty commit.
+    // If the member failed to respond to recent communication send an empty commit. This
+    // helps avoid doing expensive work until we can ascertain the member is back up.
+    if (!member.getMember().type().isStateful()) {
+      if (member.getMember().status() == Member.Status.UNAVAILABLE || System.currentTimeMillis() - member.getCommitTime() > context.getElectionTimeout().toMillis() * 2) {
+        return buildEmptyRequest(member);
+      }
+    } else {
+      if (context.getLog().isEmpty() || member.getNextIndex() > context.getLog().lastIndex() || member.getFailureCount() > 0) {
+        return buildEmptyRequest(member);
+      } else {
+        return buildEntryRequest(member);
+      }
+    }
+    return buildEntryRequest(member);
+  }
+
+  /**
+   * Builds an empty AppendEntries request.
+   * <p>
+   * Empty append requests are used as heartbeats to followers.
+   */
+  private AppendRequest buildEmptyRequest(MemberState member) {
+    long prevIndex = getPrevIndex(member);
+    Entry prevEntry = getPrevEntry(member, prevIndex);
+
+    return AppendRequest.builder()
+      .withTerm(context.getTerm())
+      .withLeader(context.getCluster().getMember().id())
+      .withLogIndex(prevIndex)
+      .withLogTerm(prevEntry != null ? prevEntry.getTerm() : 0)
+      .withCommitIndex(context.getCommitIndex())
+      .build();
+  }
+
+  /**
+   * Builds a populated AppendEntries request.
+   */
+  private AppendRequest buildEntryRequest(MemberState member) {
+    long prevIndex = getPrevIndex(member);
+    Entry prevEntry = getPrevEntry(member, prevIndex);
+
+    AppendRequest.Builder builder = AppendRequest.builder()
+      .withTerm(context.getTerm())
+      .withLeader(context.getCluster().getMember().id())
+      .withLogIndex(prevIndex)
+      .withLogTerm(prevEntry != null ? prevEntry.getTerm() : 0)
+      .withCommitIndex(context.getCommitIndex());
+
+    // Build a list of entries to send to the member.
+    if (!context.getLog().isEmpty()) {
+      long index = prevIndex != 0 ? prevIndex + 1 : context.getLog().firstIndex();
+
+      // We build a list of entries up to the MAX_BATCH_SIZE. Note that entries in the log may
+      // be null if they've been compacted and the member to which we're sending entries is just
+      // joining the cluster or is otherwise far behind. Null entries are simply skipped and not
+      // counted towards the size of the batch.
+      int size = 0;
+      while (index <= context.getLog().lastIndex()) {
+        // Get the entry from the log and append it if it's not null. Entries in the log can be null
+        // if they've been cleaned or compacted from the log. Each entry sent in the append request
+        // has a unique index to handle gaps in the log.
+        Entry entry = context.getLog().get(index);
+        if (entry != null) {
+          if (size + entry.size() > MAX_BATCH_SIZE) {
+            break;
+          }
+          size += entry.size();
+          builder.addEntry(entry);
+        }
+        index++;
+      }
+    }
+
+    // Release the previous entry back to the entry pool.
+    if (prevEntry != null) {
+      prevEntry.release();
+    }
+
+    return builder.build();
+  }
+
+  @Override
+  protected void startAppendRequest(MemberState member, AppendRequest request) {
+    super.startAppendRequest(member, request);
+    member.setCommitStartTime(commitTime);
+  }
+
+  @Override
+  protected void endAppendRequest(MemberState member, AppendRequest request, Throwable error) {
+    super.endAppendRequest(member, request, error);
+    commitTime(member, error);
+  }
+
+  @Override
+  protected void handleAppendResponse(MemberState member, AppendRequest request, AppendResponse response) {
+    if (response.status() == Response.Status.OK) {
+      handleAppendResponseOk(member, request, response);
+    } else {
+      handleAppendResponseError(member, request, response);
+    }
+  }
+
+  /**
+   * Handles a {@link Response.Status#OK} response.
+   */
+  private void handleAppendResponseOk(MemberState member, AppendRequest request, AppendResponse response) {
+    succeedAttempt(member);
+
+    // Update the commit time for the replica. This will cause heartbeat futures to be triggered.
+    commitTime(member, null);
+
+    // If replication succeeded then trigger commit futures.
+    if (response.succeeded()) {
+      updateMatchIndex(member, response);
+      updateNextIndex(member);
+
+      // If entries were committed to the replica then check commit indexes.
+      if (!request.entries().isEmpty()) {
+        commitEntries();
+      }
+
+      // If there are more entries to send then attempt to send another commit.
+      if (hasMoreEntries(member)) {
+        appendEntries(member);
+      }
+    }
+    // If we've received a greater term, update the term and transition back to follower.
+    else if (response.term() > context.getTerm()) {
+      context.setTerm(response.term()).setLeader(0);
+      context.transition(CopycatServer.State.FOLLOWER);
+    }
+    // If the response failed, the follower should have provided the correct last index in their log. This helps
+    // us converge on the matchIndex faster than by simply decrementing nextIndex one index at a time.
+    else {
+      resetMatchIndex(member, response);
+      resetNextIndex(member);
+
+      // If there are more entries to send then attempt to send another commit.
+      if (hasMoreEntries(member)) {
+        appendEntries(member);
+      }
+    }
+  }
+
+  /**
+   * Handles a {@link Response.Status#ERROR} response.
+   */
+  private void handleAppendResponseError(MemberState member, AppendRequest request, AppendResponse response) {
+    // If we've received a greater term, update the term and transition back to follower.
+    if (response.term() > context.getTerm()) {
+      LOGGER.debug("{} - Received higher term from {}", context.getCluster().getMember().serverAddress(), member.getMember().serverAddress());
+      context.setTerm(response.term()).setLeader(0);
+      context.transition(CopycatServer.State.FOLLOWER);
+    } else {
+      // If any other error occurred, increment the failure count for the member. Log the first three failures,
+      // and thereafter log 1% of the failures. This keeps the log from filling up with annoying error messages
+      // when attempting to send entries to down followers.
+      int failures = member.incrementFailureCount();
+      if (failures <= 3 || failures % 100 == 0) {
+        LOGGER.warn("{} - AppendRequest to {} failed. Reason: [{}]", context.getCluster().getMember().serverAddress(), member.getMember().serverAddress(), response.error() != null ? response.error() : "");
+      }
+    }
+  }
+
+  @Override
+  protected void handleAppendError(MemberState member, AppendRequest request, Throwable error) {
+    failAttempt(member, error);
+  }
+
+  /**
+   * Succeeds an attempt to contact a member.
+   */
+  private void succeedAttempt(MemberState member) {
+    // Reset the member failure count.
+    member.resetFailureCount();
+
+    // If the member is currently marked as UNAVAILABLE, change its status to AVAILABLE and update the configuration.
+    if (member.getMember().status() == Member.Status.UNAVAILABLE) {
+      member.getMember().update(Member.Status.AVAILABLE);
+      leader.configure(context.getCluster().getMembers());
+    }
+  }
+
+  /**
+   * Fails an attempt to contact a member.
+   */
+  private void failAttempt(MemberState member, Throwable error) {
+    // If any append error occurred, increment the failure count for the member. Log the first three failures,
+    // and thereafter log 1% of the failures. This keeps the log from filling up with annoying error messages
+    // when attempting to send entries to down followers.
+    int failures = member.incrementFailureCount();
+    if (failures <= 3 || failures % 100 == 0) {
+      LOGGER.warn("{} - {}", context.getCluster().getMember().serverAddress(), error.getMessage());
+    }
+
+    // Verify that the leader has contacted a majority of the cluster within the last two election timeouts.
+    // If the leader is not able to contact a majority of the cluster within two election timeouts, assume
+    // that a partition occurred and transition back to the FOLLOWER state.
+    if (System.currentTimeMillis() - Math.max(commitTime(), leaderTime) > context.getElectionTimeout().toMillis() * 2) {
+      LOGGER.warn("{} - Suspected network partition. Stepping down", context.getCluster().getMember().serverAddress());
+      context.setLeader(0);
+      context.transition(CopycatServer.State.FOLLOWER);
+    }
+    // If the number of failures has increased above 3 and the member hasn't been marked as UNAVAILABLE, do so.
+    else if (failures >= 3) {
+      // If the member is currently marked as AVAILABLE, change its status to UNAVAILABLE and update the configuration.
+      member.getMember().update(Member.Status.UNAVAILABLE);
+      leader.configure(context.getCluster().getMembers());
+    }
+  }
+
+}

--- a/server/src/main/java/io/atomix/copycat/server/state/LeaderAppender.java
+++ b/server/src/main/java/io/atomix/copycat/server/state/LeaderAppender.java
@@ -93,7 +93,7 @@ final class LeaderAppender extends AbstractAppender {
    */
   public CompletableFuture<Long> appendEntries() {
     // If there are no other active members in the cluster, simply complete the append operation.
-    if (context.getCluster().getMembers().size() == 0)
+    if (context.getCluster().getRemoteMemberStates().size() == 0)
       return CompletableFuture.completedFuture(null);
 
     // If no commit future already exists, that indicates there's no heartbeat currently under way.

--- a/server/src/main/java/io/atomix/copycat/server/state/LeaderAppender.java
+++ b/server/src/main/java/io/atomix/copycat/server/state/LeaderAppender.java
@@ -231,7 +231,7 @@ final class LeaderAppender extends AbstractAppender {
     // Sort the list of replicas, order by the last index that was replicated
     // to the replica. This will allow us to determine the median index
     // for all known replicated entries across all cluster members.
-    List<MemberState> members = context.getCluster().getVotingMemberStates((m1, m2)->
+    List<MemberState> members = context.getCluster().getVotingMemberStates((m1, m2) ->
       Long.compare(m2.getMatchIndex() != 0 ? m2.getMatchIndex() : 0l, m1.getMatchIndex() != 0 ? m1.getMatchIndex() : 0l));
 
     // If the active members list is empty (a configuration change occurred between an append request/response)
@@ -302,6 +302,7 @@ final class LeaderAppender extends AbstractAppender {
       .withLogIndex(prevIndex)
       .withLogTerm(prevEntry != null ? prevEntry.getTerm() : 0)
       .withCommitIndex(context.getCommitIndex())
+      .withGlobalIndex(context.getGlobalIndex())
       .build();
   }
 
@@ -317,7 +318,8 @@ final class LeaderAppender extends AbstractAppender {
       .withLeader(context.getCluster().getMember().id())
       .withLogIndex(prevIndex)
       .withLogTerm(prevEntry != null ? prevEntry.getTerm() : 0)
-      .withCommitIndex(context.getCommitIndex());
+      .withCommitIndex(context.getCommitIndex())
+      .withGlobalIndex(context.getGlobalIndex());
 
     // Build a list of entries to send to the member.
     if (!context.getLog().isEmpty()) {

--- a/server/src/main/java/io/atomix/copycat/server/state/LeaderState.java
+++ b/server/src/main/java/io/atomix/copycat/server/state/LeaderState.java
@@ -871,7 +871,7 @@ final class LeaderState extends ActiveState {
 
   @Override
   public synchronized CompletableFuture<Void> close() {
-    return super.close().thenRun(this::cancelAppendTimer);
+    return super.close().thenRun(appender::close).thenRun(this::cancelAppendTimer);
   }
 
 }

--- a/server/src/main/java/io/atomix/copycat/server/state/LeaderState.java
+++ b/server/src/main/java/io/atomix/copycat/server/state/LeaderState.java
@@ -211,7 +211,8 @@ final class LeaderState extends ActiveState {
     }
 
     // If the member is already a known member of the cluster, complete the join successfully.
-    if (context.getCluster().getMember(request.member().hashCode()) != null) {
+    MemberState existingMember = context.getCluster().getMember(request.member().hashCode());
+    if (existingMember != null && existingMember.getClientAddress() != null && existingMember.getClientAddress().equals(request.member().clientAddress())) {
       return CompletableFuture.completedFuture(logResponse(JoinResponse.builder()
         .withStatus(Response.Status.OK)
         .withVersion(context.getCluster().getVersion())

--- a/server/src/main/java/io/atomix/copycat/server/state/LeaderState.java
+++ b/server/src/main/java/io/atomix/copycat/server/state/LeaderState.java
@@ -95,9 +95,7 @@ final class LeaderState extends ActiveState {
     }
 
     // Append a configuration entry to propagate the leader's cluster configuration.
-    try (ConfigurationEntry entry = context.getLog().create(ConfigurationEntry.class)) {
-      entry.setTerm(term).setMembers(context.getCluster().getMembers());
-    }
+    configure(context.getCluster().getMembers());
   }
 
   /**

--- a/server/src/main/java/io/atomix/copycat/server/state/LeaderState.java
+++ b/server/src/main/java/io/atomix/copycat/server/state/LeaderState.java
@@ -20,7 +20,6 @@ import io.atomix.catalyst.util.concurrent.ComposableFuture;
 import io.atomix.catalyst.util.concurrent.Scheduled;
 import io.atomix.copycat.client.Command;
 import io.atomix.copycat.client.Query;
-import io.atomix.copycat.client.error.InternalException;
 import io.atomix.copycat.client.error.RaftError;
 import io.atomix.copycat.client.error.RaftException;
 import io.atomix.copycat.client.request.*;
@@ -31,7 +30,7 @@ import io.atomix.copycat.server.response.*;
 import io.atomix.copycat.server.storage.entry.*;
 
 import java.time.Duration;
-import java.util.*;
+import java.util.Collection;
 import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
 
@@ -41,15 +40,13 @@ import java.util.stream.Collectors;
  * @author <a href="http://github.com/kuujo">Jordan Halterman</a>
  */
 final class LeaderState extends ActiveState {
-  private static final int MAX_BATCH_SIZE = 1024 * 28;
-  private Scheduled currentTimer;
-  private final Replicator replicator = new Replicator();
-  private long leaderTime = System.currentTimeMillis();
-  private long leaderIndex;
+  private final LeaderAppender appender;
+  private Scheduled appendTimer;
   private long configuring;
 
   public LeaderState(ServerState context) {
     super(context);
+    this.appender = new LeaderAppender(this);
   }
 
   @Override
@@ -67,7 +64,7 @@ final class LeaderState extends ActiveState {
     // What is critical about this logic is that the heartbeat timer not be started until a no-op entry has been committed.
     context.getThreadContext().execute(this::commitInitialEntries).whenComplete((result, error) -> {
       if (isOpen() && error == null) {
-        startHeartbeatTimer();
+        startAppendTimer();
       }
     });
 
@@ -81,7 +78,7 @@ final class LeaderState extends ActiveState {
    */
   private void takeLeadership() {
     context.setLeader(context.getCluster().getMember().id());
-    context.getCluster().getRemoteMemberStates(RaftMemberType.ACTIVE).forEach(m -> m.resetState(context.getLog()));
+    context.getCluster().getVotingMemberStates().forEach(m -> m.resetState(context.getLog()));
   }
 
   /**
@@ -93,8 +90,8 @@ final class LeaderState extends ActiveState {
     // Append a no-op entry to reset session timeouts and commit entries from prior terms.
     try (NoOpEntry entry = context.getLog().create(NoOpEntry.class)) {
       entry.setTerm(term)
-        .setTimestamp(leaderTime);
-      leaderIndex = entry.getIndex();
+        .setTimestamp(appender.time());
+      assert context.getLog().append(entry) == appender.index();
     }
 
     // Append a configuration entry to propagate the leader's cluster configuration.
@@ -112,7 +109,7 @@ final class LeaderState extends ActiveState {
     // we force entries to be appended up to the leader's no-op entry. The LeaderAppender will ensure
     // that the commitIndex is not increased until the no-op entry (appender.index()) is committed.
     CompletableFuture<Void> future = new CompletableFuture<>();
-    replicator.commit(leaderIndex).whenComplete((resultIndex, error) -> {
+    appender.appendEntries(appender.index()).whenComplete((resultIndex, error) -> {
       context.checkThread();
       if (isOpen()) {
         if (error == null) {
@@ -152,37 +149,50 @@ final class LeaderState extends ActiveState {
   }
 
   /**
-   * Starts heartbeating all cluster members.
+   * Starts sending AppendEntries requests to all cluster members.
    */
-  private void startHeartbeatTimer() {
+  private void startAppendTimer() {
     // Set a timer that will be used to periodically synchronize with other nodes
     // in the cluster. This timer acts as a heartbeat to ensure this node remains
     // the leader.
-    LOGGER.debug("{} - Starting heartbeat timer", context.getCluster().getMember().serverAddress());
-    currentTimer = context.getThreadContext().schedule(Duration.ZERO, context.getHeartbeatInterval(), this::heartbeatMembers);
+    LOGGER.debug("{} - Starting append timer", context.getCluster().getMember().serverAddress());
+    appendTimer = context.getThreadContext().schedule(Duration.ZERO, context.getHeartbeatInterval(), this::appendMembers);
   }
 
   /**
-   * Sends a heartbeat to all members of the cluster.
+   * Sends AppendEntries requests to members of the cluster that haven't heard from the leader in a while.
    */
-  private void heartbeatMembers() {
+  private void appendMembers() {
     context.checkThread();
     if (isOpen()) {
-      replicator.commit().whenComplete((result, error) -> {
+      appender.appendEntries().whenComplete((result, error) -> {
         context.getLog().compactor().minorIndex(context.getLastCompleted());
       });
     }
   }
 
   /**
-   * Checks for expired sessions.
+   * Checks to determine whether any sessions have expired.
+   * <p>
+   * Copycat allows only leaders to explicitly unregister sessions due to expiration. This ensures
+   * that sessions cannot be expired by lengthy election periods or other disruptions to time.
+   * To do so, the leader periodically iterates through registered sessions and checks for sessions
+   * that have been marked suspicious. The internal state machine marks sessions as suspicious when
+   * keep alive entries are not committed for longer than the session timeout. Once the leader marks
+   * a session as suspicious, it will log and replicate an {@link UnregisterEntry} to unregister the session.
    */
   private void checkSessions() {
     long term = context.getTerm();
+
+    // Iterate through all currently registered sessions.
     for (ServerSession session : context.getStateMachine().executor().context().sessions().sessions.values()) {
+      // If the session isn't already being unregistered by this leader and a keep-alive entry hasn't
+      // been committed for the session in some time, log and commit a new UnregisterEntry.
       if (!session.isUnregistering() && session.isSuspect()) {
         LOGGER.debug("{} - Detected expired session: {}", context.getCluster().getMember().serverAddress(), session.id());
 
+        // Log the unregister entry, indicating that the session was explicitly unregistered by the leader.
+        // This will result in state machine expire() methods being called when the entry is applied.
         final long index;
         try (UnregisterEntry entry = context.getLog().create(UnregisterEntry.class)) {
           entry.setTerm(term)
@@ -190,19 +200,49 @@ final class LeaderState extends ActiveState {
             .setExpired(true)
             .setTimestamp(System.currentTimeMillis());
           index = context.getLog().append(entry);
-          LOGGER.debug("{} - Appended {} to log at index {}", context.getCluster().getMember().serverAddress(), entry, index);
+          LOGGER.debug("{} - Appended {}", context.getCluster().getMember().serverAddress(), entry);
         }
 
-        replicator.commit(index).whenComplete((result, error) -> {
+        // Commit the unregister entry and apply it to the state machine.
+        appender.appendEntries(index).whenComplete((result, error) -> {
           if (isOpen()) {
             UnregisterEntry entry = context.getLog().get(index);
             LOGGER.debug("{} - Applying {}", context.getCluster().getMember().serverAddress(), entry);
             context.getStateMachine().apply(entry, true).whenComplete((unregisterResult, unregisterError) -> entry.release());
           }
         });
+
+        // Mark the session as being unregistered in order to ensure this leader doesn't attempt
+        // to unregister it again.
         session.unregister();
       }
     }
+  }
+
+  /**
+   * Commits the given configuration.
+   */
+  protected CompletableFuture<Long> configure(Collection<Member> members) {
+    final long index;
+    try (ConfigurationEntry entry = context.getLog().create(ConfigurationEntry.class)) {
+      entry.setTerm(context.getTerm())
+        .setMembers(members);
+      index = context.getLog().append(entry);
+      LOGGER.debug("{} - Appended {} to log at index {}", context.getCluster().getMember().serverAddress(), entry, index);
+
+      // Store the index of the configuration entry in order to prevent other configurations from
+      // being logged and committed concurrently. This is an important safety property of Raft.
+      configuring = index;
+      context.getCluster().configure(entry.getIndex(), entry.getMembers());
+    }
+
+    return appender.appendEntries(index).whenComplete((commitIndex, commitError) -> {
+      context.checkThread();
+      if (isOpen()) {
+        // Reset the configuration index to allow new configuration changes to be committed.
+        configuring = 0;
+      }
+    });
   }
 
   @Override
@@ -220,7 +260,7 @@ final class LeaderState extends ActiveState {
     // If the leader index is 0 or is greater than the commitIndex, reject the join requests.
     // Configuration changes should not be allowed until the leader has committed a no-op entry.
     // See https://groups.google.com/forum/#!topic/raft-dev/t4xj6dJTP6E
-    if (leaderIndex == 0 || context.getCommitIndex() < leaderIndex) {
+    if (appender.index() == 0 || context.getCommitIndex() < appender.index()) {
       return CompletableFuture.completedFuture(logResponse(JoinResponse.builder()
         .withStatus(Response.Status.ERROR)
         .build()));
@@ -236,31 +276,16 @@ final class LeaderState extends ActiveState {
         .build()));
     }
 
-    final long term = context.getTerm();
-    final long index;
-
     Collection<Member> members = context.getCluster().getMembers();
     members.add(request.member());
 
-    try (ConfigurationEntry entry = context.getLog().create(ConfigurationEntry.class)) {
-      entry.setTerm(term)
-        .setMembers(members);
-      index = context.getLog().append(entry);
-      LOGGER.debug("{} - Appended {} to log at index {}", context.getCluster().getMember().serverAddress(), entry, index);
-
-      // Store the index of the configuration entry in order to prevent other configurations from
-      // being logged and committed concurrently. This is an important safety property of Raft.
-      configuring = index;
-      context.getCluster().configure(entry.getIndex(), entry.getMembers());
-    }
-
     CompletableFuture<JoinResponse> future = new CompletableFuture<>();
-    replicator.commit(index).whenComplete((commitIndex, commitError) -> {
+    configure(members).whenComplete((index, error) -> {
       context.checkThread();
       if (isOpen()) {
         // Reset the configuration index to allow new configuration changes to be committed.
         configuring = 0;
-        if (commitError == null) {
+        if (error == null) {
           future.complete(logResponse(JoinResponse.builder()
             .withStatus(Response.Status.OK)
             .withVersion(index)
@@ -292,7 +317,7 @@ final class LeaderState extends ActiveState {
     // If the leader index is 0 or is greater than the commitIndex, reject the join requests.
     // Configuration changes should not be allowed until the leader has committed a no-op entry.
     // See https://groups.google.com/forum/#!topic/raft-dev/t4xj6dJTP6E
-    if (leaderIndex == 0 || context.getCommitIndex() < leaderIndex) {
+    if (appender.index() == 0 || context.getCommitIndex() < appender.index()) {
       return CompletableFuture.completedFuture(logResponse(LeaveResponse.builder()
         .withStatus(Response.Status.ERROR)
         .build()));
@@ -306,31 +331,16 @@ final class LeaderState extends ActiveState {
         .build()));
     }
 
-    final long term = context.getTerm();
-    final long index;
-
     Collection<Member> members = context.getCluster().getMembers();
     members.remove(request.member());
 
-    try (ConfigurationEntry entry = context.getLog().create(ConfigurationEntry.class)) {
-      entry.setTerm(term)
-        .setMembers(members);
-      index = context.getLog().append(entry);
-      LOGGER.debug("{} - Appended {} to log at index {}", context.getCluster().getMember().serverAddress(), entry, index);
-
-      // Store the index of the configuration entry in order to prevent other configurations from
-      // being logged and committed concurrently. This is an important safety property of Raft.
-      configuring = index;
-      context.getCluster().configure(entry.getIndex(), entry.getMembers());
-    }
-
     CompletableFuture<LeaveResponse> future = new CompletableFuture<>();
-    replicator.commit(index).whenComplete((commitIndex, commitError) -> {
+    configure(members).whenComplete((index, error) -> {
       context.checkThread();
       if (isOpen()) {
         // Reset the configuration index to allow new configuration changes to be committed.
         configuring = 0;
-        if (commitError == null) {
+        if (error == null) {
           future.complete(logResponse(LeaveResponse.builder()
             .withStatus(Response.Status.OK)
             .withVersion(index)
@@ -434,7 +444,7 @@ final class LeaderState extends ActiveState {
       LOGGER.debug("{} - Appended {} to log at index {}", context.getCluster().getMember().serverAddress(), entry, index);
     }
 
-    replicator.commit(index).whenComplete((commitIndex, commitError) -> {
+    appender.appendEntries(index).whenComplete((commitIndex, commitError) -> {
       context.checkThread();
       if (isOpen()) {
         if (commitError == null) {
@@ -529,8 +539,7 @@ final class LeaderState extends ActiveState {
    * Submits a query with lease bounded linearizable consistency.
    */
   private CompletableFuture<QueryResponse> submitQueryBoundedLinearizable(QueryEntry entry) {
-    long commitTime = replicator.commitTime();
-    if (System.currentTimeMillis() - commitTime < context.getElectionTimeout().toMillis()) {
+    if (System.currentTimeMillis() - appender.time() < context.getElectionTimeout().toMillis()) {
       return submitQueryLocal(entry);
     } else {
       return submitQueryLinearizable(entry);
@@ -542,7 +551,7 @@ final class LeaderState extends ActiveState {
    */
   private CompletableFuture<QueryResponse> submitQueryLinearizable(QueryEntry entry) {
     CompletableFuture<QueryResponse> future = new CompletableFuture<>();
-    replicator.commit().whenComplete((commitIndex, commitError) -> {
+    appender.appendEntries().whenComplete((commitIndex, commitError) -> {
       context.checkThread();
       if (isOpen()) {
         if (commitError == null) {
@@ -612,7 +621,7 @@ final class LeaderState extends ActiveState {
     }
 
     CompletableFuture<RegisterResponse> future = new CompletableFuture<>();
-    replicator.commit(index).whenComplete((commitIndex, commitError) -> {
+    appender.appendEntries(index).whenComplete((commitIndex, commitError) -> {
       context.checkThread();
       if (isOpen()) {
         if (commitError == null) {
@@ -693,7 +702,7 @@ final class LeaderState extends ActiveState {
     context.getStateMachine().executor().context().sessions().registerAddress(request.session(), request.address());
 
     CompletableFuture<AcceptResponse> future = new CompletableFuture<>();
-    replicator.commit(index).whenComplete((commitIndex, commitError) -> {
+    appender.appendEntries(index).whenComplete((commitIndex, commitError) -> {
       context.checkThread();
       if (isOpen()) {
         if (commitError == null) {
@@ -749,7 +758,7 @@ final class LeaderState extends ActiveState {
     }
 
     CompletableFuture<KeepAliveResponse> future = new CompletableFuture<>();
-    replicator.commit(index).whenComplete((commitIndex, commitError) -> {
+    appender.appendEntries(index).whenComplete((commitIndex, commitError) -> {
       context.checkThread();
       if (isOpen()) {
         if (commitError == null) {
@@ -811,7 +820,7 @@ final class LeaderState extends ActiveState {
     }
 
     CompletableFuture<UnregisterResponse> future = new CompletableFuture<>();
-    replicator.commit(index).whenComplete((commitIndex, commitError) -> {
+    appender.appendEntries(index).whenComplete((commitIndex, commitError) -> {
       context.checkThread();
       if (isOpen()) {
         if (commitError == null) {
@@ -851,501 +860,18 @@ final class LeaderState extends ActiveState {
   }
 
   /**
-   * Cancels the ping timer.
+   * Cancels the append timer.
    */
-  private void cancelPingTimer() {
-    if (currentTimer != null) {
-      LOGGER.debug("{} - Cancelling heartbeat timer", context.getCluster().getMember().serverAddress());
-      currentTimer.cancel();
+  private void cancelAppendTimer() {
+    if (appendTimer != null) {
+      LOGGER.debug("{} - Cancelling append timer", context.getCluster().getMember().serverAddress());
+      appendTimer.cancel();
     }
   }
 
   @Override
   public synchronized CompletableFuture<Void> close() {
-    return super.close().thenRun(this::cancelPingTimer);
-  }
-
-  /**
-   * Log replicator.
-   */
-  private class Replicator {
-    private final Set<MemberState> committing = new HashSet<>();
-    private long commitTime;
-    private int commitFailures;
-    private CompletableFuture<Long> commitFuture;
-    private CompletableFuture<Long> nextCommitFuture;
-    private final TreeMap<Long, CompletableFuture<Long>> commitFutures = new TreeMap<>();
-
-    /**
-     * Returns the current quorum index.
-     *
-     * @return The current quorum index.
-     */
-    private int quorumIndex() {
-      return context.getCluster().getQuorum() - 2;
-    }
-
-    /**
-     * Triggers a commit.
-     *
-     * @return A completable future to be completed the next time entries are committed to a majority of the cluster.
-     */
-    private CompletableFuture<Long> commit() {
-      if (context.getCluster().getMembers().size() == 0)
-        return CompletableFuture.completedFuture(null);
-
-      // If no commit future already exists, that indicates there's no heartbeat currently under way.
-      // Create a new commit future and commit to all members in the cluster.
-      if (commitFuture == null) {
-        commitFuture = new CompletableFuture<>();
-        commitTime = System.currentTimeMillis();
-        for (MemberState member : context.getCluster().getRemoteMemberStates()) {
-          commit(member);
-        }
-        return commitFuture;
-      }
-      // If a commit future already exists, that indicates there is a heartbeat currently underway.
-      // We don't want to allow callers to be completed by a heartbeat that may already almost be done.
-      // So, we create the next commit future if necessary and return that. Once the current heartbeat
-      // completes the next future will be used to do another heartbeat. This ensures that only one
-      // heartbeat can be outstanding at any given point in time.
-      else if (nextCommitFuture == null) {
-        nextCommitFuture = new CompletableFuture<>();
-        return nextCommitFuture;
-      } else {
-        return nextCommitFuture;
-      }
-    }
-
-    /**
-     * Registers a commit handler for the given commit index.
-     *
-     * @param index The index for which to register the handler.
-     * @return A completable future to be completed once the given log index has been committed.
-     */
-    private CompletableFuture<Long> commit(long index) {
-      if (index == 0)
-        return commit();
-
-      // If there are no other servers in the cluster, immediately commit the index.
-      if (context.getCluster().getRemoteMemberStates().isEmpty()) {
-        context.setCommitIndex(index);
-        context.setGlobalIndex(index);
-        return CompletableFuture.completedFuture(index);
-      }
-      // If there are no other active members in the cluster, update the commit index and complete
-      // the commit but ensure append entries requests are sent to passive members.
-      else if (context.getCluster().getRemoteMemberStates(RaftMemberType.ACTIVE).isEmpty()) {
-        context.setCommitIndex(index);
-        for (MemberState member : context.getCluster().getRemoteMemberStates()) {
-          commit(member);
-        }
-        return CompletableFuture.completedFuture(index);
-      }
-
-      // Ensure append requests are being sent to all members, including passive members.
-      return commitFutures.computeIfAbsent(index, i -> {
-        for (MemberState member : context.getCluster().getRemoteMemberStates()) {
-          commit(member);
-        }
-        return new CompletableFuture<>();
-      });
-    }
-
-    /**
-     * Returns the last time a majority of the cluster was contacted.
-     */
-    private long commitTime() {
-      int quorumIndex = quorumIndex();
-      if (quorumIndex >= 0) {
-        return context.getCluster().getRemoteMemberStates(RaftMemberType.ACTIVE, (m1, m2)-> Long.compare(m2.getCommitTime(), m1.getCommitTime())).get(quorumIndex).getCommitTime();
-      }
-      return System.currentTimeMillis();
-    }
-
-    /**
-     * Sets a commit time or fails the commit if a quorum of successful responses cannot be achieved.
-     */
-    private void commitTime(MemberState member, Throwable error) {
-      if (commitFuture == null) {
-        return;
-      }
-
-      boolean completed = false;
-      if (error != null && member.getCommitStartTime() == this.commitTime) {
-        int activeMemberSize = context.getCluster().getRemoteMemberStates(RaftMemberType.ACTIVE).size() + (context.getCluster().getMember().type() == RaftMemberType.ACTIVE ? 1 : 0);
-        int quorumSize = context.getCluster().getQuorum();
-        // If a quorum of successful responses cannot be achieved, fail this commit.
-        if (activeMemberSize - quorumSize + 1 <= ++commitFailures) {
-          commitFuture.completeExceptionally(new InternalException("Failed to reach consensus"));
-          completed = true;
-        }
-      } else {
-        member.setCommitTime(System.currentTimeMillis());
-
-        // Sort the list of commit times. Use the quorum index to get the last time the majority of the cluster
-        // was contacted. If the current commitFuture's time is less than the commit time then trigger the
-        // commit future and reset it to the next commit future.
-        if (this.commitTime <= commitTime()) {
-          commitFuture.complete(null);
-          completed = true;
-        }
-      }
-
-      if (completed) {
-        commitFailures = 0;
-        commitFuture = nextCommitFuture;
-        nextCommitFuture = null;
-        if (commitFuture != null) {
-          this.commitTime = System.currentTimeMillis();
-          for (MemberState replica : context.getCluster().getRemoteMemberStates()) {
-            commit(replica);
-          }
-        }
-      }
-    }
-
-    /**
-     * Checks whether any futures can be completed.
-     */
-    private void commitEntries() {
-      context.checkThread();
-
-      // The global index may have increased even if the commit index didn't. Update the global index.
-      // The global index is calculated by the minimum matchIndex for *all* servers in the cluster, including
-      // passive members. This is critical since passive members still have state machines and thus it's still
-      // important to ensure that tombstones are applied to their state machines.
-      // If the members list is empty, use the local server's last log index as the global index.
-      long globalMatchIndex = context.getCluster().getRemoteMemberStates().stream().mapToLong(MemberState::getMatchIndex).min().orElse(context.getLog().lastIndex());
-      context.setGlobalIndex(globalMatchIndex);
-
-      // Sort the list of replicas, order by the last index that was replicated
-      // to the replica. This will allow us to determine the median index
-      // for all known replicated entries across all cluster members.
-      List<MemberState> members = context.getCluster().getRemoteMemberStates(RaftMemberType.ACTIVE, (m1, m2)->
-        Long.compare(m2.getMatchIndex() != 0 ? m2.getMatchIndex() : 0l, m1.getMatchIndex() != 0 ? m1.getMatchIndex() : 0l));
-
-      // If the active members list is empty (a configuration change occurred between an append request/response)
-      // ensure all commit futures are completed and cleared.
-      if (members.isEmpty()) {
-        context.setCommitIndex(context.getLog().lastIndex());
-        for (Map.Entry<Long, CompletableFuture<Long>> entry : commitFutures.entrySet()) {
-          entry.getValue().complete(entry.getKey());
-        }
-        commitFutures.clear();
-        return;
-      }
-
-      // Calculate the current commit index as the median matchIndex.
-      long commitIndex = members.get(quorumIndex()).getMatchIndex();
-
-      // If the commit index has increased then update the commit index. Note that in order to ensure
-      // the leader completeness property holds, verify that the commit index is greater than or equal to
-      // the index of the leader's no-op entry. Update the commit index and trigger commit futures.
-      if (commitIndex > 0 && commitIndex > context.getCommitIndex() && (leaderIndex > 0 && commitIndex >= leaderIndex)) {
-        context.setCommitIndex(commitIndex);
-
-        // TODO: This seems like an annoyingly expensive operation to perform on every response.
-        // Futures could simply be stored in a hash map and we could use a sequential index starting
-        // from the previous commit index to get the appropriate futures. But for now, at least this
-        // ensures that no memory leaks can occur.
-        SortedMap<Long, CompletableFuture<Long>> futures = commitFutures.headMap(commitIndex, true);
-        for (Map.Entry<Long, CompletableFuture<Long>> entry : futures.entrySet()) {
-          entry.getValue().complete(entry.getKey());
-        }
-        futures.clear();
-      }
-    }
-
-    /**
-     * Triggers a commit for the replica.
-     */
-    private void commit(MemberState member) {
-      if (!committing.contains(member) && isOpen()) {
-        // If the log is empty then send an empty commit.
-        // If the next index hasn't yet been set then we send an empty commit first.
-        // If the next index is greater than the last index then send an empty commit.
-        // If the member failed to respond to recent communication send an empty commit. This
-        // helps avoid doing expensive work until we can ascertain the member is back up.
-        if (context.getLog().isEmpty() || member.getNextIndex() > context.getLog().lastIndex() || member.getFailureCount() > 0) {
-          emptyCommit(member);
-        } else {
-          entriesCommit(member);
-        }
-      }
-    }
-
-    /**
-     * Gets the previous index.
-     */
-    private long getPrevIndex(MemberState member) {
-      return member.getNextIndex() - 1;
-    }
-
-    /**
-     * Gets the previous entry.
-     */
-    private Entry getPrevEntry(MemberState member, long prevIndex) {
-      if (prevIndex > 0) {
-        return context.getLog().get(prevIndex);
-      }
-      return null;
-    }
-
-    /**
-     * Performs an empty commit.
-     */
-    private void emptyCommit(MemberState member) {
-      long prevIndex = getPrevIndex(member);
-      Entry prevEntry = getPrevEntry(member, prevIndex);
-
-      AppendRequest.Builder builder = AppendRequest.builder()
-        .withTerm(context.getTerm())
-        .withLeader(context.getCluster().getMember().serverAddress().hashCode())
-        .withLogIndex(prevIndex)
-        .withLogTerm(prevEntry != null ? prevEntry.getTerm() : 0)
-        .withCommitIndex(context.getCommitIndex())
-        .withGlobalIndex(context.getGlobalIndex());
-
-      commit(member, builder.build(), false);
-    }
-
-    /**
-     * Performs a commit with entries.
-     */
-    private void entriesCommit(MemberState member) {
-      long prevIndex = getPrevIndex(member);
-      Entry prevEntry = getPrevEntry(member, prevIndex);
-
-      AppendRequest.Builder builder = AppendRequest.builder()
-        .withTerm(context.getTerm())
-        .withLeader(context.getCluster().getMember().serverAddress().hashCode())
-        .withLogIndex(prevIndex)
-        .withLogTerm(prevEntry != null ? prevEntry.getTerm() : 0)
-        .withCommitIndex(context.getCommitIndex())
-        .withGlobalIndex(context.getGlobalIndex());
-
-      // Build a list of entries to send to the member.
-      if (!context.getLog().isEmpty()) {
-        long index = prevIndex != 0 ? prevIndex + 1 : context.getLog().firstIndex();
-
-        // We build a list of entries up to the MAX_BATCH_SIZE. Note that entries in the log may
-        // be null if they've been compacted and the member to which we're sending entries is just
-        // joining the cluster or is otherwise far behind. Null entries are simply skipped and not
-        // counted towards the size of the batch.
-        int size = 0;
-        while (index <= context.getLog().lastIndex()) {
-          Entry entry = context.getLog().get(index);
-          if (entry != null) {
-            if (size + entry.size() > MAX_BATCH_SIZE) {
-              break;
-            }
-            size += entry.size();
-            builder.addEntry(entry);
-          }
-          index++;
-        }
-      }
-
-      // Release the previous entry back to the entry pool.
-      if (prevEntry != null) {
-        prevEntry.release();
-      }
-
-      commit(member, builder.build(), true);
-    }
-
-    /**
-     * Connects to the member and sends a commit message.
-     */
-    private void commit(MemberState member, AppendRequest request, boolean recursive) {
-      committing.add(member);
-      member.setCommitStartTime(commitTime);
-
-      LOGGER.debug("{} - Sent {} to {}", context.getCluster().getMember().serverAddress(), request, member.getMember().serverAddress());
-      context.getConnections().getConnection(member.getMember().serverAddress()).whenComplete((connection, error) -> {
-        context.checkThread();
-
-        if (isOpen()) {
-          if (error == null) {
-            commit(connection, member, request, recursive);
-          } else {
-            committing.remove(member);
-            commitTime(member, error);
-            failAttempt(member, error);
-          }
-        }
-      });
-    }
-
-    /**
-     * Sends a commit message.
-     */
-    private void commit(Connection connection, MemberState member, AppendRequest request, boolean recursive) {
-      connection.<AppendRequest, AppendResponse>send(request).whenComplete((response, error) -> {
-        committing.remove(member);
-        context.checkThread();
-
-        if (isOpen()) {
-          if (error == null) {
-            LOGGER.debug("{} - Received {} from {}", context.getCluster().getMember().serverAddress(), response, member.getMember().serverAddress());
-            if (response.status() == Response.Status.OK) {
-              // Reset the member failure count.
-              member.resetFailureCount();
-
-              // Update the commit time for the replica. This will cause heartbeat futures to be triggered.
-              commitTime(member, null);
-
-              // If replication succeeded then trigger commit futures.
-              if (response.succeeded()) {
-                updateMatchIndex(member, response);
-                updateNextIndex(member);
-                updateConfiguration(member);
-
-                // If entries were committed to the replica then check commit indexes.
-                if (recursive) {
-                  commitEntries();
-                }
-
-                // If there are more entries to send then attempt to send another commit.
-                if (hasMoreEntries(member)) {
-                  commit();
-                }
-              } else if (response.term() > context.getTerm()) {
-                context.setLeader(0);
-                transition(CopycatServer.State.FOLLOWER);
-              } else {
-                resetMatchIndex(member, response);
-                resetNextIndex(member);
-
-                // If there are more entries to send then attempt to send another commit.
-                if (hasMoreEntries(member)) {
-                  commit();
-                }
-              }
-            } else if (response.term() > context.getTerm()) {
-              LOGGER.debug("{} - Received higher term from {}", context.getCluster().getMember().serverAddress(), member.getMember().serverAddress());
-              context.setLeader(0);
-              transition(CopycatServer.State.FOLLOWER);
-            } else {
-              int failures = member.incrementFailureCount();
-              if (failures <= 3 || failures % 100 == 0) {
-                LOGGER.warn("{} - AppendRequest to {} failed. Reason: [{}]", context.getCluster().getMember().serverAddress(), member.getMember().serverAddress(), response.error() != null ? response.error() : "");
-              }
-            }
-          } else {
-            commitTime(member, error);
-            failAttempt(member, error);
-          }
-        }
-      });
-    }
-
-    /**
-     * Fails an attempt to contact a member.
-     */
-    private void failAttempt(MemberState member, Throwable error) {
-      int failures = member.incrementFailureCount();
-      if (failures <= 3 || failures % 100 == 0) {
-        LOGGER.warn("{} - {}", context.getCluster().getMember().serverAddress(), error.getMessage());
-      }
-
-      // Verify that the leader has contacted a majority of the cluster within the last two election timeouts.
-      // If the leader is not able to contact a majority of the cluster within two election timeouts, assume
-      // that a partition occurred and transition back to the FOLLOWER state.
-      if (System.currentTimeMillis() - Math.max(commitTime(), leaderTime) > context.getElectionTimeout().toMillis() * 2) {
-        LOGGER.warn("{} - Suspected network partition. Stepping down", context.getCluster().getMember().serverAddress());
-        context.setLeader(0);
-        transition(CopycatServer.State.FOLLOWER);
-      }
-    }
-
-    /**
-     * Returns a boolean value indicating whether there are more entries to send.
-     */
-    private boolean hasMoreEntries(MemberState member) {
-      return member.getNextIndex() < context.getLog().lastIndex();
-    }
-
-    /**
-     * Updates the match index when a response is received.
-     */
-    private void updateMatchIndex(MemberState member, AppendResponse response) {
-      // If the replica returned a valid match index then update the existing match index.
-      member.setMatchIndex(Math.max(member.getMatchIndex(), response.logIndex()));
-    }
-
-    /**
-     * Updates the next index when the match index is updated.
-     */
-    private void updateNextIndex(MemberState member) {
-      // If the match index was set, update the next index to be greater than the match index if necessary.
-      member.setNextIndex(Math.max(member.getNextIndex(), Math.max(member.getMatchIndex() + 1, 1)));
-    }
-
-    /**
-     * Updates the cluster configuration for the given member.
-     */
-    private void updateConfiguration(MemberState member) {
-      if (member.getMember().type() == RaftMemberType.PASSIVE && member.getMatchIndex() >= context.getCommitIndex()) {
-        if (configuring > 0) {
-          commit(configuring).whenComplete((result, error) -> {
-            promoteConfiguration(member);
-          });
-        } else {
-          promoteConfiguration(member);
-        }
-      }
-    }
-
-    /**
-     * Promotes the given member.
-     */
-    private void promoteConfiguration(MemberState member) {
-      LOGGER.info("{} - Promoting {}", context.getCluster().getMember().serverAddress(), member);
-
-      member.getMember().update(RaftMemberType.ACTIVE);
-
-      Collection<Member> members = context.getCluster().getMembers();
-
-      try (ConfigurationEntry entry = context.getLog().create(ConfigurationEntry.class)) {
-        entry.setTerm(context.getTerm())
-          .setMembers(members);
-        long index = context.getLog().append(entry);
-        LOGGER.debug("{} - Appended {} to log at index {}", context.getCluster().getMember().serverAddress(), entry, index);
-
-        // Immediately apply the configuration upon appending the configuration entry.
-        // Store the index of the configuration in order to block other configurations from taking
-        // place at the same time.
-        configuring = index;
-        context.getCluster().configure(entry.getIndex(), entry.getMembers());
-      }
-
-      commit(configuring).whenComplete((result, error) -> {
-        context.checkThread();
-        configuring = 0;
-      });
-    }
-
-    /**
-     * Resets the match index when a response fails.
-     */
-    private void resetMatchIndex(MemberState member, AppendResponse response) {
-      member.setMatchIndex(response.logIndex());
-      LOGGER.debug("{} - Reset match index for {} to {}", context.getCluster().getMember().serverAddress(), member, member.getMatchIndex());
-    }
-
-    /**
-     * Resets the next index when a response fails.
-     */
-    private void resetNextIndex(MemberState member) {
-      if (member.getMatchIndex() != 0) {
-        member.setNextIndex(member.getMatchIndex() + 1);
-      } else {
-        member.setNextIndex(context.getLog().firstIndex());
-      }
-      LOGGER.debug("{} - Reset next index for {} to {}", context.getCluster().getMember().serverAddress(), member, member.getNextIndex());
-    }
+    return super.close().thenRun(this::cancelAppendTimer);
   }
 
 }

--- a/server/src/main/java/io/atomix/copycat/server/state/Member.java
+++ b/server/src/main/java/io/atomix/copycat/server/state/Member.java
@@ -20,6 +20,7 @@ import io.atomix.catalyst.buffer.BufferOutput;
 import io.atomix.catalyst.serializer.CatalystSerializable;
 import io.atomix.catalyst.serializer.Serializer;
 import io.atomix.catalyst.transport.Address;
+import io.atomix.catalyst.util.Assert;
 
 /**
  * Cluster member.
@@ -27,15 +28,35 @@ import io.atomix.catalyst.transport.Address;
  * @author <a href="http://github.com/kuujo>Jordan Halterman</a>
  */
 public class Member implements CatalystSerializable {
+  private MemberType type;
   private Address serverAddress;
   private Address clientAddress;
 
   Member() {
   }
 
-  public Member(Address serverAddress, Address clientAddress) {
-    this.serverAddress = serverAddress;
+  public Member(MemberType type, Address serverAddress, Address clientAddress) {
+    this.type = Assert.notNull(type, "type");
+    this.serverAddress = Assert.notNull(serverAddress, "serverAddress");
     this.clientAddress = clientAddress;
+  }
+
+  /**
+   * Returns the member ID.
+   *
+   * @return The member ID.
+   */
+  public int id() {
+    return hashCode();
+  }
+
+  /**
+   * Returns the member type.
+   *
+   * @return The member type.
+   */
+  public MemberType type() {
+    return type;
   }
 
   /**
@@ -54,6 +75,28 @@ public class Member implements CatalystSerializable {
    */
   public Address clientAddress() {
     return clientAddress;
+  }
+
+  /**
+   * Updates the member type.
+   *
+   * @param type The member type.
+   * @return The member.
+   */
+  Member update(MemberType type) {
+    this.type = Assert.notNull(type, "type");
+    return this;
+  }
+
+  /**
+   * Updates the member client addrtess.
+   *
+   * @param clientAddress The member client address.
+   * @return The member.
+   */
+  Member update(Address clientAddress) {
+    this.clientAddress = Assert.notNull(clientAddress, "clientAddres");
+    return this;
   }
 
   @Override

--- a/server/src/main/java/io/atomix/copycat/server/state/Member.java
+++ b/server/src/main/java/io/atomix/copycat/server/state/Member.java
@@ -101,12 +101,14 @@ public class Member implements CatalystSerializable {
 
   @Override
   public void writeObject(BufferOutput<?> buffer, Serializer serializer) {
+    serializer.writeObject(type, buffer);
     serializer.writeObject(serverAddress, buffer);
     serializer.writeObject(clientAddress, buffer);
   }
 
   @Override
   public void readObject(BufferInput<?> buffer, Serializer serializer) {
+    type = serializer.readObject(buffer);
     serverAddress = serializer.readObject(buffer);
     clientAddress = serializer.readObject(buffer);
   }

--- a/server/src/main/java/io/atomix/copycat/server/state/Member.java
+++ b/server/src/main/java/io/atomix/copycat/server/state/Member.java
@@ -54,7 +54,7 @@ public class Member implements CatalystSerializable {
   }
 
   public Member(MemberType type, Address serverAddress, Address clientAddress) {
-    this.type = Assert.notNull(type, "type");
+    this.type = type;
     this.serverAddress = Assert.notNull(serverAddress, "serverAddress");
     this.clientAddress = clientAddress;
   }

--- a/server/src/main/java/io/atomix/copycat/server/state/Member.java
+++ b/server/src/main/java/io/atomix/copycat/server/state/Member.java
@@ -111,7 +111,7 @@ public class Member implements CatalystSerializable {
    * @return The member.
    */
   Member update(MemberType type) {
-    this.type = Assert.notNull(type, "type");
+    this.type = type;
     return this;
   }
 
@@ -133,7 +133,7 @@ public class Member implements CatalystSerializable {
    * @return The member.
    */
   Member update(Address clientAddress) {
-    this.clientAddress = Assert.notNull(clientAddress, "clientAddres");
+    this.clientAddress = clientAddress;
     return this;
   }
 

--- a/server/src/main/java/io/atomix/copycat/server/state/Member.java
+++ b/server/src/main/java/io/atomix/copycat/server/state/Member.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License
+ */
+package io.atomix.copycat.server.state;
+
+import io.atomix.catalyst.buffer.BufferInput;
+import io.atomix.catalyst.buffer.BufferOutput;
+import io.atomix.catalyst.serializer.CatalystSerializable;
+import io.atomix.catalyst.serializer.Serializer;
+import io.atomix.catalyst.transport.Address;
+
+/**
+ * Cluster member.
+ *
+ * @author <a href="http://github.com/kuujo>Jordan Halterman</a>
+ */
+public class Member implements CatalystSerializable {
+  private Address serverAddress;
+  private Address clientAddress;
+
+  Member() {
+  }
+
+  public Member(Address serverAddress, Address clientAddress) {
+    this.serverAddress = serverAddress;
+    this.clientAddress = clientAddress;
+  }
+
+  /**
+   * Returns the server address.
+   *
+   * @return The server address.
+   */
+  public Address serverAddress() {
+    return serverAddress;
+  }
+
+  /**
+   * Returns the client address.
+   *
+   * @return The client address.
+   */
+  public Address clientAddress() {
+    return clientAddress;
+  }
+
+  @Override
+  public void writeObject(BufferOutput<?> buffer, Serializer serializer) {
+    serializer.writeObject(serverAddress, buffer);
+    serializer.writeObject(clientAddress, buffer);
+  }
+
+  @Override
+  public void readObject(BufferInput<?> buffer, Serializer serializer) {
+    serverAddress = serializer.readObject(buffer);
+    clientAddress = serializer.readObject(buffer);
+  }
+
+  @Override
+  public int hashCode() {
+    return serverAddress.hashCode();
+  }
+
+  @Override
+  public boolean equals(Object object) {
+    return object instanceof Member && ((Member) object).serverAddress().equals(serverAddress);
+  }
+
+  @Override
+  public String toString() {
+    return String.format("%s[serverAddress=%s, clientAddress=%s]", getClass().getSimpleName(), serverAddress, clientAddress);
+  }
+
+}

--- a/server/src/main/java/io/atomix/copycat/server/state/Member.java
+++ b/server/src/main/java/io/atomix/copycat/server/state/Member.java
@@ -29,8 +29,26 @@ import io.atomix.catalyst.util.Assert;
  */
 public class Member implements CatalystSerializable {
   private MemberType type;
+  private Status status = Status.AVAILABLE;
   private Address serverAddress;
   private Address clientAddress;
+
+  /**
+   * Member status.
+   */
+  public enum Status {
+
+    /**
+     * Available member status.
+     */
+    AVAILABLE,
+
+    /**
+     * Unavailable member status.
+     */
+    UNAVAILABLE
+
+  }
 
   Member() {
   }
@@ -57,6 +75,15 @@ public class Member implements CatalystSerializable {
    */
   public MemberType type() {
     return type;
+  }
+
+  /**
+   * Returns the member status.
+   *
+   * @return The member status.
+   */
+  public Status status() {
+    return status;
   }
 
   /**
@@ -89,6 +116,17 @@ public class Member implements CatalystSerializable {
   }
 
   /**
+   * Updates the member status.
+   *
+   * @param status The member status.
+   * @return The member.
+   */
+  Member update(Status status) {
+    this.status = Assert.notNull(status, "status");
+    return this;
+  }
+
+  /**
    * Updates the member client addrtess.
    *
    * @param clientAddress The member client address.
@@ -102,6 +140,7 @@ public class Member implements CatalystSerializable {
   @Override
   public void writeObject(BufferOutput<?> buffer, Serializer serializer) {
     serializer.writeObject(type, buffer);
+    serializer.writeObject(status, buffer);
     serializer.writeObject(serverAddress, buffer);
     serializer.writeObject(clientAddress, buffer);
   }
@@ -109,6 +148,7 @@ public class Member implements CatalystSerializable {
   @Override
   public void readObject(BufferInput<?> buffer, Serializer serializer) {
     type = serializer.readObject(buffer);
+    status = serializer.readObject(buffer);
     serverAddress = serializer.readObject(buffer);
     clientAddress = serializer.readObject(buffer);
   }
@@ -125,7 +165,7 @@ public class Member implements CatalystSerializable {
 
   @Override
   public String toString() {
-    return String.format("%s[serverAddress=%s, clientAddress=%s]", getClass().getSimpleName(), serverAddress, clientAddress);
+    return String.format("%s[type=%s, status=%s, serverAddress=%s, clientAddress=%s]", getClass().getSimpleName(), type, status, serverAddress, clientAddress);
   }
 
 }

--- a/server/src/main/java/io/atomix/copycat/server/state/Member.java
+++ b/server/src/main/java/io/atomix/copycat/server/state/Member.java
@@ -127,13 +127,15 @@ public class Member implements CatalystSerializable {
   }
 
   /**
-   * Updates the member client addrtess.
+   * Updates the member client address.
    *
    * @param clientAddress The member client address.
    * @return The member.
    */
   Member update(Address clientAddress) {
-    this.clientAddress = clientAddress;
+    if (clientAddress != null) {
+      this.clientAddress = clientAddress;
+    }
     return this;
   }
 

--- a/server/src/main/java/io/atomix/copycat/server/state/MemberState.java
+++ b/server/src/main/java/io/atomix/copycat/server/state/MemberState.java
@@ -15,7 +15,6 @@
  */
 package io.atomix.copycat.server.state;
 
-import io.atomix.catalyst.transport.Address;
 import io.atomix.catalyst.util.Assert;
 import io.atomix.copycat.server.storage.Log;
 
@@ -26,7 +25,8 @@ import io.atomix.copycat.server.storage.Log;
  */
 class MemberState {
   private Member member;
-  private int index;
+  private long term;
+  private long version;
   private long matchIndex;
   private long nextIndex;
   private long commitTime;
@@ -69,22 +69,42 @@ class MemberState {
   }
 
   /**
-   * Returns the member index.
+   * Returns the member term.
    *
-   * @return The member index.
+   * @return The member term.
    */
-  public int getIndex() {
-    return index;
+  long getTerm() {
+    return term;
   }
 
   /**
-   * Sets the member index.
+   * Sets the member term.
    *
-   * @param index The member index.
+   * @param term The member term.
    * @return The member state.
    */
-  MemberState setIndex(int index) {
-    this.index = index;
+  MemberState setTerm(long term) {
+    this.term = term;
+    return this;
+  }
+
+  /**
+   * Returns the member configuration version.
+   *
+   * @return The member configuration version.
+   */
+  long getVersion() {
+    return version;
+  }
+
+  /**
+   * Sets the member version.
+   *
+   * @param version The member version.
+   * @return The member state.
+   */
+  MemberState setVersion(long version) {
+    this.version = version;
     return this;
   }
 

--- a/server/src/main/java/io/atomix/copycat/server/state/MemberState.java
+++ b/server/src/main/java/io/atomix/copycat/server/state/MemberState.java
@@ -25,8 +25,7 @@ import io.atomix.copycat.server.storage.Log;
  * @author <a href="http://github.com/kuujo">Jordan Halterman</a>
  */
 class MemberState {
-  private final Address serverAddress;
-  private Address clientAddress;
+  private Member member;
   private int index;
   private long matchIndex;
   private long nextIndex;
@@ -34,8 +33,8 @@ class MemberState {
   private long commitStartTime;
   private int failures;
 
-  public MemberState(Address serverAddress) {
-    this.serverAddress = Assert.notNull(serverAddress, "serverAddress");
+  public MemberState(Member member) {
+    this.member = Assert.notNull(member, "member");
   }
 
   /**
@@ -50,31 +49,22 @@ class MemberState {
   }
 
   /**
-   * Returns the server address.
+   * Returs the member.
    *
-   * @return The server address.
+   * @return The member.
    */
-  public Address getServerAddress() {
-    return serverAddress;
+  public Member getMember() {
+    return member;
   }
 
   /**
-   * Returns the client address.
+   * Sets the member.
    *
-   * @return The client address.
-   */
-  public Address getClientAddress() {
-    return clientAddress;
-  }
-
-  /**
-   * Sets the client address.
-   *
-   * @param address The client address.
+   * @param member The member.
    * @return The member state.
    */
-  public MemberState setClientAddress(Address address) {
-    this.clientAddress = clientAddress;
+  MemberState setMember(Member member) {
+    this.member = Assert.notNull(member, "member");
     return this;
   }
 
@@ -208,7 +198,7 @@ class MemberState {
 
   @Override
   public String toString() {
-    return serverAddress.toString();
+    return member.serverAddress().toString();
   }
 
 }

--- a/server/src/main/java/io/atomix/copycat/server/state/MemberState.java
+++ b/server/src/main/java/io/atomix/copycat/server/state/MemberState.java
@@ -25,7 +25,8 @@ import io.atomix.copycat.server.storage.Log;
  * @author <a href="http://github.com/kuujo">Jordan Halterman</a>
  */
 class MemberState {
-  private final Address address;
+  private final Address serverAddress;
+  private Address clientAddress;
   private int index;
   private long matchIndex;
   private long nextIndex;
@@ -33,8 +34,8 @@ class MemberState {
   private long commitStartTime;
   private int failures;
 
-  public MemberState(Address address) {
-    this.address = Assert.notNull(address, "address");
+  public MemberState(Address serverAddress) {
+    this.serverAddress = Assert.notNull(serverAddress, "serverAddress");
   }
 
   /**
@@ -49,12 +50,32 @@ class MemberState {
   }
 
   /**
-   * Returns the member address.
+   * Returns the server address.
    *
-   * @return The member address.
+   * @return The server address.
    */
-  public Address getAddress() {
-    return address;
+  public Address getServerAddress() {
+    return serverAddress;
+  }
+
+  /**
+   * Returns the client address.
+   *
+   * @return The client address.
+   */
+  public Address getClientAddress() {
+    return clientAddress;
+  }
+
+  /**
+   * Sets the client address.
+   *
+   * @param address The client address.
+   * @return The member state.
+   */
+  public MemberState setClientAddress(Address address) {
+    this.clientAddress = clientAddress;
+    return this;
   }
 
   /**
@@ -187,7 +208,7 @@ class MemberState {
 
   @Override
   public String toString() {
-    return address.toString();
+    return serverAddress.toString();
   }
 
 }

--- a/server/src/main/java/io/atomix/copycat/server/state/MemberType.java
+++ b/server/src/main/java/io/atomix/copycat/server/state/MemberType.java
@@ -21,4 +21,19 @@ package io.atomix.copycat.server.state;
  * @author <a href="http://github.com/kuujo>Jordan Halterman</a>
  */
 public interface MemberType {
+
+  /**
+   * Returns a boolean value indicating whether the member is a stateful member.
+   *
+   * @return Indicates whether the member is a stateful member.
+   */
+  boolean isStateful();
+
+  /**
+   * Returns a boolean value indicating whether the member is a voting member.
+   *
+   * @return Indicates whether the member is a voting member.
+   */
+  boolean isVoting();
+
 }

--- a/server/src/main/java/io/atomix/copycat/server/state/MemberType.java
+++ b/server/src/main/java/io/atomix/copycat/server/state/MemberType.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License
+ */
+package io.atomix.copycat.server.state;
+
+/**
+ * Cluster member type.
+ *
+ * @author <a href="http://github.com/kuujo>Jordan Halterman</a>
+ */
+public interface MemberType {
+}

--- a/server/src/main/java/io/atomix/copycat/server/state/PassiveState.java
+++ b/server/src/main/java/io/atomix/copycat/server/state/PassiveState.java
@@ -70,7 +70,7 @@ class PassiveState extends AbstractState {
     // reply false and return our current term. The leader will receive
     // the updated term and step down.
     if (request.term() < context.getTerm()) {
-      LOGGER.warn("{} - Rejected {}: request term is less than the current term ({})", context.getAddress(), request, context.getTerm());
+      LOGGER.warn("{} - Rejected {}: request term is less than the current term ({})", context.getMember().serverAddress(), request, context.getTerm());
       return AppendResponse.builder()
         .withStatus(Response.Status.OK)
         .withTerm(context.getTerm())
@@ -89,7 +89,7 @@ class PassiveState extends AbstractState {
    */
   protected AppendResponse doCheckPreviousEntry(AppendRequest request) {
     if (request.logIndex() != 0 && context.getLog().isEmpty()) {
-      LOGGER.warn("{} - Rejected {}: Previous index ({}) is greater than the local log's last index ({})", context.getAddress(), request, request.logIndex(), context.getLog().lastIndex());
+      LOGGER.warn("{} - Rejected {}: Previous index ({}) is greater than the local log's last index ({})", context.getMember().serverAddress(), request, request.logIndex(), context.getLog().lastIndex());
       return AppendResponse.builder()
         .withStatus(Response.Status.OK)
         .withTerm(context.getTerm())
@@ -97,7 +97,7 @@ class PassiveState extends AbstractState {
         .withLogIndex(context.getLog().lastIndex())
         .build();
     } else if (request.logIndex() != 0 && context.getLog().lastIndex() != 0 && request.logIndex() > context.getLog().lastIndex()) {
-      LOGGER.warn("{} - Rejected {}: Previous index ({}) is greater than the local log's last index ({})", context.getAddress(), request, request.logIndex(), context.getLog().lastIndex());
+      LOGGER.warn("{} - Rejected {}: Previous index ({}) is greater than the local log's last index ({})", context.getMember().serverAddress(), request, request.logIndex(), context.getLog().lastIndex());
       return AppendResponse.builder()
         .withStatus(Response.Status.OK)
         .withTerm(context.getTerm())
@@ -109,7 +109,7 @@ class PassiveState extends AbstractState {
     // If the previous entry term doesn't match the local previous term then reject the request.
     try (Entry entry = context.getLog().get(request.logIndex())) {
       if (entry == null || entry.getTerm() != request.logTerm()) {
-        LOGGER.warn("{} - Rejected {}: Request log term does not match local log term {} for the same entry", context.getAddress(), request, entry != null ? entry.getTerm() : "unknown");
+        LOGGER.warn("{} - Rejected {}: Request log term does not match local log term {} for the same entry", context.getMember().serverAddress(), request, entry != null ? entry.getTerm() : "unknown");
         return AppendResponse.builder()
           .withStatus(Response.Status.OK)
           .withTerm(context.getTerm())
@@ -135,7 +135,7 @@ class PassiveState extends AbstractState {
         // If the entry index is greater than the last log index, skip missing entries.
         if (context.getLog().lastIndex() < entry.getIndex()) {
           context.getLog().skip(entry.getIndex() - context.getLog().lastIndex() - 1).append(entry);
-          LOGGER.debug("{} - Appended {} to log at index {}", context.getAddress(), entry, entry.getIndex());
+          LOGGER.debug("{} - Appended {} to log at index {}", context.getMember().serverAddress(), entry, entry.getIndex());
         } else {
           // Compare the term of the received entry with the matching entry in the log.
           try (Entry match = context.getLog().get(entry.getIndex())) {
@@ -143,13 +143,13 @@ class PassiveState extends AbstractState {
               if (entry.getTerm() != match.getTerm()) {
                 // We found an invalid entry in the log. Remove the invalid entry and append the new entry.
                 // If appending to the log fails, apply commits and reply false to the append request.
-                LOGGER.warn("{} - Appended entry term does not match local log, removing incorrect entries", context.getAddress());
+                LOGGER.warn("{} - Appended entry term does not match local log, removing incorrect entries", context.getMember().serverAddress());
                 context.getLog().truncate(entry.getIndex() - 1).append(entry);
-                LOGGER.debug("{} - Appended {} to log at index {}", context.getAddress(), entry, entry.getIndex());
+                LOGGER.debug("{} - Appended {} to log at index {}", context.getMember().serverAddress(), entry, entry.getIndex());
               }
             } else {
               context.getLog().truncate(entry.getIndex() - 1).append(entry);
-              LOGGER.debug("{} - Appended {} to log at index {}", context.getAddress(), entry, entry.getIndex());
+              LOGGER.debug("{} - Appended {} to log at index {}", context.getMember().serverAddress(), entry, entry.getIndex());
             }
           }
         }
@@ -205,7 +205,7 @@ class PassiveState extends AbstractState {
     // If the effective commit index is greater than the last index applied to the state machine then apply remaining entries.
     if (effectiveIndex > lastApplied) {
       long entriesToApply = effectiveIndex - lastApplied;
-      LOGGER.debug("{} - Applying {} commits", context.getAddress(), entriesToApply);
+      LOGGER.debug("{} - Applying {} commits", context.getMember().serverAddress(), entriesToApply);
 
       CompletableFuture<Void> future = new CompletableFuture<>();
 
@@ -217,7 +217,7 @@ class PassiveState extends AbstractState {
         if (entry != null) {
           applyEntry(entry).whenComplete((result, error) -> {
             if (isOpen() && error != null) {
-              LOGGER.info("{} - An application error occurred: {}", context.getAddress(), error.getMessage());
+              LOGGER.info("{} - An application error occurred: {}", context.getMember().serverAddress(), error.getMessage());
             }
 
             if (counter.incrementAndGet() == entriesToApply) {
@@ -255,7 +255,7 @@ class PassiveState extends AbstractState {
    * Applies an entry to the state machine.
    */
   protected CompletableFuture<?> applyEntry(Entry entry) {
-    LOGGER.debug("{} - Applying {}", context.getAddress(), entry);
+    LOGGER.debug("{} - Applying {}", context.getMember().serverAddress(), entry);
     return context.getStateMachine().apply(entry);
   }
 

--- a/server/src/main/java/io/atomix/copycat/server/state/PassiveState.java
+++ b/server/src/main/java/io/atomix/copycat/server/state/PassiveState.java
@@ -370,7 +370,7 @@ class PassiveState extends AbstractState {
 
     return CompletableFuture.completedFuture(logResponse(KeepAliveResponse.builder()
       .withStatus(Response.Status.ERROR)
-      .withLeader(context.getLeader().serverAddress())
+      .withLeader(context.getLeader() != null ? context.getLeader().serverAddress() : null)
       .withError(RaftError.Type.ILLEGAL_MEMBER_STATE_ERROR)
       .build()));
   }

--- a/server/src/main/java/io/atomix/copycat/server/state/PassiveState.java
+++ b/server/src/main/java/io/atomix/copycat/server/state/PassiveState.java
@@ -70,7 +70,7 @@ class PassiveState extends AbstractState {
     // reply false and return our current term. The leader will receive
     // the updated term and step down.
     if (request.term() < context.getTerm()) {
-      LOGGER.warn("{} - Rejected {}: request term is less than the current term ({})", context.getMember().serverAddress(), request, context.getTerm());
+      LOGGER.warn("{} - Rejected {}: request term is less than the current term ({})", context.getCluster().getMember().serverAddress(), request, context.getTerm());
       return AppendResponse.builder()
         .withStatus(Response.Status.OK)
         .withTerm(context.getTerm())
@@ -89,7 +89,7 @@ class PassiveState extends AbstractState {
    */
   protected AppendResponse doCheckPreviousEntry(AppendRequest request) {
     if (request.logIndex() != 0 && context.getLog().isEmpty()) {
-      LOGGER.warn("{} - Rejected {}: Previous index ({}) is greater than the local log's last index ({})", context.getMember().serverAddress(), request, request.logIndex(), context.getLog().lastIndex());
+      LOGGER.warn("{} - Rejected {}: Previous index ({}) is greater than the local log's last index ({})", context.getCluster().getMember().serverAddress(), request, request.logIndex(), context.getLog().lastIndex());
       return AppendResponse.builder()
         .withStatus(Response.Status.OK)
         .withTerm(context.getTerm())
@@ -97,7 +97,7 @@ class PassiveState extends AbstractState {
         .withLogIndex(context.getLog().lastIndex())
         .build();
     } else if (request.logIndex() != 0 && context.getLog().lastIndex() != 0 && request.logIndex() > context.getLog().lastIndex()) {
-      LOGGER.warn("{} - Rejected {}: Previous index ({}) is greater than the local log's last index ({})", context.getMember().serverAddress(), request, request.logIndex(), context.getLog().lastIndex());
+      LOGGER.warn("{} - Rejected {}: Previous index ({}) is greater than the local log's last index ({})", context.getCluster().getMember().serverAddress(), request, request.logIndex(), context.getLog().lastIndex());
       return AppendResponse.builder()
         .withStatus(Response.Status.OK)
         .withTerm(context.getTerm())
@@ -109,7 +109,7 @@ class PassiveState extends AbstractState {
     // If the previous entry term doesn't match the local previous term then reject the request.
     try (Entry entry = context.getLog().get(request.logIndex())) {
       if (entry == null || entry.getTerm() != request.logTerm()) {
-        LOGGER.warn("{} - Rejected {}: Request log term does not match local log term {} for the same entry", context.getMember().serverAddress(), request, entry != null ? entry.getTerm() : "unknown");
+        LOGGER.warn("{} - Rejected {}: Request log term does not match local log term {} for the same entry", context.getCluster().getMember().serverAddress(), request, entry != null ? entry.getTerm() : "unknown");
         return AppendResponse.builder()
           .withStatus(Response.Status.OK)
           .withTerm(context.getTerm())
@@ -135,7 +135,7 @@ class PassiveState extends AbstractState {
         // If the entry index is greater than the last log index, skip missing entries.
         if (context.getLog().lastIndex() < entry.getIndex()) {
           context.getLog().skip(entry.getIndex() - context.getLog().lastIndex() - 1).append(entry);
-          LOGGER.debug("{} - Appended {} to log at index {}", context.getMember().serverAddress(), entry, entry.getIndex());
+          LOGGER.debug("{} - Appended {} to log at index {}", context.getCluster().getMember().serverAddress(), entry, entry.getIndex());
         } else {
           // Compare the term of the received entry with the matching entry in the log.
           try (Entry match = context.getLog().get(entry.getIndex())) {
@@ -143,13 +143,13 @@ class PassiveState extends AbstractState {
               if (entry.getTerm() != match.getTerm()) {
                 // We found an invalid entry in the log. Remove the invalid entry and append the new entry.
                 // If appending to the log fails, apply commits and reply false to the append request.
-                LOGGER.warn("{} - Appended entry term does not match local log, removing incorrect entries", context.getMember().serverAddress());
+                LOGGER.warn("{} - Appended entry term does not match local log, removing incorrect entries", context.getCluster().getMember().serverAddress());
                 context.getLog().truncate(entry.getIndex() - 1).append(entry);
-                LOGGER.debug("{} - Appended {} to log at index {}", context.getMember().serverAddress(), entry, entry.getIndex());
+                LOGGER.debug("{} - Appended {} to log at index {}", context.getCluster().getMember().serverAddress(), entry, entry.getIndex());
               }
             } else {
               context.getLog().truncate(entry.getIndex() - 1).append(entry);
-              LOGGER.debug("{} - Appended {} to log at index {}", context.getMember().serverAddress(), entry, entry.getIndex());
+              LOGGER.debug("{} - Appended {} to log at index {}", context.getCluster().getMember().serverAddress(), entry, entry.getIndex());
             }
           }
         }
@@ -157,14 +157,14 @@ class PassiveState extends AbstractState {
         // If the entry is a configuration entry then immediately configure the cluster.
         if (entry instanceof ConfigurationEntry) {
           ConfigurationEntry configurationEntry = (ConfigurationEntry) entry;
-          if (context.getCluster().isPassive()) {
-            context.getCluster().configure(entry.getIndex(), configurationEntry.getActive(), configurationEntry.getPassive());
-            if (context.getCluster().isActive()) {
+          if (context.getCluster().getMember().type() == RaftMemberType.PASSIVE) {
+            context.getCluster().configure(entry.getIndex(), configurationEntry.getMembers());
+            if (context.getCluster().getMember().type() == RaftMemberType.ACTIVE) {
               transition(CopycatServer.State.FOLLOWER);
             }
           } else {
-            context.getCluster().configure(entry.getIndex(), configurationEntry.getActive(), configurationEntry.getPassive());
-            if (context.getCluster().isPassive()) {
+            context.getCluster().configure(entry.getIndex(), configurationEntry.getMembers());
+            if (context.getCluster().getMember().type() == RaftMemberType.PASSIVE) {
               transition(CopycatServer.State.PASSIVE);
             }
           }
@@ -205,7 +205,7 @@ class PassiveState extends AbstractState {
     // If the effective commit index is greater than the last index applied to the state machine then apply remaining entries.
     if (effectiveIndex > lastApplied) {
       long entriesToApply = effectiveIndex - lastApplied;
-      LOGGER.debug("{} - Applying {} commits", context.getMember().serverAddress(), entriesToApply);
+      LOGGER.debug("{} - Applying {} commits", context.getCluster().getMember().serverAddress(), entriesToApply);
 
       CompletableFuture<Void> future = new CompletableFuture<>();
 
@@ -217,7 +217,7 @@ class PassiveState extends AbstractState {
         if (entry != null) {
           applyEntry(entry).whenComplete((result, error) -> {
             if (isOpen() && error != null) {
-              LOGGER.info("{} - An application error occurred: {}", context.getMember().serverAddress(), error.getMessage());
+              LOGGER.info("{} - An application error occurred: {}", context.getCluster().getMember().serverAddress(), error.getMessage());
             }
 
             if (counter.incrementAndGet() == entriesToApply) {
@@ -255,7 +255,7 @@ class PassiveState extends AbstractState {
    * Applies an entry to the state machine.
    */
   protected CompletableFuture<?> applyEntry(Entry entry) {
-    LOGGER.debug("{} - Applying {}", context.getMember().serverAddress(), entry);
+    LOGGER.debug("{} - Applying {}", context.getCluster().getMember().serverAddress(), entry);
     return context.getStateMachine().apply(entry);
   }
 

--- a/server/src/main/java/io/atomix/copycat/server/state/RaftMemberType.java
+++ b/server/src/main/java/io/atomix/copycat/server/state/RaftMemberType.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License
+ */
+package io.atomix.copycat.server.state;
+
+/**
+ * Raft member types.
+ *
+ * @author <a href="http://github.com/kuujo>Jordan Halterman</a>
+ */
+public enum RaftMemberType implements MemberType {
+
+  /**
+   * Active member type.
+   */
+  ACTIVE,
+
+  /**
+   * Passive member type.
+   */
+  PASSIVE
+
+}

--- a/server/src/main/java/io/atomix/copycat/server/state/RaftMemberType.java
+++ b/server/src/main/java/io/atomix/copycat/server/state/RaftMemberType.java
@@ -25,11 +25,31 @@ public enum RaftMemberType implements MemberType {
   /**
    * Active member type.
    */
-  ACTIVE,
+  ACTIVE {
+    @Override
+    public boolean isStateful() {
+      return true;
+    }
+
+    @Override
+    public boolean isVoting() {
+      return true;
+    }
+  },
 
   /**
    * Passive member type.
    */
-  PASSIVE
+  PASSIVE {
+    @Override
+    public boolean isStateful() {
+      return true;
+    }
+
+    @Override
+    public boolean isVoting() {
+      return false;
+    }
+  }
 
 }

--- a/server/src/main/java/io/atomix/copycat/server/state/ServerContext.java
+++ b/server/src/main/java/io/atomix/copycat/server/state/ServerContext.java
@@ -83,7 +83,7 @@ public class ServerContext implements Managed<ServerState> {
 
       internalServer.listen(serverAddress, c -> state.connectServer(c)).whenComplete((internalResult, internalError) -> {
         if (internalError == null) {
-          state = new ServerState(new Member(serverAddress, clientAddress), members, log, userStateMachine, connections, context);
+          state = new ServerState(new Member(null, serverAddress, clientAddress), members, log, userStateMachine, connections, context);
 
           // If the client address is different than the server address, start a separate client server.
           if (!clientAddress.equals(serverAddress)) {

--- a/server/src/main/java/io/atomix/copycat/server/state/ServerContext.java
+++ b/server/src/main/java/io/atomix/copycat/server/state/ServerContext.java
@@ -46,7 +46,8 @@ public class ServerContext implements Managed<ServerState> {
   private final Address serverAddress;
   private final Collection<Address> members;
   private final StateMachine userStateMachine;
-  private final Transport transport;
+  private final Transport clientTransport;
+  private final Transport serverTransport;
   private final Storage storage;
   private final ThreadContext context;
   private Server clientServer;
@@ -54,12 +55,13 @@ public class ServerContext implements Managed<ServerState> {
   private ServerState state;
   private volatile boolean open;
 
-  public ServerContext(Address clientAddress, Address serverAddress, Collection<Address> members, StateMachine stateMachine, Transport transport, Storage storage, Serializer serializer) {
+  public ServerContext(Address clientAddress, Transport clientTransport, Address serverAddress, Transport serverTransport, Collection<Address> members, StateMachine stateMachine, Storage storage, Serializer serializer) {
     this.clientAddress = Assert.notNull(clientAddress, "clientAddress");
     this.serverAddress = Assert.notNull(serverAddress, "serverAddress");
+    this.clientTransport = Assert.notNull(clientTransport, "clientTransport");
+    this.serverTransport = Assert.notNull(serverTransport, "serverTransport");
     this.members = Assert.notNull(members, "members");
     this.userStateMachine = Assert.notNull(stateMachine, "stateMachine");
-    this.transport = Assert.notNull(transport, "transport");
     this.storage = Assert.notNull(storage, "storage");
     this.context = new SingleThreadContext("copycat-server-" + serverAddress, serializer);
 
@@ -76,8 +78,8 @@ public class ServerContext implements Managed<ServerState> {
       Log log = storage.open("copycat");
 
       // Setup the server and connection manager.
-      internalServer = transport.server();
-      ConnectionManager connections = new ConnectionManager(transport.client());
+      internalServer = serverTransport.server();
+      ConnectionManager connections = new ConnectionManager(serverTransport.client());
 
       internalServer.listen(serverAddress, c -> state.connectServer(c)).whenComplete((internalResult, internalError) -> {
         if (internalError == null) {
@@ -85,7 +87,7 @@ public class ServerContext implements Managed<ServerState> {
 
           // If the client address is different than the server address, start a separate client server.
           if (!clientAddress.equals(serverAddress)) {
-            clientServer = transport.server();
+            clientServer = clientTransport.server();
             clientServer.listen(clientAddress, c -> state.connectClient(c)).whenComplete((clientResult, clientError) -> {
               open = true;
               future.complete(state);

--- a/server/src/main/java/io/atomix/copycat/server/state/ServerState.java
+++ b/server/src/main/java/io/atomix/copycat/server/state/ServerState.java
@@ -416,6 +416,7 @@ public class ServerState {
     // Note we do not use method references here because the "state" variable changes over time.
     // We have to use lambdas to ensure the request handler points to the current state.
     connection.handler(RegisterRequest.class, request -> state.register(request));
+    connection.handler(ConnectRequest.class, request -> state.connect(request, connection));
     connection.handler(AcceptRequest.class, request -> state.accept(request));
     connection.handler(KeepAliveRequest.class, request -> state.keepAlive(request));
     connection.handler(UnregisterRequest.class, request -> state.unregister(request));

--- a/server/src/main/java/io/atomix/copycat/server/state/ServerState.java
+++ b/server/src/main/java/io/atomix/copycat/server/state/ServerState.java
@@ -398,7 +398,6 @@ public class ServerState {
     // We have to use lambdas to ensure the request handler points to the current state.
     connection.handler(RegisterRequest.class, request -> state.register(request));
     connection.handler(ConnectRequest.class, request -> state.connect(request, connection));
-    connection.handler(AcceptRequest.class, request -> state.accept(request));
     connection.handler(KeepAliveRequest.class, request -> state.keepAlive(request));
     connection.handler(UnregisterRequest.class, request -> state.unregister(request));
     connection.handler(CommandRequest.class, request -> state.command(request));
@@ -417,7 +416,6 @@ public class ServerState {
     // Note we do not use method references here because the "state" variable changes over time.
     // We have to use lambdas to ensure the request handler points to the current state.
     connection.handler(RegisterRequest.class, request -> state.register(request));
-    connection.handler(ConnectRequest.class, request -> state.connect(request, connection));
     connection.handler(AcceptRequest.class, request -> state.accept(request));
     connection.handler(KeepAliveRequest.class, request -> state.keepAlive(request));
     connection.handler(UnregisterRequest.class, request -> state.unregister(request));

--- a/server/src/main/java/io/atomix/copycat/server/storage/Log.java
+++ b/server/src/main/java/io/atomix/copycat/server/storage/Log.java
@@ -244,6 +244,15 @@ public class Log implements AutoCloseable {
   }
 
   /**
+   * Returns the next index in the log.
+   *
+   * @return The next index in the log.
+   */
+  public long nextIndex() {
+    return lastIndex() + 1;
+  }
+
+  /**
    * Checks whether we need to roll over to a new segment.
    */
   private void checkRoll() {

--- a/server/src/main/java/io/atomix/copycat/server/storage/MetaStore.java
+++ b/server/src/main/java/io/atomix/copycat/server/storage/MetaStore.java
@@ -18,8 +18,11 @@ package io.atomix.copycat.server.storage;
 import io.atomix.catalyst.buffer.Buffer;
 import io.atomix.catalyst.buffer.FileBuffer;
 import io.atomix.catalyst.buffer.HeapBuffer;
+import io.atomix.catalyst.util.Assert;
+import io.atomix.copycat.server.state.Member;
 
 import java.io.File;
+import java.util.Collection;
 
 /**
  * Persists server state via the {@link Storage} module.
@@ -31,9 +34,11 @@ import java.io.File;
  * @author <a href="http://github.com/kuujo>Jordan Halterman</a>
  */
 public class MetaStore implements AutoCloseable {
+  private final Storage storage;
   private final Buffer buffer;
 
   MetaStore(String name, Storage storage) {
+    this.storage = Assert.notNull(storage, "storage");
     if (storage.level() == StorageLevel.MEMORY) {
       buffer = HeapBuffer.allocate(12);
     } else {
@@ -83,6 +88,34 @@ public class MetaStore implements AutoCloseable {
     return buffer.readInt(8);
   }
 
+  /**
+   * Stores the current cluster configuration.
+   *
+   * @param configuration The current cluster configuration.
+   * @return The metastore.
+   */
+  public MetaStore storeConfiguration(Configuration configuration) {
+    buffer.position(12).writeLong(configuration.version);
+    storage.serializer().writeObject(configuration.members, buffer);
+    return this;
+  }
+
+  /**
+   * Loads the current cluster configuration.
+   *
+   * @return The current cluster configuration.
+   */
+  public Configuration loadConfiguration() {
+    long version = buffer.position(12).readLong();
+    if (version > 0) {
+      return new Configuration(
+        version,
+        storage.serializer().readObject(buffer)
+      );
+    }
+    return null;
+  }
+
   @Override
   public void close() {
     buffer.close();
@@ -103,6 +136,42 @@ public class MetaStore implements AutoCloseable {
       return String.format("%s[%s]", getClass().getSimpleName(), ((FileBuffer) buffer).file());
     } else {
       return getClass().getSimpleName();
+    }
+  }
+
+  /**
+   * Metastore configuration.
+   */
+  public static class Configuration {
+    private final long version;
+    private final Collection<Member> members;
+
+    public Configuration(long version, Collection<Member> members) {
+      this.version = version;
+      this.members = Assert.notNull(members, "members");
+    }
+
+    /**
+     * Returns the configuration version.
+     *
+     * @return The configuration version.
+     */
+    public long version() {
+      return version;
+    }
+
+    /**
+     * Returns the collection of active members.
+     *
+     * @return The collection of active members.
+     */
+    public Collection<Member> members() {
+      return members;
+    }
+
+    @Override
+    public String toString() {
+      return String.format("%s[members=%s]", getClass().getSimpleName(), members);
     }
   }
 

--- a/server/src/main/java/io/atomix/copycat/server/storage/entry/CommandEntry.java
+++ b/server/src/main/java/io/atomix/copycat/server/storage/entry/CommandEntry.java
@@ -29,7 +29,7 @@ import io.atomix.copycat.client.Operation;
  *
  * @author <a href="http://github.com/kuujo">Jordan Halterman</a>
  */
-@SerializeWith(id=220)
+@SerializeWith(id=221)
 public class CommandEntry extends OperationEntry<CommandEntry> {
   private Command command;
 

--- a/server/src/main/java/io/atomix/copycat/server/storage/entry/ConfigurationEntry.java
+++ b/server/src/main/java/io/atomix/copycat/server/storage/entry/ConfigurationEntry.java
@@ -30,7 +30,7 @@ import java.util.Collection;
  *
  * @author <a href="http://github.com/kuujo">Jordan Halterman</a>
  */
-@SerializeWith(id=221)
+@SerializeWith(id=222)
 public class ConfigurationEntry extends Entry<ConfigurationEntry> {
   private Collection<Member> members;
 

--- a/server/src/main/java/io/atomix/copycat/server/storage/entry/ConfigurationEntry.java
+++ b/server/src/main/java/io/atomix/copycat/server/storage/entry/ConfigurationEntry.java
@@ -19,9 +19,9 @@ import io.atomix.catalyst.buffer.BufferInput;
 import io.atomix.catalyst.buffer.BufferOutput;
 import io.atomix.catalyst.serializer.SerializeWith;
 import io.atomix.catalyst.serializer.Serializer;
-import io.atomix.catalyst.transport.Address;
 import io.atomix.catalyst.util.Assert;
 import io.atomix.catalyst.util.ReferenceManager;
+import io.atomix.copycat.server.state.Member;
 
 import java.util.Collection;
 
@@ -32,8 +32,8 @@ import java.util.Collection;
  */
 @SerializeWith(id=221)
 public class ConfigurationEntry extends Entry<ConfigurationEntry> {
-  private Collection<Address> active;
-  private Collection<Address> passive;
+  private Collection<Member> active;
+  private Collection<Member> passive;
 
   public ConfigurationEntry() {
   }
@@ -47,7 +47,7 @@ public class ConfigurationEntry extends Entry<ConfigurationEntry> {
    *
    * @return The active members.
    */
-  public Collection<Address> getActive() {
+  public Collection<Member> getActive() {
     return active;
   }
 
@@ -58,7 +58,7 @@ public class ConfigurationEntry extends Entry<ConfigurationEntry> {
    * @return The configuration entry.
    * @throws NullPointerException if {@code members} is null
    */
-  public ConfigurationEntry setActive(Collection<Address> members) {
+  public ConfigurationEntry setActive(Collection<Member> members) {
     this.active = Assert.notNull(members, "members");
     return this;
   }
@@ -68,7 +68,7 @@ public class ConfigurationEntry extends Entry<ConfigurationEntry> {
    *
    * @return The passive members.
    */
-  public Collection<Address> getPassive() {
+  public Collection<Member> getPassive() {
     return passive;
   }
 
@@ -79,7 +79,7 @@ public class ConfigurationEntry extends Entry<ConfigurationEntry> {
    * @return The configuration entry.
    * @throws NullPointerException if {@code members} is null
    */
-  public ConfigurationEntry setPassive(Collection<Address> members) {
+  public ConfigurationEntry setPassive(Collection<Member> members) {
     this.passive = Assert.notNull(members, "members");
     return this;
   }

--- a/server/src/main/java/io/atomix/copycat/server/storage/entry/ConfigurationEntry.java
+++ b/server/src/main/java/io/atomix/copycat/server/storage/entry/ConfigurationEntry.java
@@ -32,8 +32,7 @@ import java.util.Collection;
  */
 @SerializeWith(id=221)
 public class ConfigurationEntry extends Entry<ConfigurationEntry> {
-  private Collection<Member> active;
-  private Collection<Member> passive;
+  private Collection<Member> members;
 
   public ConfigurationEntry() {
   }
@@ -43,64 +42,41 @@ public class ConfigurationEntry extends Entry<ConfigurationEntry> {
   }
 
   /**
-   * Returns the active members.
+   * Returns the members.
    *
-   * @return The active members.
+   * @return The members.
    */
-  public Collection<Member> getActive() {
-    return active;
+  public Collection<Member> getMembers() {
+    return members;
   }
 
   /**
-   * Sets the active members.
+   * Sets the members.
    *
-   * @param members The active members.
+   * @param members The members.
    * @return The configuration entry.
    * @throws NullPointerException if {@code members} is null
    */
-  public ConfigurationEntry setActive(Collection<Member> members) {
-    this.active = Assert.notNull(members, "members");
-    return this;
-  }
-
-  /**
-   * Returns the passive members.
-   *
-   * @return The passive members.
-   */
-  public Collection<Member> getPassive() {
-    return passive;
-  }
-
-  /**
-   * Sets the passive members.
-   *
-   * @param members The passive members.
-   * @return The configuration entry.
-   * @throws NullPointerException if {@code members} is null
-   */
-  public ConfigurationEntry setPassive(Collection<Member> members) {
-    this.passive = Assert.notNull(members, "members");
+  public ConfigurationEntry setMembers(Collection<Member> members) {
+    this.members = Assert.notNull(members, "members");
     return this;
   }
 
   @Override
   public void writeObject(BufferOutput buffer, Serializer serializer) {
     super.writeObject(buffer, serializer);
-    serializer.writeObject(active, buffer);
-    serializer.writeObject(passive, buffer);
+    serializer.writeObject(members, buffer);
   }
 
   @Override
   public void readObject(BufferInput buffer, Serializer serializer) {
     super.readObject(buffer, serializer);
-    active = serializer.readObject(buffer);
-    passive = serializer.readObject(buffer);
+    members = serializer.readObject(buffer);
   }
 
   @Override
   public String toString() {
-    return String.format("%s[index=%d, term=%d, active=%s, passive=%s]", getClass().getSimpleName(), getIndex(), getTerm(), active, passive);
+    return String.format("%s[index=%d, term=%d, members=%s]", getClass().getSimpleName(), getIndex(), getTerm(), members);
   }
 
 }

--- a/server/src/main/java/io/atomix/copycat/server/storage/entry/ConnectEntry.java
+++ b/server/src/main/java/io/atomix/copycat/server/storage/entry/ConnectEntry.java
@@ -28,7 +28,7 @@ import io.atomix.catalyst.util.ReferenceManager;
  *
  * @author <a href="http://github.com/kuujo">Jordan Halterman</a>
  */
-@SerializeWith(id=226)
+@SerializeWith(id=227)
 public class ConnectEntry extends SessionEntry<ConnectEntry> {
   private Address address;
 

--- a/server/src/main/java/io/atomix/copycat/server/storage/entry/KeepAliveEntry.java
+++ b/server/src/main/java/io/atomix/copycat/server/storage/entry/KeepAliveEntry.java
@@ -26,7 +26,7 @@ import io.atomix.catalyst.util.ReferenceManager;
  *
  * @author <a href="http://github.com/kuujo">Jordan Halterman</a>
  */
-@SerializeWith(id=222)
+@SerializeWith(id=223)
 public class KeepAliveEntry extends SessionEntry<KeepAliveEntry> {
   private long commandSequence;
   private long eventVersion;

--- a/server/src/main/java/io/atomix/copycat/server/storage/entry/NoOpEntry.java
+++ b/server/src/main/java/io/atomix/copycat/server/storage/entry/NoOpEntry.java
@@ -23,7 +23,7 @@ import io.atomix.catalyst.util.ReferenceManager;
  *
  * @author <a href="http://github.com/kuujo">Jordan Halterman</a>
  */
-@SerializeWith(id=223)
+@SerializeWith(id=224)
 public class NoOpEntry extends TimestampedEntry<NoOpEntry> {
 
   public NoOpEntry() {

--- a/server/src/main/java/io/atomix/copycat/server/storage/entry/QueryEntry.java
+++ b/server/src/main/java/io/atomix/copycat/server/storage/entry/QueryEntry.java
@@ -29,7 +29,7 @@ import io.atomix.catalyst.util.ReferenceManager;
  *
  * @author <a href="http://github.com/kuujo">Jordan Halterman</a>
  */
-@SerializeWith(id=224)
+@SerializeWith(id=225)
 public class QueryEntry extends OperationEntry<QueryEntry> {
   private long version;
   private Query query;

--- a/server/src/main/java/io/atomix/copycat/server/storage/entry/RegisterEntry.java
+++ b/server/src/main/java/io/atomix/copycat/server/storage/entry/RegisterEntry.java
@@ -29,7 +29,7 @@ import java.util.UUID;
  *
  * @author <a href="http://github.com/kuujo">Jordan Halterman</a>
  */
-@SerializeWith(id=225)
+@SerializeWith(id=226)
 public class RegisterEntry extends TimestampedEntry<RegisterEntry> {
   private UUID client;
   private long timeout;

--- a/server/src/main/java/io/atomix/copycat/server/storage/entry/UnregisterEntry.java
+++ b/server/src/main/java/io/atomix/copycat/server/storage/entry/UnregisterEntry.java
@@ -26,7 +26,7 @@ import io.atomix.catalyst.util.ReferenceManager;
  *
  * @author <a href="http://github.com/kuujo">Jordan Halterman</a>
  */
-@SerializeWith(id=227)
+@SerializeWith(id=228)
 public class UnregisterEntry extends SessionEntry<UnregisterEntry> {
   private boolean expired;
 

--- a/server/src/main/resources/META-INF/services/io.atomix.catalyst.serializer.CatalystSerializable
+++ b/server/src/main/resources/META-INF/services/io.atomix.catalyst.serializer.CatalystSerializable
@@ -13,6 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+io.atomix.copycat.server.state.Member
+
 io.atomix.copycat.server.request.AcceptRequest
 io.atomix.copycat.server.response.AcceptResponse
 io.atomix.copycat.server.request.AppendRequest

--- a/server/src/main/resources/META-INF/services/io.atomix.catalyst.serializer.CatalystSerializable
+++ b/server/src/main/resources/META-INF/services/io.atomix.catalyst.serializer.CatalystSerializable
@@ -23,6 +23,8 @@ io.atomix.copycat.server.request.JoinRequest
 io.atomix.copycat.server.response.JoinResponse
 io.atomix.copycat.server.request.LeaveRequest
 io.atomix.copycat.server.response.LeaveResponse
+io.atomix.copycat.server.request.ConfigureRequest
+io.atomix.copycat.server.response.ConfigureResponse
 io.atomix.copycat.server.request.PollRequest
 io.atomix.copycat.server.response.PollResponse
 io.atomix.copycat.server.request.VoteRequest

--- a/server/src/test/java/io/atomix/copycat/server/state/AbstractStateTest.java
+++ b/server/src/test/java/io/atomix/copycat/server/state/AbstractStateTest.java
@@ -148,7 +148,7 @@ public abstract class AbstractStateTest<T extends AbstractState> extends Concurr
   private List<Member> createMembers(int nodes) {
     List<Member> members = new ArrayList<>();
     for (int i = 0; i < nodes; i++) {
-      members.add(new Member(new Address("localhost", 5000 + i), new Address("localhost", 6000 + i)));
+      members.add(new Member(RaftMemberType.ACTIVE, new Address("localhost", 5000 + i), new Address("localhost", 6000 + i)));
     }
     return members;
   }

--- a/server/src/test/java/io/atomix/copycat/server/state/AbstractStateTest.java
+++ b/server/src/test/java/io/atomix/copycat/server/state/AbstractStateTest.java
@@ -39,6 +39,7 @@ import org.testng.annotations.Test;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 
 /**
  * Abstract state test.
@@ -53,7 +54,7 @@ public abstract class AbstractStateTest<T extends AbstractState> extends Concurr
   protected ThreadContext serverCtx;
   protected LocalTransport transport;
   protected ServerState serverState;
-  protected List<Address> members;
+  protected List<Member> members;
 
   /**
    * Sets up a server state.
@@ -72,7 +73,7 @@ public abstract class AbstractStateTest<T extends AbstractState> extends Concurr
     transport = new LocalTransport(new LocalServerRegistry());
 
     serverCtx = new SingleThreadContext("test-server", serializer);
-    serverState = new ServerState(members.get(0), members, log, stateMachine, new ConnectionManager(transport.client()), serverCtx);
+    serverState = new ServerState(members.get(0), members.stream().map(Member::serverAddress).collect(Collectors.toList()), log, stateMachine, new ConnectionManager(transport.client()), serverCtx);
   }
 
   /**
@@ -144,10 +145,10 @@ public abstract class AbstractStateTest<T extends AbstractState> extends Concurr
   /**
    * Creates a collection of member addresses.
    */
-  private List<Address> createMembers(int nodes) {
-    List<Address> members = new ArrayList<>();
+  private List<Member> createMembers(int nodes) {
+    List<Member> members = new ArrayList<>();
     for (int i = 0; i < nodes; i++) {
-      members.add(new Address("localhost", 5000 + i));
+      members.add(new Member(new Address("localhost", 5000 + i), new Address("localhost", 6000 + i)));
     }
     return members;
   }

--- a/server/src/test/java/io/atomix/copycat/server/state/ActiveStateTest.java
+++ b/server/src/test/java/io/atomix/copycat/server/state/ActiveStateTest.java
@@ -84,7 +84,7 @@ public class ActiveStateTest extends AbstractStateTest<ActiveState> {
 
       PollRequest request = PollRequest.builder()
         .withTerm(2)
-        .withCandidate(serverState.getMember().serverAddress().hashCode())
+        .withCandidate(serverState.getCluster().getMember().serverAddress().hashCode())
         .withLogIndex(1)
         .withLogTerm(1)
         .build();
@@ -104,7 +104,7 @@ public class ActiveStateTest extends AbstractStateTest<ActiveState> {
 
       PollRequest request = PollRequest.builder()
         .withTerm(1)
-        .withCandidate(serverState.getMember().serverAddress().hashCode())
+        .withCandidate(serverState.getCluster().getMember().serverAddress().hashCode())
         .withLogIndex(1)
         .withLogTerm(1)
         .build();
@@ -125,7 +125,7 @@ public class ActiveStateTest extends AbstractStateTest<ActiveState> {
 
       PollRequest request = PollRequest.builder()
         .withTerm(2)
-        .withCandidate(serverState.getMember().serverAddress().hashCode())
+        .withCandidate(serverState.getCluster().getMember().serverAddress().hashCode())
         .withLogIndex(1)
         .withLogTerm(1)
         .build();
@@ -147,7 +147,7 @@ public class ActiveStateTest extends AbstractStateTest<ActiveState> {
 
       PollRequest request = PollRequest.builder()
         .withTerm(2)
-        .withCandidate(serverState.getMember().serverAddress().hashCode())
+        .withCandidate(serverState.getCluster().getMember().serverAddress().hashCode())
         .withLogIndex(4)
         .withLogTerm(1)
         .build();
@@ -167,7 +167,7 @@ public class ActiveStateTest extends AbstractStateTest<ActiveState> {
 
       VoteRequest request = VoteRequest.builder()
         .withTerm(2)
-        .withCandidate(serverState.getCluster().getActiveMembers().iterator().next().getServerAddress().hashCode())
+        .withCandidate(serverState.getCluster().getRemoteMemberStates(RaftMemberType.ACTIVE).iterator().next().getMember().id())
         .withLogIndex(1)
         .withLogTerm(1)
         .build();
@@ -188,7 +188,7 @@ public class ActiveStateTest extends AbstractStateTest<ActiveState> {
 
       VoteRequest request = VoteRequest.builder()
         .withTerm(1)
-        .withCandidate(serverState.getCluster().getActiveMembers().iterator().next().getServerAddress().hashCode())
+        .withCandidate(serverState.getCluster().getRemoteMemberStates(RaftMemberType.ACTIVE).iterator().next().getMember().id())
         .withLogIndex(1)
         .withLogTerm(1)
         .build();
@@ -209,7 +209,7 @@ public class ActiveStateTest extends AbstractStateTest<ActiveState> {
 
       VoteRequest request = VoteRequest.builder()
         .withTerm(2)
-        .withCandidate(serverState.getCluster().getActiveMembers().iterator().next().getServerAddress().hashCode())
+        .withCandidate(serverState.getCluster().getRemoteMemberStates(RaftMemberType.ACTIVE).iterator().next().getMember().id())
         .withLogIndex(1)
         .withLogTerm(1)
         .build();
@@ -231,7 +231,7 @@ public class ActiveStateTest extends AbstractStateTest<ActiveState> {
 
       VoteRequest request = VoteRequest.builder()
         .withTerm(2)
-        .withCandidate(serverState.getCluster().getActiveMembers().iterator().next().getServerAddress().hashCode())
+        .withCandidate(serverState.getCluster().getRemoteMemberStates(RaftMemberType.ACTIVE).iterator().next().getMember().id())
         .withLogIndex(4)
         .withLogTerm(1)
         .build();

--- a/server/src/test/java/io/atomix/copycat/server/state/ActiveStateTest.java
+++ b/server/src/test/java/io/atomix/copycat/server/state/ActiveStateTest.java
@@ -84,7 +84,7 @@ public class ActiveStateTest extends AbstractStateTest<ActiveState> {
 
       PollRequest request = PollRequest.builder()
         .withTerm(2)
-        .withCandidate(serverState.getAddress().hashCode())
+        .withCandidate(serverState.getMember().serverAddress().hashCode())
         .withLogIndex(1)
         .withLogTerm(1)
         .build();
@@ -104,7 +104,7 @@ public class ActiveStateTest extends AbstractStateTest<ActiveState> {
 
       PollRequest request = PollRequest.builder()
         .withTerm(1)
-        .withCandidate(serverState.getAddress().hashCode())
+        .withCandidate(serverState.getMember().serverAddress().hashCode())
         .withLogIndex(1)
         .withLogTerm(1)
         .build();
@@ -125,7 +125,7 @@ public class ActiveStateTest extends AbstractStateTest<ActiveState> {
 
       PollRequest request = PollRequest.builder()
         .withTerm(2)
-        .withCandidate(serverState.getAddress().hashCode())
+        .withCandidate(serverState.getMember().serverAddress().hashCode())
         .withLogIndex(1)
         .withLogTerm(1)
         .build();
@@ -147,7 +147,7 @@ public class ActiveStateTest extends AbstractStateTest<ActiveState> {
 
       PollRequest request = PollRequest.builder()
         .withTerm(2)
-        .withCandidate(serverState.getAddress().hashCode())
+        .withCandidate(serverState.getMember().serverAddress().hashCode())
         .withLogIndex(4)
         .withLogTerm(1)
         .build();
@@ -167,7 +167,7 @@ public class ActiveStateTest extends AbstractStateTest<ActiveState> {
 
       VoteRequest request = VoteRequest.builder()
         .withTerm(2)
-        .withCandidate(serverState.getCluster().getActiveMembers().iterator().next().getAddress().hashCode())
+        .withCandidate(serverState.getCluster().getActiveMembers().iterator().next().getServerAddress().hashCode())
         .withLogIndex(1)
         .withLogTerm(1)
         .build();
@@ -188,7 +188,7 @@ public class ActiveStateTest extends AbstractStateTest<ActiveState> {
 
       VoteRequest request = VoteRequest.builder()
         .withTerm(1)
-        .withCandidate(serverState.getCluster().getActiveMembers().iterator().next().getAddress().hashCode())
+        .withCandidate(serverState.getCluster().getActiveMembers().iterator().next().getServerAddress().hashCode())
         .withLogIndex(1)
         .withLogTerm(1)
         .build();
@@ -209,7 +209,7 @@ public class ActiveStateTest extends AbstractStateTest<ActiveState> {
 
       VoteRequest request = VoteRequest.builder()
         .withTerm(2)
-        .withCandidate(serverState.getCluster().getActiveMembers().iterator().next().getAddress().hashCode())
+        .withCandidate(serverState.getCluster().getActiveMembers().iterator().next().getServerAddress().hashCode())
         .withLogIndex(1)
         .withLogTerm(1)
         .build();
@@ -231,7 +231,7 @@ public class ActiveStateTest extends AbstractStateTest<ActiveState> {
 
       VoteRequest request = VoteRequest.builder()
         .withTerm(2)
-        .withCandidate(serverState.getCluster().getActiveMembers().iterator().next().getAddress().hashCode())
+        .withCandidate(serverState.getCluster().getActiveMembers().iterator().next().getServerAddress().hashCode())
         .withLogIndex(4)
         .withLogTerm(1)
         .build();

--- a/server/src/test/java/io/atomix/copycat/server/state/ActiveStateTest.java
+++ b/server/src/test/java/io/atomix/copycat/server/state/ActiveStateTest.java
@@ -172,7 +172,7 @@ public class ActiveStateTest extends AbstractStateTest<ActiveState> {
 
       VoteRequest request = VoteRequest.builder()
         .withTerm(2)
-        .withCandidate(serverState.getCluster().getRemoteMemberStates(RaftMemberType.ACTIVE).iterator().next().getMember().id())
+        .withCandidate(serverState.getCluster().getVotingMemberStates().iterator().next().getMember().id())
         .withLogIndex(1)
         .withLogTerm(1)
         .build();
@@ -193,7 +193,7 @@ public class ActiveStateTest extends AbstractStateTest<ActiveState> {
 
       VoteRequest request = VoteRequest.builder()
         .withTerm(1)
-        .withCandidate(serverState.getCluster().getRemoteMemberStates(RaftMemberType.ACTIVE).iterator().next().getMember().id())
+        .withCandidate(serverState.getCluster().getVotingMemberStates().iterator().next().getMember().id())
         .withLogIndex(1)
         .withLogTerm(1)
         .build();
@@ -214,7 +214,7 @@ public class ActiveStateTest extends AbstractStateTest<ActiveState> {
 
       VoteRequest request = VoteRequest.builder()
         .withTerm(2)
-        .withCandidate(serverState.getCluster().getRemoteMemberStates(RaftMemberType.ACTIVE).iterator().next().getMember().id())
+        .withCandidate(serverState.getCluster().getVotingMemberStates().iterator().next().getMember().id())
         .withLogIndex(1)
         .withLogTerm(1)
         .build();
@@ -236,7 +236,7 @@ public class ActiveStateTest extends AbstractStateTest<ActiveState> {
 
       VoteRequest request = VoteRequest.builder()
         .withTerm(2)
-        .withCandidate(serverState.getCluster().getRemoteMemberStates(RaftMemberType.ACTIVE).iterator().next().getMember().id())
+        .withCandidate(serverState.getCluster().getVotingMemberStates().iterator().next().getMember().id())
         .withLogIndex(4)
         .withLogTerm(1)
         .build();

--- a/server/src/test/java/io/atomix/copycat/server/state/CandidateStateTest.java
+++ b/server/src/test/java/io/atomix/copycat/server/state/CandidateStateTest.java
@@ -44,7 +44,7 @@ public class CandidateStateTest extends AbstractStateTest<CandidateState> {
 
   public void testCandidateAppendAndTransitionOnTerm() throws Throwable {
     runOnServer(() -> {
-      int leader = serverState.getCluster().getActiveMembers().iterator().next().getAddress().hashCode();
+      int leader = serverState.getCluster().getActiveMembers().iterator().next().getServerAddress().hashCode();
       serverState.setTerm(1);
       AppendRequest request = AppendRequest.builder()
         .withTerm(2)
@@ -64,7 +64,7 @@ public class CandidateStateTest extends AbstractStateTest<CandidateState> {
 
   public void testCandidateIncrementsTermVotesForSelfOnElection() throws Throwable {
     runOnServer(() -> {
-      int self = serverState.getAddress().hashCode();
+      int self = serverState.getMember().serverAddress().hashCode();
       serverState.setTerm(2);
 
       state.startElection();
@@ -76,7 +76,7 @@ public class CandidateStateTest extends AbstractStateTest<CandidateState> {
 
   public void testCandidateVotesForSelfOnRequest() throws Throwable {
     runOnServer(() -> {
-      int self = serverState.getAddress().hashCode();
+      int self = serverState.getMember().serverAddress().hashCode();
       serverState.setTerm(2);
 
       state.startElection();
@@ -102,7 +102,7 @@ public class CandidateStateTest extends AbstractStateTest<CandidateState> {
 
   public void testCandidateVotesAndTransitionsOnTerm() throws Throwable {
     runOnServer(() -> {
-      int candidate = serverState.getCluster().getActiveMembers().iterator().next().getAddress().hashCode();
+      int candidate = serverState.getCluster().getActiveMembers().iterator().next().getServerAddress().hashCode();
       serverState.setTerm(1);
 
       state.startElection();
@@ -129,7 +129,7 @@ public class CandidateStateTest extends AbstractStateTest<CandidateState> {
 
   public void testCandidateRejectsVoteAndTransitionsOnTerm() throws Throwable {
     runOnServer(() -> {
-      int candidate = serverState.getCluster().getActiveMembers().iterator().next().getAddress().hashCode();
+      int candidate = serverState.getCluster().getActiveMembers().iterator().next().getServerAddress().hashCode();
       serverState.setTerm(1);
 
       append(2, 1);
@@ -165,7 +165,7 @@ public class CandidateStateTest extends AbstractStateTest<CandidateState> {
     runOnServer(() -> {
       for (MemberState member : serverState.getCluster().getActiveMembers()) {
         Server server = transport.server();
-        server.listen(member.getAddress(), c -> {
+        server.listen(member.getServerAddress(), c -> {
           c.handler(VoteRequest.class, request -> CompletableFuture.completedFuture(VoteResponse.builder()
             .withTerm(2)
             .withVoted(true)
@@ -177,7 +177,7 @@ public class CandidateStateTest extends AbstractStateTest<CandidateState> {
     await(1000, serverState.getCluster().getActiveMembers().size());
 
     runOnServer(() -> {
-      int self = serverState.getAddress().hashCode();
+      int self = serverState.getMember().serverAddress().hashCode();
       serverState.setTerm(1);
 
       state.startElection();
@@ -197,7 +197,7 @@ public class CandidateStateTest extends AbstractStateTest<CandidateState> {
     runOnServer(() -> {
       for (MemberState member : serverState.getCluster().getActiveMembers()) {
         Server server = transport.server();
-        server.listen(member.getAddress(), c -> {
+        server.listen(member.getServerAddress(), c -> {
           c.handler(VoteRequest.class, request -> CompletableFuture.completedFuture(VoteResponse.builder()
             .withTerm(2)
             .withVoted(false)
@@ -209,7 +209,7 @@ public class CandidateStateTest extends AbstractStateTest<CandidateState> {
     await(1000, serverState.getCluster().getActiveMembers().size());
 
     runOnServer(() -> {
-      int self = serverState.getAddress().hashCode();
+      int self = serverState.getMember().serverAddress().hashCode();
       serverState.setTerm(1);
 
       state.startElection();

--- a/server/src/test/java/io/atomix/copycat/server/state/CandidateStateTest.java
+++ b/server/src/test/java/io/atomix/copycat/server/state/CandidateStateTest.java
@@ -44,7 +44,7 @@ public class CandidateStateTest extends AbstractStateTest<CandidateState> {
 
   public void testCandidateAppendAndTransitionOnTerm() throws Throwable {
     runOnServer(() -> {
-      int leader = serverState.getCluster().getRemoteMemberStates(RaftMemberType.ACTIVE).iterator().next().getMember().id();
+      int leader = serverState.getCluster().getVotingMemberStates().iterator().next().getMember().id();
       serverState.setTerm(1);
       AppendRequest request = AppendRequest.builder()
         .withTerm(2)
@@ -104,7 +104,7 @@ public class CandidateStateTest extends AbstractStateTest<CandidateState> {
 
   public void testCandidateVotesAndTransitionsOnTerm() throws Throwable {
     runOnServer(() -> {
-      int candidate = serverState.getCluster().getRemoteMembers(RaftMemberType.ACTIVE).iterator().next().id();
+      int candidate = serverState.getCluster().getVotingMembers().iterator().next().id();
       serverState.setTerm(1);
 
       state.startElection();
@@ -131,7 +131,7 @@ public class CandidateStateTest extends AbstractStateTest<CandidateState> {
 
   public void testCandidateRejectsVoteAndTransitionsOnTerm() throws Throwable {
     runOnServer(() -> {
-      int candidate = serverState.getCluster().getRemoteMembers(RaftMemberType.ACTIVE).iterator().next().id();
+      int candidate = serverState.getCluster().getVotingMembers().iterator().next().id();
       serverState.setTerm(1);
 
       append(2, 1);

--- a/server/src/test/java/io/atomix/copycat/server/state/CandidateStateTest.java
+++ b/server/src/test/java/io/atomix/copycat/server/state/CandidateStateTest.java
@@ -44,7 +44,7 @@ public class CandidateStateTest extends AbstractStateTest<CandidateState> {
 
   public void testCandidateAppendAndTransitionOnTerm() throws Throwable {
     runOnServer(() -> {
-      int leader = serverState.getCluster().getActiveMembers().iterator().next().getServerAddress().hashCode();
+      int leader = serverState.getCluster().getRemoteMemberStates(RaftMemberType.ACTIVE).iterator().next().getMember().id();
       serverState.setTerm(1);
       AppendRequest request = AppendRequest.builder()
         .withTerm(2)
@@ -64,7 +64,7 @@ public class CandidateStateTest extends AbstractStateTest<CandidateState> {
 
   public void testCandidateIncrementsTermVotesForSelfOnElection() throws Throwable {
     runOnServer(() -> {
-      int self = serverState.getMember().serverAddress().hashCode();
+      int self = serverState.getCluster().getMember().serverAddress().hashCode();
       serverState.setTerm(2);
 
       state.startElection();
@@ -76,7 +76,7 @@ public class CandidateStateTest extends AbstractStateTest<CandidateState> {
 
   public void testCandidateVotesForSelfOnRequest() throws Throwable {
     runOnServer(() -> {
-      int self = serverState.getMember().serverAddress().hashCode();
+      int self = serverState.getCluster().getMember().serverAddress().hashCode();
       serverState.setTerm(2);
 
       state.startElection();
@@ -102,7 +102,7 @@ public class CandidateStateTest extends AbstractStateTest<CandidateState> {
 
   public void testCandidateVotesAndTransitionsOnTerm() throws Throwable {
     runOnServer(() -> {
-      int candidate = serverState.getCluster().getActiveMembers().iterator().next().getServerAddress().hashCode();
+      int candidate = serverState.getCluster().getRemoteMembers(RaftMemberType.ACTIVE).iterator().next().id();
       serverState.setTerm(1);
 
       state.startElection();
@@ -129,7 +129,7 @@ public class CandidateStateTest extends AbstractStateTest<CandidateState> {
 
   public void testCandidateRejectsVoteAndTransitionsOnTerm() throws Throwable {
     runOnServer(() -> {
-      int candidate = serverState.getCluster().getActiveMembers().iterator().next().getServerAddress().hashCode();
+      int candidate = serverState.getCluster().getRemoteMembers(RaftMemberType.ACTIVE).iterator().next().id();
       serverState.setTerm(1);
 
       append(2, 1);
@@ -163,9 +163,9 @@ public class CandidateStateTest extends AbstractStateTest<CandidateState> {
     });
 
     runOnServer(() -> {
-      for (MemberState member : serverState.getCluster().getActiveMembers()) {
+      for (Member member : serverState.getCluster().getMembers()) {
         Server server = transport.server();
-        server.listen(member.getServerAddress(), c -> {
+        server.listen(member.serverAddress(), c -> {
           c.handler(VoteRequest.class, request -> CompletableFuture.completedFuture(VoteResponse.builder()
             .withTerm(2)
             .withVoted(true)
@@ -174,10 +174,10 @@ public class CandidateStateTest extends AbstractStateTest<CandidateState> {
       }
     });
 
-    await(1000, serverState.getCluster().getActiveMembers().size());
+    await(1000, serverState.getCluster().getMembers().size());
 
     runOnServer(() -> {
-      int self = serverState.getMember().serverAddress().hashCode();
+      int self = serverState.getCluster().getMember().serverAddress().hashCode();
       serverState.setTerm(1);
 
       state.startElection();
@@ -195,9 +195,9 @@ public class CandidateStateTest extends AbstractStateTest<CandidateState> {
     });
 
     runOnServer(() -> {
-      for (MemberState member : serverState.getCluster().getActiveMembers()) {
+      for (Member member : serverState.getCluster().getMembers()) {
         Server server = transport.server();
-        server.listen(member.getServerAddress(), c -> {
+        server.listen(member.serverAddress(), c -> {
           c.handler(VoteRequest.class, request -> CompletableFuture.completedFuture(VoteResponse.builder()
             .withTerm(2)
             .withVoted(false)
@@ -206,10 +206,10 @@ public class CandidateStateTest extends AbstractStateTest<CandidateState> {
       }
     });
 
-    await(1000, serverState.getCluster().getActiveMembers().size());
+    await(1000, serverState.getCluster().getMembers().size());
 
     runOnServer(() -> {
-      int self = serverState.getMember().serverAddress().hashCode();
+      int self = serverState.getCluster().getMember().serverAddress().hashCode();
       serverState.setTerm(1);
 
       state.startElection();

--- a/server/src/test/java/io/atomix/copycat/server/state/FollowerStateTest.java
+++ b/server/src/test/java/io/atomix/copycat/server/state/FollowerStateTest.java
@@ -15,9 +15,6 @@
  */
 package io.atomix.copycat.server.state;
 
-import org.testng.annotations.BeforeMethod;
-import org.testng.annotations.Test;
-
 import io.atomix.copycat.client.response.Response.Status;
 import io.atomix.copycat.server.request.AppendRequest;
 import io.atomix.copycat.server.request.PollRequest;
@@ -25,6 +22,8 @@ import io.atomix.copycat.server.request.VoteRequest;
 import io.atomix.copycat.server.response.AppendResponse;
 import io.atomix.copycat.server.response.PollResponse;
 import io.atomix.copycat.server.response.VoteResponse;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
 
 /**
  * Follower state test.
@@ -355,7 +354,7 @@ public class FollowerStateTest extends AbstractStateTest<FollowerState> {
       AppendResponse response2 = state.append(request2).get();
 
       threadAssertEquals(serverState.getTerm(), 3L);
-      threadAssertEquals(serverState.getLeader(), members.get(2).serverAddress());
+      threadAssertEquals(serverState.getLeader().serverAddress(), members.get(2).serverAddress());
       threadAssertEquals(serverState.getLastVotedFor(), 0);
       threadAssertEquals(response2.term(), 3L);
       threadAssertTrue(response2.succeeded());

--- a/server/src/test/java/io/atomix/copycat/server/state/FollowerStateTest.java
+++ b/server/src/test/java/io/atomix/copycat/server/state/FollowerStateTest.java
@@ -354,7 +354,7 @@ public class FollowerStateTest extends AbstractStateTest<FollowerState> {
       AppendResponse response2 = state.append(request2).get();
 
       threadAssertEquals(serverState.getTerm(), 3L);
-      threadAssertEquals(serverState.getLeader(), members.get(2));
+      threadAssertEquals(serverState.getLeader(), members.get(2).serverAddress());
       threadAssertEquals(serverState.getLastVotedFor(), 0);
       threadAssertEquals(response2.term(), 3L);
       threadAssertTrue(response2.succeeded());

--- a/server/src/test/java/io/atomix/copycat/server/state/MemberTest.java
+++ b/server/src/test/java/io/atomix/copycat/server/state/MemberTest.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License
+ */
+package io.atomix.copycat.server.state;
+
+import io.atomix.catalyst.serializer.Serializer;
+import io.atomix.catalyst.serializer.ServiceLoaderTypeResolver;
+import io.atomix.catalyst.transport.Address;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNull;
+
+/**
+ * Member test.
+ *
+ * @author <a href="http://github.com/kuujo>Jordan Halterman</a>
+ */
+@Test
+public class MemberTest {
+
+  /**
+   * Tests member getters.
+   */
+  public void testMemberGetters() {
+    Member member = new Member(RaftMemberType.ACTIVE, new Address("localhost", 5000), new Address("localhost", 6000));
+    assertEquals(member.type(), RaftMemberType.ACTIVE);
+    assertEquals(member.status(), Member.Status.AVAILABLE);
+    assertEquals(member.serverAddress(), new Address("localhost", 5000));
+    assertEquals(member.clientAddress(), new Address("localhost", 6000));
+  }
+
+  /**
+   * Tests serializing and deserializing a member.
+   */
+  public void testSerializeDeserialize() {
+    Member member = new Member(RaftMemberType.ACTIVE, new Address("localhost", 5000), null);
+    Serializer serializer = new Serializer(new ServiceLoaderTypeResolver());
+    Member result = serializer.readObject(serializer.writeObject(member).flip());
+    assertEquals(result.type(), member.type());
+  }
+
+  /**
+   * Tests updating a member.
+   */
+  public void testMemberUpdate() {
+    Member member = new Member(RaftMemberType.ACTIVE, new Address("localhost", 5000), null);
+    member.update((MemberType) null);
+    assertNull(member.type());
+    member.update(Member.Status.UNAVAILABLE);
+    assertEquals(member.status(), Member.Status.UNAVAILABLE);
+    assertNull(member.clientAddress());
+    member.update(new Address("localhost", 6000));
+    assertEquals(member.clientAddress(), new Address("localhost", 6000));
+  }
+
+}

--- a/server/src/test/java/io/atomix/copycat/server/state/PassiveStateTest.java
+++ b/server/src/test/java/io/atomix/copycat/server/state/PassiveStateTest.java
@@ -94,7 +94,7 @@ public class PassiveStateTest extends AbstractStateTest<PassiveState> {
       AppendResponse response = state.append(request).get();
       
       threadAssertEquals(serverState.getTerm(), 2L);
-      threadAssertEquals(serverState.getLeader(), members.get(1).serverAddress());
+      threadAssertEquals(serverState.getLeader().serverAddress(), members.get(1).serverAddress());
       threadAssertEquals(serverState.getLastVotedFor(), 0);
       threadAssertEquals(response.term(), 2L);
       threadAssertTrue(response.succeeded());

--- a/server/src/test/java/io/atomix/copycat/server/state/PassiveStateTest.java
+++ b/server/src/test/java/io/atomix/copycat/server/state/PassiveStateTest.java
@@ -44,7 +44,7 @@ public class PassiveStateTest extends AbstractStateTest<PassiveState> {
 
   public void testAccept() throws Throwable {
     runOnServer(() -> {
-      AcceptRequest request = AcceptRequest.builder().withAddress(members.get(0)).withSession(1).build();
+      AcceptRequest request = AcceptRequest.builder().withAddress(members.get(0).serverAddress()).withSession(1).build();
       AcceptResponse response = state.accept(request).get();
       assertIllegalMemberStateError(response);
     });
@@ -93,7 +93,7 @@ public class PassiveStateTest extends AbstractStateTest<PassiveState> {
       AppendResponse response = state.append(request).get();
       
       threadAssertEquals(serverState.getTerm(), 2L);
-      threadAssertEquals(serverState.getLeader(), members.get(1));
+      threadAssertEquals(serverState.getLeader(), members.get(1).serverAddress());
       threadAssertEquals(serverState.getLastVotedFor(), 0);
       threadAssertEquals(response.term(), 2L);
       threadAssertTrue(response.succeeded());
@@ -102,7 +102,7 @@ public class PassiveStateTest extends AbstractStateTest<PassiveState> {
 
   public void testAppendTermAndLeaderUpdated() throws Throwable {
     runOnServer(() -> {
-      int leader = serverState.getCluster().getActiveMembers().iterator().next().getAddress().hashCode();
+      int leader = serverState.getCluster().getActiveMembers().iterator().next().getServerAddress().hashCode();
       serverState.setTerm(1);
       AppendRequest request = AppendRequest.builder()
         .withTerm(2)
@@ -126,7 +126,7 @@ public class PassiveStateTest extends AbstractStateTest<PassiveState> {
 
       AppendRequest request = AppendRequest.builder()
         .withTerm(1)
-        .withLeader(serverState.getCluster().getActiveMembers().iterator().next().getAddress().hashCode())
+        .withLeader(serverState.getCluster().getActiveMembers().iterator().next().getServerAddress().hashCode())
         .withLogIndex(2)
         .withLogTerm(2)
         .build();
@@ -147,7 +147,7 @@ public class PassiveStateTest extends AbstractStateTest<PassiveState> {
 
       AppendRequest request = AppendRequest.builder()
         .withTerm(2)
-        .withLeader(serverState.getCluster().getActiveMembers().iterator().next().getAddress().hashCode())
+        .withLeader(serverState.getCluster().getActiveMembers().iterator().next().getServerAddress().hashCode())
         .withLogIndex(2)
         .withLogTerm(2)
         .build();
@@ -168,7 +168,7 @@ public class PassiveStateTest extends AbstractStateTest<PassiveState> {
 
       AppendRequest request = AppendRequest.builder()
         .withTerm(1)
-        .withLeader(serverState.getCluster().getActiveMembers().iterator().next().getAddress().hashCode())
+        .withLeader(serverState.getCluster().getActiveMembers().iterator().next().getServerAddress().hashCode())
         .withLogIndex(1)
         .withLogTerm(1)
         .withEntries(new TestEntry().setIndex(2).setTerm(1))
@@ -190,7 +190,7 @@ public class PassiveStateTest extends AbstractStateTest<PassiveState> {
 
       AppendRequest request = AppendRequest.builder()
         .withTerm(2)
-        .withLeader(serverState.getCluster().getActiveMembers().iterator().next().getAddress().hashCode())
+        .withLeader(serverState.getCluster().getActiveMembers().iterator().next().getServerAddress().hashCode())
         .withLogIndex(2)
         .withLogTerm(2)
         .build();
@@ -210,7 +210,7 @@ public class PassiveStateTest extends AbstractStateTest<PassiveState> {
 
       AppendRequest request = AppendRequest.builder()
         .withTerm(1)
-        .withLeader(serverState.getCluster().getActiveMembers().iterator().next().getAddress().hashCode())
+        .withLeader(serverState.getCluster().getActiveMembers().iterator().next().getServerAddress().hashCode())
         .withLogIndex(0)
         .withLogTerm(0)
         .withEntries(new TestEntry().setIndex(1).setTerm(1))
@@ -235,7 +235,7 @@ public class PassiveStateTest extends AbstractStateTest<PassiveState> {
 
       AppendRequest request = AppendRequest.builder()
         .withTerm(1)
-        .withLeader(serverState.getCluster().getActiveMembers().iterator().next().getAddress().hashCode())
+        .withLeader(serverState.getCluster().getActiveMembers().iterator().next().getServerAddress().hashCode())
         .withLogIndex(0)
         .withLogTerm(0)
         .withEntries(new TestEntry().setIndex(2).setTerm(1))
@@ -261,7 +261,7 @@ public class PassiveStateTest extends AbstractStateTest<PassiveState> {
 
       AppendRequest request = AppendRequest.builder()
         .withTerm(3)
-        .withLeader(serverState.getCluster().getActiveMembers().iterator().next().getAddress().hashCode())
+        .withLeader(serverState.getCluster().getActiveMembers().iterator().next().getServerAddress().hashCode())
         .withLogIndex(1)
         .withLogTerm(1)
         .withEntries(new TestEntry().setIndex(2).setTerm(2), new TestEntry().setIndex(3).setTerm(3), new TestEntry().setIndex(4).setTerm(3))
@@ -288,7 +288,7 @@ public class PassiveStateTest extends AbstractStateTest<PassiveState> {
 
       AppendRequest request = AppendRequest.builder()
         .withTerm(1)
-        .withLeader(serverState.getCluster().getActiveMembers().iterator().next().getAddress().hashCode())
+        .withLeader(serverState.getCluster().getActiveMembers().iterator().next().getServerAddress().hashCode())
         .withLogIndex(1)
         .withLogTerm(1)
         .withEntries(new TestEntry().setIndex(2).setTerm(1), new TestEntry().setIndex(4).setTerm(1))

--- a/server/src/test/java/io/atomix/copycat/server/state/PassiveStateTest.java
+++ b/server/src/test/java/io/atomix/copycat/server/state/PassiveStateTest.java
@@ -102,7 +102,7 @@ public class PassiveStateTest extends AbstractStateTest<PassiveState> {
 
   public void testAppendTermAndLeaderUpdated() throws Throwable {
     runOnServer(() -> {
-      int leader = serverState.getCluster().getActiveMembers().iterator().next().getServerAddress().hashCode();
+      int leader = serverState.getCluster().getRemoteMembers(RaftMemberType.ACTIVE).iterator().next().id();
       serverState.setTerm(1);
       AppendRequest request = AppendRequest.builder()
         .withTerm(2)
@@ -126,7 +126,7 @@ public class PassiveStateTest extends AbstractStateTest<PassiveState> {
 
       AppendRequest request = AppendRequest.builder()
         .withTerm(1)
-        .withLeader(serverState.getCluster().getActiveMembers().iterator().next().getServerAddress().hashCode())
+        .withLeader(serverState.getCluster().getRemoteMembers(RaftMemberType.ACTIVE).iterator().next().id())
         .withLogIndex(2)
         .withLogTerm(2)
         .build();
@@ -147,7 +147,7 @@ public class PassiveStateTest extends AbstractStateTest<PassiveState> {
 
       AppendRequest request = AppendRequest.builder()
         .withTerm(2)
-        .withLeader(serverState.getCluster().getActiveMembers().iterator().next().getServerAddress().hashCode())
+        .withLeader(serverState.getCluster().getRemoteMembers(RaftMemberType.ACTIVE).iterator().next().id())
         .withLogIndex(2)
         .withLogTerm(2)
         .build();
@@ -168,7 +168,7 @@ public class PassiveStateTest extends AbstractStateTest<PassiveState> {
 
       AppendRequest request = AppendRequest.builder()
         .withTerm(1)
-        .withLeader(serverState.getCluster().getActiveMembers().iterator().next().getServerAddress().hashCode())
+        .withLeader(serverState.getCluster().getRemoteMembers(RaftMemberType.ACTIVE).iterator().next().id())
         .withLogIndex(1)
         .withLogTerm(1)
         .withEntries(new TestEntry().setIndex(2).setTerm(1))
@@ -190,7 +190,7 @@ public class PassiveStateTest extends AbstractStateTest<PassiveState> {
 
       AppendRequest request = AppendRequest.builder()
         .withTerm(2)
-        .withLeader(serverState.getCluster().getActiveMembers().iterator().next().getServerAddress().hashCode())
+        .withLeader(serverState.getCluster().getRemoteMembers(RaftMemberType.ACTIVE).iterator().next().id())
         .withLogIndex(2)
         .withLogTerm(2)
         .build();
@@ -210,7 +210,7 @@ public class PassiveStateTest extends AbstractStateTest<PassiveState> {
 
       AppendRequest request = AppendRequest.builder()
         .withTerm(1)
-        .withLeader(serverState.getCluster().getActiveMembers().iterator().next().getServerAddress().hashCode())
+        .withLeader(serverState.getCluster().getRemoteMembers(RaftMemberType.ACTIVE).iterator().next().id())
         .withLogIndex(0)
         .withLogTerm(0)
         .withEntries(new TestEntry().setIndex(1).setTerm(1))
@@ -235,7 +235,7 @@ public class PassiveStateTest extends AbstractStateTest<PassiveState> {
 
       AppendRequest request = AppendRequest.builder()
         .withTerm(1)
-        .withLeader(serverState.getCluster().getActiveMembers().iterator().next().getServerAddress().hashCode())
+        .withLeader(serverState.getCluster().getRemoteMembers(RaftMemberType.ACTIVE).iterator().next().id())
         .withLogIndex(0)
         .withLogTerm(0)
         .withEntries(new TestEntry().setIndex(2).setTerm(1))
@@ -261,7 +261,7 @@ public class PassiveStateTest extends AbstractStateTest<PassiveState> {
 
       AppendRequest request = AppendRequest.builder()
         .withTerm(3)
-        .withLeader(serverState.getCluster().getActiveMembers().iterator().next().getServerAddress().hashCode())
+        .withLeader(serverState.getCluster().getRemoteMembers(RaftMemberType.ACTIVE).iterator().next().id())
         .withLogIndex(1)
         .withLogTerm(1)
         .withEntries(new TestEntry().setIndex(2).setTerm(2), new TestEntry().setIndex(3).setTerm(3), new TestEntry().setIndex(4).setTerm(3))
@@ -288,7 +288,7 @@ public class PassiveStateTest extends AbstractStateTest<PassiveState> {
 
       AppendRequest request = AppendRequest.builder()
         .withTerm(1)
-        .withLeader(serverState.getCluster().getActiveMembers().iterator().next().getServerAddress().hashCode())
+        .withLeader(serverState.getCluster().getRemoteMembers(RaftMemberType.ACTIVE).iterator().next().id())
         .withLogIndex(1)
         .withLogTerm(1)
         .withEntries(new TestEntry().setIndex(2).setTerm(1), new TestEntry().setIndex(4).setTerm(1))

--- a/server/src/test/java/io/atomix/copycat/server/state/PassiveStateTest.java
+++ b/server/src/test/java/io/atomix/copycat/server/state/PassiveStateTest.java
@@ -103,7 +103,7 @@ public class PassiveStateTest extends AbstractStateTest<PassiveState> {
 
   public void testAppendTermAndLeaderUpdated() throws Throwable {
     runOnServer(() -> {
-      int leader = serverState.getCluster().getRemoteMembers(RaftMemberType.ACTIVE).iterator().next().id();
+      int leader = serverState.getCluster().getVotingMembers().iterator().next().id();
       serverState.setTerm(1);
       AppendRequest request = AppendRequest.builder()
         .withTerm(2)
@@ -129,7 +129,7 @@ public class PassiveStateTest extends AbstractStateTest<PassiveState> {
 
       AppendRequest request = AppendRequest.builder()
         .withTerm(1)
-        .withLeader(serverState.getCluster().getRemoteMembers(RaftMemberType.ACTIVE).iterator().next().id())
+        .withLeader(serverState.getCluster().getVotingMembers().iterator().next().id())
         .withLogIndex(2)
         .withLogTerm(2)
         .withCommitIndex(0)
@@ -152,7 +152,7 @@ public class PassiveStateTest extends AbstractStateTest<PassiveState> {
 
       AppendRequest request = AppendRequest.builder()
         .withTerm(2)
-        .withLeader(serverState.getCluster().getRemoteMembers(RaftMemberType.ACTIVE).iterator().next().id())
+        .withLeader(serverState.getCluster().getVotingMembers().iterator().next().id())
         .withLogIndex(2)
         .withLogTerm(2)
         .withCommitIndex(0)
@@ -175,7 +175,7 @@ public class PassiveStateTest extends AbstractStateTest<PassiveState> {
 
       AppendRequest request = AppendRequest.builder()
         .withTerm(1)
-        .withLeader(serverState.getCluster().getRemoteMembers(RaftMemberType.ACTIVE).iterator().next().id())
+        .withLeader(serverState.getCluster().getVotingMembers().iterator().next().id())
         .withLogIndex(1)
         .withLogTerm(1)
         .withCommitIndex(0)
@@ -199,7 +199,7 @@ public class PassiveStateTest extends AbstractStateTest<PassiveState> {
 
       AppendRequest request = AppendRequest.builder()
         .withTerm(2)
-        .withLeader(serverState.getCluster().getRemoteMembers(RaftMemberType.ACTIVE).iterator().next().id())
+        .withLeader(serverState.getCluster().getVotingMembers().iterator().next().id())
         .withLogIndex(2)
         .withLogTerm(2)
         .withCommitIndex(0)
@@ -221,7 +221,7 @@ public class PassiveStateTest extends AbstractStateTest<PassiveState> {
 
       AppendRequest request = AppendRequest.builder()
         .withTerm(1)
-        .withLeader(serverState.getCluster().getRemoteMembers(RaftMemberType.ACTIVE).iterator().next().id())
+        .withLeader(serverState.getCluster().getVotingMembers().iterator().next().id())
         .withLogIndex(0)
         .withLogTerm(0)
         .withCommitIndex(0)
@@ -248,7 +248,7 @@ public class PassiveStateTest extends AbstractStateTest<PassiveState> {
 
       AppendRequest request = AppendRequest.builder()
         .withTerm(1)
-        .withLeader(serverState.getCluster().getRemoteMembers(RaftMemberType.ACTIVE).iterator().next().id())
+        .withLeader(serverState.getCluster().getVotingMembers().iterator().next().id())
         .withLogIndex(0)
         .withLogTerm(0)
         .withCommitIndex(0)
@@ -276,7 +276,7 @@ public class PassiveStateTest extends AbstractStateTest<PassiveState> {
 
       AppendRequest request = AppendRequest.builder()
         .withTerm(3)
-        .withLeader(serverState.getCluster().getRemoteMembers(RaftMemberType.ACTIVE).iterator().next().id())
+        .withLeader(serverState.getCluster().getVotingMembers().iterator().next().id())
         .withLogIndex(1)
         .withLogTerm(1)
         .withCommitIndex(0)
@@ -305,7 +305,7 @@ public class PassiveStateTest extends AbstractStateTest<PassiveState> {
 
       AppendRequest request = AppendRequest.builder()
         .withTerm(1)
-        .withLeader(serverState.getCluster().getRemoteMembers(RaftMemberType.ACTIVE).iterator().next().id())
+        .withLeader(serverState.getCluster().getVotingMembers().iterator().next().id())
         .withLogIndex(1)
         .withLogTerm(1)
         .withCommitIndex(0)

--- a/server/src/test/java/io/atomix/copycat/server/state/ServerStateTest.java
+++ b/server/src/test/java/io/atomix/copycat/server/state/ServerStateTest.java
@@ -15,22 +15,16 @@
  */
 package io.atomix.copycat.server.state;
 
-import java.util.function.Consumer;
-
-import org.testng.annotations.AfterMethod;
-import org.testng.annotations.BeforeMethod;
-import org.testng.annotations.Test;
-
-import io.atomix.catalyst.transport.Client;
-import io.atomix.catalyst.transport.Connection;
-import io.atomix.catalyst.transport.LocalServerRegistry;
-import io.atomix.catalyst.transport.LocalTransport;
-import io.atomix.catalyst.transport.Server;
-import io.atomix.catalyst.transport.Transport;
+import io.atomix.catalyst.transport.*;
 import io.atomix.catalyst.util.concurrent.SingleThreadContext;
 import io.atomix.catalyst.util.concurrent.ThreadContext;
 import io.atomix.copycat.client.request.Request;
 import io.atomix.copycat.client.response.Response;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import java.util.function.Consumer;
 
 /**
  * Server context test.
@@ -61,7 +55,7 @@ public class ServerStateTest extends AbstractStateTest<AbstractState> {
     client = transport.client();
 
     serverCtx.execute(() -> {
-      server.listen(members.get(0), serverState::connect).whenComplete((result, error) -> {
+      server.listen(members.get(0).clientAddress(), serverState::connectClient).whenComplete((result, error) -> {
         threadAssertNull(error);
         resume();
       });
@@ -69,7 +63,7 @@ public class ServerStateTest extends AbstractStateTest<AbstractState> {
     await();
 
     clientCtx.execute(() -> {
-      client.connect(members.get(0)).whenComplete((result, error) -> {
+      client.connect(members.get(0).clientAddress()).whenComplete((result, error) -> {
         threadAssertNull(error);
         this.connection = result;
         resume();

--- a/test/src/test/java/io/atomix/copycat/test/ClusterTest.java
+++ b/test/src/test/java/io/atomix/copycat/test/ClusterTest.java
@@ -27,6 +27,7 @@ import io.atomix.copycat.server.CopycatServer;
 import io.atomix.copycat.server.RaftServer;
 import io.atomix.copycat.server.StateMachine;
 import io.atomix.copycat.server.state.Member;
+import io.atomix.copycat.server.state.RaftMemberType;
 import io.atomix.copycat.server.storage.Storage;
 import io.atomix.copycat.server.storage.StorageLevel;
 import net.jodah.concurrentunit.ConcurrentTestCase;
@@ -950,7 +951,7 @@ public class ClusterTest extends ConcurrentTestCase {
    * @return The next server address.
    */
   private Member nextMember() {
-    Member member = new Member(new Address("localhost", ++port), new Address("localhost", port + 1000));
+    Member member = new Member(RaftMemberType.ACTIVE, new Address("localhost", ++port), new Address("localhost", port + 1000));
     members.add(member);
     return member;
   }
@@ -1037,7 +1038,7 @@ public class ClusterTest extends ConcurrentTestCase {
     clients.forEach(c -> c.close().join());
     if (servers.size() < count) {
       for (int i = servers.size(); i < count; i++) {
-        createServer(new Member(new Address("localhost", 5000 + i), new Address("localhost", 6000 + i))).open().join();
+        createServer(new Member(RaftMemberType.ACTIVE, new Address("localhost", 5000 + i), new Address("localhost", 6000 + i))).open().join();
       }
     }
 


### PR DESCRIPTION
This PR improves the client/server communication interfaces by supporting *optional* separate `Address`es for clients and servers. Each server can specify a client `Address` and `Transport` through which clients can communicate with the server. This will potentially allow for different types of transports and protocols in the future. The addition of client addresses necessitated some significant cleanup of the configuration system. In order to ensure client addresses are propagated, servers submit a `JoinRequest` to the leader which logs and replicates it as a normal configuration change. This means configuration changes now take place absent the actual quorum size changing as they're used to essentially identify nodes.

This PR should be reviewed by going through the commits sequentially. They should be easy to understand. Commits towards the end are mostly bug fixes.