### PR TITLE
Use volatile keyword for fields participating in double-checked locking

### DIFF
--- a/client/src/main/java/io/atomix/copycat/client/CopycatClient.java
+++ b/client/src/main/java/io/atomix/copycat/client/CopycatClient.java
@@ -117,9 +117,9 @@ public class CopycatClient implements RaftClient {
   private final Serializer serializer;
   private final ConnectionStrategy connectionStrategy;
   private final RecoveryStrategy recoveryStrategy;
-  private ClientSession session;
-  private CompletableFuture<RaftClient> openFuture;
-  private CompletableFuture<Void> closeFuture;
+  private volatile ClientSession session;
+  private volatile CompletableFuture<RaftClient> openFuture;
+  private volatile CompletableFuture<Void> closeFuture;
 
   protected CopycatClient(Transport transport, Collection<Address> members, Serializer serializer, ConnectionStrategy connectionStrategy, RecoveryStrategy recoveryStrategy) {
     serializer.resolve(new ServiceLoaderTypeResolver());

--- a/server/src/main/java/io/atomix/copycat/server/CopycatServer.java
+++ b/server/src/main/java/io/atomix/copycat/server/CopycatServer.java
@@ -160,8 +160,8 @@ public class CopycatServer implements RaftServer {
   }
 
   private final ServerContext context;
-  private CompletableFuture<RaftServer> openFuture;
-  private CompletableFuture<Void> closeFuture;
+  private volatile CompletableFuture<RaftServer> openFuture;
+  private volatile CompletableFuture<Void> closeFuture;
   private ServerState state;
   private final Duration electionTimeout;
   private final Duration heartbeatInterval;


### PR DESCRIPTION
In order to force the compiler to not optimize access to a locally unchanged variable when entering a synchronized block, the variable needs to be defined as "volatile". See for example https://en.wikipedia.org/wiki/Double-checked_locking#Usage_in_Java.