### PR TITLE
Count last segment in major compaction manager's uncleaned entry count

### DIFF
--- a/server/src/main/java/io/atomix/copycat/server/storage/compaction/MajorCompactionManager.java
+++ b/server/src/main/java/io/atomix/copycat/server/storage/compaction/MajorCompactionManager.java
@@ -76,8 +76,8 @@ public final class MajorCompactionManager implements CompactionManager {
         segments.add(segment);
       }
       // If the total size of all segments is less than the maximum size of any segment, add the segment to the segments list.
-      else if (segments.stream().mapToLong(Segment::size).sum() + segment.size() < storage.maxSegmentSize()
-        && segments.stream().mapToLong(s -> s.count() - s.cleanCount()).sum() + (segment.count() - segment.cleanCount()) < storage.maxEntriesPerSegment()) {
+      else if (segments.stream().mapToLong(Segment::size).sum() + segment.size() <= storage.maxSegmentSize()
+        && segments.stream().mapToLong(s -> s.count() - s.cleanCount()).sum() + (segment.count() - segment.cleanCount()) <= storage.maxEntriesPerSegment()) {
         segments.add(segment);
       }
       // If there's not enough room to combine segments, reset the segments list.

--- a/server/src/main/java/io/atomix/copycat/server/storage/compaction/MajorCompactionManager.java
+++ b/server/src/main/java/io/atomix/copycat/server/storage/compaction/MajorCompactionManager.java
@@ -77,7 +77,7 @@ public final class MajorCompactionManager implements CompactionManager {
       }
       // If the total size of all segments is less than the maximum size of any segment, add the segment to the segments list.
       else if (segments.stream().mapToLong(Segment::size).sum() + segment.size() < storage.maxSegmentSize()
-        && segments.stream().mapToLong(s -> s.count() - s.cleanCount()).sum() < storage.maxEntriesPerSegment()) {
+        && segments.stream().mapToLong(s -> s.count() - s.cleanCount()).sum() + (segment.count() - segment.cleanCount()) < storage.maxEntriesPerSegment()) {
         segments.add(segment);
       }
       // If there's not enough room to combine segments, reset the segments list.


### PR DESCRIPTION
The `MajorCompactionManager` calculates a set of segments for which to perform major compaction by aggregating a group of segments that can be combined into a single segment. But the current implementation does not properly take into account the last segment when determining whether the total number of entries in the resulting compacted segment will be less than the configured `maxEntriesPerSegment`. This can result in the compact segment exceeding the `maxEntriesPerSegment` and an exception being thrown. This PR ensures the last segment is included in that calculation and also uses `<=` checks rather than `<` for comparisons.