### PR TITLE
Add client connection strategies

### DIFF
--- a/client/src/main/java/io/atomix/copycat/client/ConnectionStrategies.java
+++ b/client/src/main/java/io/atomix/copycat/client/ConnectionStrategies.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License
+ */
+package io.atomix.copycat.client;
+
+import java.time.Duration;
+
+/**
+ * Basic connection strategies.
+ *
+ * @author <a href="http://github.com/kuujo>Jordan Halterman</a>
+ */
+public enum ConnectionStrategies implements ConnectionStrategy {
+
+  /**
+   * Attempts to connect to the cluster one time and fails.
+   */
+  ONCE {
+    @Override
+    public void attemptFailed(Attempt attempt) {
+      attempt.fail();
+    }
+  },
+
+  /**
+   * Attempts to connect to the cluster using exponential backoff up to a one minute retry interval.
+   */
+  BACKOFF {
+    @Override
+    public void attemptFailed(Attempt attempt) {
+      attempt.retry(Duration.ofSeconds(Math.min(attempt.attempt() * attempt.attempt(), 60)));
+    }
+  }
+
+}

--- a/client/src/main/java/io/atomix/copycat/client/ConnectionStrategy.java
+++ b/client/src/main/java/io/atomix/copycat/client/ConnectionStrategy.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License
+ */
+package io.atomix.copycat.client;
+
+import java.time.Duration;
+
+/**
+ * Connection strategies define how clients should handle initializing connections to the cluster.
+ *
+ * @author <a href="http://github.com/kuujo>Jordan Halterman</a>
+ */
+public interface ConnectionStrategy {
+
+  /**
+   * Called when an attempt to connect to the cluster fails.
+   *
+   * @param attempt The failed attempt.
+   */
+  void attemptFailed(Attempt attempt);
+
+  /**
+   * Represents a failed attempt at connecting to the server.
+   */
+  interface Attempt {
+
+    /**
+     * Indicates the number of attempts.
+     *
+     * @return The number of attempts.
+     */
+    int attempt();
+
+    /**
+     * Fails the connection attempt.
+     */
+    void fail();
+
+    /**
+     * Retries connecting to the cluster.
+     */
+    void retry();
+
+    /**
+     * Retries connecting to the cluster after the given duration.
+     *
+     * @param after The duration after which to retry the connect attempt.
+     */
+    void retry(Duration after);
+
+  }
+
+}

--- a/client/src/main/java/io/atomix/copycat/client/CopycatClient.java
+++ b/client/src/main/java/io/atomix/copycat/client/CopycatClient.java
@@ -296,7 +296,7 @@ public interface CopycatClient extends Managed<CopycatClient> {
     private Transport transport;
     private Serializer serializer;
     private Set<Address> members;
-    private ConnectionStrategy connectionStrategy = ConnectionStrategies.FOLLOWERS;
+    private SubmissionStrategy submissionStrategy = SubmissionStrategies.FOLLOWERS;
     private RecoveryStrategy recoveryStrategy = RecoveryStrategies.CLOSE;
 
     private Builder(Collection<Address> members) {
@@ -333,13 +333,13 @@ public interface CopycatClient extends Managed<CopycatClient> {
     }
 
     /**
-     * Sets the client connection strategy.
+     * Sets the client submission strategy.
      *
-     * @param connectionStrategy The client connection strategy.
+     * @param submissionStrategy The client submission strategy.
      * @return The client builder.
      */
-    public Builder withConnectionStrategy(ConnectionStrategy connectionStrategy) {
-      this.connectionStrategy = Assert.notNull(connectionStrategy, "connectionStrategy");
+    public Builder withSubmissionStrategy(SubmissionStrategy submissionStrategy) {
+      this.submissionStrategy = Assert.notNull(submissionStrategy, "submissionStrategy");
       return this;
     }
 
@@ -373,7 +373,7 @@ public interface CopycatClient extends Managed<CopycatClient> {
       if (serializer == null) {
         serializer = new Serializer();
       }
-      return new DefaultCopycatClient(transport, members, serializer, connectionStrategy, recoveryStrategy);
+      return new DefaultCopycatClient(transport, members, serializer, submissionStrategy, recoveryStrategy);
     }
   }
 

--- a/client/src/main/java/io/atomix/copycat/client/CopycatClient.java
+++ b/client/src/main/java/io/atomix/copycat/client/CopycatClient.java
@@ -296,6 +296,7 @@ public interface CopycatClient extends Managed<CopycatClient> {
     private Transport transport;
     private Serializer serializer;
     private Set<Address> members;
+    private ConnectionStrategy connectionStrategy = ConnectionStrategies.ONCE;
     private SubmissionStrategy submissionStrategy = SubmissionStrategies.FOLLOWERS;
     private RecoveryStrategy recoveryStrategy = RecoveryStrategies.CLOSE;
 
@@ -329,6 +330,18 @@ public interface CopycatClient extends Managed<CopycatClient> {
      */
     public Builder withSerializer(Serializer serializer) {
       this.serializer = Assert.notNull(serializer, "serializer");
+      return this;
+    }
+
+    /**
+     * Sets the client connection strategy.
+     *
+     * @param connectionStrategy The client connection strategy.
+     * @return The client builder.
+     * @throws NullPointerException If the connection strategy is {@code null}
+     */
+    public Builder withConnectionStrategy(ConnectionStrategy connectionStrategy) {
+      this.connectionStrategy = Assert.notNull(connectionStrategy, "connectionStrategy");
       return this;
     }
 
@@ -373,7 +386,7 @@ public interface CopycatClient extends Managed<CopycatClient> {
       if (serializer == null) {
         serializer = new Serializer();
       }
-      return new DefaultCopycatClient(transport, members, serializer, submissionStrategy, recoveryStrategy);
+      return new DefaultCopycatClient(transport, members, serializer, connectionStrategy, submissionStrategy, recoveryStrategy);
     }
   }
 

--- a/client/src/main/java/io/atomix/copycat/client/DefaultCopycatClient.java
+++ b/client/src/main/java/io/atomix/copycat/client/DefaultCopycatClient.java
@@ -86,18 +86,18 @@ public class DefaultCopycatClient implements CopycatClient {
   private final Transport transport;
   private final Collection<Address> members;
   private final Serializer serializer;
-  private final ConnectionStrategy connectionStrategy;
+  private final SubmissionStrategy submissionStrategy;
   private final RecoveryStrategy recoveryStrategy;
   private volatile ClientSession session;
   private volatile CompletableFuture<CopycatClient> openFuture;
   private volatile CompletableFuture<Void> closeFuture;
 
-  protected DefaultCopycatClient(Transport transport, Collection<Address> members, Serializer serializer, ConnectionStrategy connectionStrategy, RecoveryStrategy recoveryStrategy) {
+  protected DefaultCopycatClient(Transport transport, Collection<Address> members, Serializer serializer, SubmissionStrategy submissionStrategy, RecoveryStrategy recoveryStrategy) {
     serializer.resolve(new ServiceLoaderTypeResolver());
     this.transport = Assert.notNull(transport, "transport");
     this.members = Assert.notNull(members, "members");
     this.serializer = Assert.notNull(serializer, "serializer");
-    this.connectionStrategy = Assert.notNull(connectionStrategy, "connectionStrategy");
+    this.submissionStrategy = Assert.notNull(submissionStrategy, "submissionStrategy");
     this.recoveryStrategy = Assert.notNull(recoveryStrategy, "recoveryStrategy");
   }
 
@@ -145,7 +145,7 @@ public class DefaultCopycatClient implements CopycatClient {
     if (openFuture == null) {
       synchronized (this) {
         if (openFuture == null) {
-          ClientSession session = new ClientSession(id, transport, members, serializer, connectionStrategy);
+          ClientSession session = new ClientSession(id, transport, members, serializer, submissionStrategy);
           if (closeFuture == null) {
             openFuture = session.open().thenApply(s -> {
               synchronized (this) {

--- a/client/src/main/java/io/atomix/copycat/client/DefaultCopycatClient.java
+++ b/client/src/main/java/io/atomix/copycat/client/DefaultCopycatClient.java
@@ -86,17 +86,19 @@ public class DefaultCopycatClient implements CopycatClient {
   private final Transport transport;
   private final Collection<Address> members;
   private final Serializer serializer;
+  private final ConnectionStrategy connectionStrategy;
   private final SubmissionStrategy submissionStrategy;
   private final RecoveryStrategy recoveryStrategy;
   private volatile ClientSession session;
   private volatile CompletableFuture<CopycatClient> openFuture;
   private volatile CompletableFuture<Void> closeFuture;
 
-  protected DefaultCopycatClient(Transport transport, Collection<Address> members, Serializer serializer, SubmissionStrategy submissionStrategy, RecoveryStrategy recoveryStrategy) {
+  protected DefaultCopycatClient(Transport transport, Collection<Address> members, Serializer serializer, ConnectionStrategy connectionStrategy, SubmissionStrategy submissionStrategy, RecoveryStrategy recoveryStrategy) {
     serializer.resolve(new ServiceLoaderTypeResolver());
     this.transport = Assert.notNull(transport, "transport");
     this.members = Assert.notNull(members, "members");
     this.serializer = Assert.notNull(serializer, "serializer");
+    this.connectionStrategy = Assert.notNull(connectionStrategy, "connectionStrategy");
     this.submissionStrategy = Assert.notNull(submissionStrategy, "submissionStrategy");
     this.recoveryStrategy = Assert.notNull(recoveryStrategy, "recoveryStrategy");
   }
@@ -145,7 +147,7 @@ public class DefaultCopycatClient implements CopycatClient {
     if (openFuture == null) {
       synchronized (this) {
         if (openFuture == null) {
-          ClientSession session = new ClientSession(id, transport, members, serializer, submissionStrategy);
+          ClientSession session = new ClientSession(id, transport, members, serializer, connectionStrategy, submissionStrategy);
           if (closeFuture == null) {
             openFuture = session.open().thenApply(s -> {
               synchronized (this) {

--- a/client/src/main/java/io/atomix/copycat/client/SubmissionStrategies.java
+++ b/client/src/main/java/io/atomix/copycat/client/SubmissionStrategies.java
@@ -24,17 +24,17 @@ import java.util.stream.Collectors;
 /**
  * Strategies for managing how clients connect to and communicate with the cluster.
  * <p>
- * Connection strategies manage which servers a client attempts to contact and submit operations
- * to. Clients can communicate with followers, leaders, or both. Connection strategies offer the
+ * Submission strategies manage which servers a client attempts to contact and submit operations
+ * to. Clients can communicate with followers, leaders, or both. Submission strategies offer the
  * option for clients to spread connections across the cluster for scalability or connect to the
  * cluster's leader for performance.
  *
  * @author <a href="http://github.com/kuujo>Jordan Halterman</a>
  */
-public enum ConnectionStrategies implements ConnectionStrategy {
+public enum SubmissionStrategies implements SubmissionStrategy {
 
   /**
-   * The {@code ANY} connection strategy allows the client to connect to any server in the cluster. Clients
+   * The {@code ANY} submission strategy allows the client to connect to any server in the cluster. Clients
    * will attempt to connect to a random server, and the client will persist its connection with the first server
    * through which it is able to communicate. If the client becomes disconnected from a server, it will attempt
    * to connect to the next random server again.
@@ -47,7 +47,7 @@ public enum ConnectionStrategies implements ConnectionStrategy {
   },
 
   /**
-   * The {@code LEADER} connection strategy forces the client to attempt to connect to the cluster's leader.
+   * The {@code LEADER} submission strategy forces the client to attempt to connect to the cluster's leader.
    * Connecting to the leader means the client's operations are always handled by the first server to receive
    * them. However, clients connected to the leader will not significantly benefit from {@link Query queries}
    * with lower consistency levels, and more clients connected to the leader could mean more load on a single
@@ -63,7 +63,7 @@ public enum ConnectionStrategies implements ConnectionStrategy {
   },
 
   /**
-   * The {@code FOLLOWERS} connection strategy forces the client to connect only to followers. Connecting to
+   * The {@code FOLLOWERS} submission strategy forces the client to connect only to followers. Connecting to
    * followers ensures that the leader is not overloaded with direct client requests. This strategy should be
    * used when clients frequently submit {@link Query queries} with lower consistency levels that don't need to
    * be forwarded to the cluster leader. For clients that frequently submit commands or queries with linearizable

--- a/client/src/main/java/io/atomix/copycat/client/SubmissionStrategy.java
+++ b/client/src/main/java/io/atomix/copycat/client/SubmissionStrategy.java
@@ -20,16 +20,16 @@ import io.atomix.catalyst.transport.Address;
 import java.util.List;
 
 /**
- * Strategy for managing client connections.
+ * Strategy for submitting operations to the cluster.
  * <p>
- * Connection strategies are responsible for defining the servers to which a client can connect.
+ * Submission strategies are responsible for defining the servers to which a client can connect.
  *
  * @author <a href="http://github.com/kuujo>Jordan Halterman</a>
  */
-public interface ConnectionStrategy {
+public interface SubmissionStrategy {
 
   /**
-   * Returns a list of servers to which the client can connect.
+   * Returns a list of servers to which the client can submit operations.
    *
    * @param leader The current cluster leader.
    * @param servers The current list of servers.

--- a/client/src/main/java/io/atomix/copycat/client/session/ClientSession.java
+++ b/client/src/main/java/io/atomix/copycat/client/session/ClientSession.java
@@ -29,8 +29,9 @@ import io.atomix.catalyst.util.concurrent.Scheduled;
 import io.atomix.catalyst.util.concurrent.SingleThreadContext;
 import io.atomix.catalyst.util.concurrent.ThreadContext;
 import io.atomix.copycat.client.Command;
-import io.atomix.copycat.client.SubmissionStrategy;
+import io.atomix.copycat.client.ConnectionStrategy;
 import io.atomix.copycat.client.Query;
+import io.atomix.copycat.client.SubmissionStrategy;
 import io.atomix.copycat.client.error.RaftError;
 import io.atomix.copycat.client.error.UnknownSessionException;
 import io.atomix.copycat.client.request.*;
@@ -86,6 +87,7 @@ public class ClientSession implements Session, Managed<Session> {
   private Address leader;
   private Set<Address> members;
   private final ThreadContext context;
+  private final ConnectionStrategy connectionStrategy;
   private final SubmissionStrategy submissionStrategy;
   private List<Address> connectMembers;
   private Connection connection;
@@ -109,11 +111,12 @@ public class ClientSession implements Session, Managed<Session> {
   private long eventVersion;
   private long completeVersion;
 
-  public ClientSession(UUID clientId, Transport transport, Collection<Address> members, Serializer serializer, SubmissionStrategy submissionStrategy) {
+  public ClientSession(UUID clientId, Transport transport, Collection<Address> members, Serializer serializer, ConnectionStrategy connectionStrategy, SubmissionStrategy submissionStrategy) {
     this.clientId = Assert.notNull(clientId, "clientId");
     this.client = Assert.notNull(transport, "transport").client();
     this.members = new HashSet<>(Assert.notNull(members, "members"));
     this.context = new SingleThreadContext("copycat-client-" + clientId.toString(), Assert.notNull(serializer, "serializer").clone());
+    this.connectionStrategy = Assert.notNull(connectionStrategy, "connectionStrategy");
     this.submissionStrategy = Assert.notNull(submissionStrategy, "submissionStrategy");
     this.connectMembers = submissionStrategy.getConnections(leader, new ArrayList<>(members));
   }
@@ -615,7 +618,7 @@ public class ClientSession implements Session, Managed<Session> {
   /**
    * Registers the session.
    */
-  private CompletableFuture<Void> register() {
+  private CompletableFuture<Void> register(final int attempt) {
     context.checkThread();
 
     CompletableFuture<Void> future = new CompletableFuture<>();
@@ -634,13 +637,40 @@ public class ClientSession implements Session, Managed<Session> {
           setupConnection(connection).whenComplete((setupResult, setupError) -> future.complete(null));
           resetConnection().resetMembers().keepAlive(Duration.ofMillis(Math.round(response.timeout() * KEEP_ALIVE_RATIO)));
         } else {
-          future.completeExceptionally(response.error().createException());
+          registerFailed(attempt, response.error().createException(), future);
         }
       } else {
-        future.completeExceptionally(error);
+        registerFailed(attempt, error, future);
       }
     });
     return future;
+  }
+
+  /**
+   * Handles the failure of a register attempt.
+   */
+  private void registerFailed(int attempt, Throwable failure, CompletableFuture<Void> future) {
+    connectionStrategy.attemptFailed(new ConnectionStrategy.Attempt() {
+      @Override
+      public int attempt() {
+        return attempt;
+      }
+
+      @Override
+      public void fail() {
+        future.completeExceptionally(failure);
+      }
+
+      @Override
+      public void retry() {
+        register(attempt + 1);
+      }
+
+      @Override
+      public void retry(Duration after) {
+        context.schedule(after, () -> register(attempt + 1));
+      }
+    });
   }
 
   /**
@@ -704,7 +734,7 @@ public class ClientSession implements Session, Managed<Session> {
   @Override
   public CompletableFuture<Session> open() {
     CompletableFuture<Session> future = new CompletableFuture<>();
-    context.executor().execute(() -> register().whenComplete((result, error) -> {
+    context.executor().execute(() -> register(1).whenComplete((result, error) -> {
       if (error == null) {
         this.state = State.OPEN;
         future.complete(this);


### PR DESCRIPTION
This PR renames the old `ConnectionStrategy` interface to `SubmissionStrategy` and adds a separate `ConnectionStrategy` that defines how to handle connecting to the cluster and initializing a session.