### PR TITLE
Clean up client connection processes

### DIFF
--- a/client/src/main/java/io/atomix/copycat/client/session/ClientSession.java
+++ b/client/src/main/java/io/atomix/copycat/client/session/ClientSession.java
@@ -419,7 +419,8 @@ public class ClientSession implements Session, Managed<Session> {
           // If the session timeout has not expired, attempt to maintain the client's session by retrying
           // after a short amount of time.
           else {
-            retry = context.schedule(Duration.ofMillis(200), ClientSession.this::retryRequests);
+            if (retry == null)
+              retry = context.schedule(Duration.ofMillis(200), ClientSession.this::retryRequests);
             retries.add(() -> {
               LOGGER.debug("Retrying {}", request);
               request(request, attempt, future, checkOpen);


### PR DESCRIPTION
This PR refactors the process by which clients connect to and communicate with the cluster. This is related to #70 

The code is fairly complex and difficult to follow simply because everything is asynchronous and thus recursive. The major changes are these:
* Only expire the client's session if it fails to connect to and submit a `ConnectRequest` or `KeepAliveRequest` to *all* members of the cluster
* `ConnectionStrategy`s are used to handle failures to connect to the cluster
* Live sessions will always attempt to reconnect to the cluster and resubmit keep-alive requests as quickly as possible before the session timeout expires
* Failures wherein the client can successfully connect to the cluster but can't submit commands for other reasons will be handled by the configured `ConnectionStrategy`.