### PR TITLE
Remove configuration/install warnings when failing to connect to server

### DIFF
--- a/server/src/main/java/io/atomix/copycat/server/state/AbstractAppender.java
+++ b/server/src/main/java/io/atomix/copycat/server/state/AbstractAppender.java
@@ -78,7 +78,6 @@ abstract class AbstractAppender implements AutoCloseable {
         if (error == null) {
           sendConfigureRequest(connection, member, request);
         } else {
-          LOGGER.warn("{} - Failed to configure {}", context.getCluster().getMember().serverAddress(), member.getMember().serverAddress());
           configuring.remove(member);
         }
       }
@@ -131,7 +130,6 @@ abstract class AbstractAppender implements AutoCloseable {
         if (error == null) {
           sendInstallRequest(connection, member, request);
         } else {
-          LOGGER.warn("{} - Failed to replicate snapshot to {}", context.getCluster().getMember().serverAddress(), member.getMember().serverAddress());
           installing.remove(member);
         }
       }


### PR DESCRIPTION
This PR removes some of the warning messages related to replicating configurations and snapshots. 