### PR TITLE
Recalculate completeIndex only after entries have been applied

### DIFF
--- a/server/src/main/java/io/atomix/copycat/server/state/LeaderState.java
+++ b/server/src/main/java/io/atomix/copycat/server/state/LeaderState.java
@@ -139,9 +139,7 @@ final class LeaderState extends ActiveState {
   private void appendMembers() {
     context.checkThread();
     if (isOpen()) {
-      appender.appendEntries().whenComplete((result, error) -> {
-        context.getLog().compactor().minorIndex(context.getStateMachine().getLastCompleted());
-      });
+      appender.appendEntries();
     }
   }
 


### PR DESCRIPTION
This PR fixes a race condition in the internal `ServerStateMachine` when calculating the `completeIndex`. The problem is, the `completeIndex` was being calculated in the server thread prior to the command being actually applied to the state machine. This meant that state machine events were published *after* the `completeIndex` was calculated. This could result in `completeIndex` being improperly decreased if later calculated after events were published by the state machine.