### PR TITLE
Support reading and writing objects in snapshots

### DIFF
--- a/server/src/main/java/io/atomix/copycat/server/storage/snapshot/FileSnapshot.java
+++ b/server/src/main/java/io/atomix/copycat/server/storage/snapshot/FileSnapshot.java
@@ -60,7 +60,7 @@ final class FileSnapshot extends Snapshot {
     descriptor.copyTo(buffer);
 
     int length = buffer.position(SnapshotDescriptor.BYTES).readInt();
-    return openWriter(new SnapshotWriter(buffer.skip(length).mark(), this), descriptor);
+    return openWriter(new SnapshotWriter(buffer.skip(length).mark(), this, store.storage.serializer()), descriptor);
   }
 
   @Override
@@ -76,7 +76,7 @@ final class FileSnapshot extends Snapshot {
     Buffer buffer = FileBuffer.allocate(file.file(), SnapshotDescriptor.BYTES, store.storage.maxSnapshotSize());
     SnapshotDescriptor descriptor = new SnapshotDescriptor(buffer);
     int length = buffer.position(SnapshotDescriptor.BYTES).readInt();
-    return openReader(new SnapshotReader(buffer.mark().limit(SnapshotDescriptor.BYTES + Integer.BYTES + length), this), descriptor);
+    return openReader(new SnapshotReader(buffer.mark().limit(SnapshotDescriptor.BYTES + Integer.BYTES + length), this, store.storage.serializer()), descriptor);
   }
 
   @Override

--- a/server/src/main/java/io/atomix/copycat/server/storage/snapshot/MemorySnapshot.java
+++ b/server/src/main/java/io/atomix/copycat/server/storage/snapshot/MemorySnapshot.java
@@ -26,6 +26,7 @@ import io.atomix.catalyst.util.Assert;
 final class MemorySnapshot extends Snapshot {
   private final HeapBuffer buffer;
   private final SnapshotDescriptor descriptor;
+  private final SnapshotStore store;
 
   MemorySnapshot(HeapBuffer buffer, SnapshotDescriptor descriptor, SnapshotStore store) {
     super(store);
@@ -33,6 +34,7 @@ final class MemorySnapshot extends Snapshot {
     this.buffer = Assert.notNull(buffer, "buffer");
     this.buffer.position(SnapshotDescriptor.BYTES).mark();
     this.descriptor = Assert.notNull(descriptor, "descriptor");
+    this.store = Assert.notNull(store, "store");
   }
 
   @Override
@@ -48,7 +50,7 @@ final class MemorySnapshot extends Snapshot {
   @Override
   public SnapshotWriter writer() {
     checkWriter();
-    return new SnapshotWriter(buffer.reset().slice(), this);
+    return new SnapshotWriter(buffer.reset().slice(), this, store.storage.serializer());
   }
 
   @Override
@@ -59,7 +61,7 @@ final class MemorySnapshot extends Snapshot {
 
   @Override
   public synchronized SnapshotReader reader() {
-    return openReader(new SnapshotReader(buffer.reset().slice(), this), descriptor);
+    return openReader(new SnapshotReader(buffer.reset().slice(), this, store.storage.serializer()), descriptor);
   }
 
   @Override

--- a/server/src/main/java/io/atomix/copycat/server/storage/snapshot/SnapshotReader.java
+++ b/server/src/main/java/io/atomix/copycat/server/storage/snapshot/SnapshotReader.java
@@ -18,6 +18,7 @@ package io.atomix.copycat.server.storage.snapshot;
 import io.atomix.catalyst.buffer.Buffer;
 import io.atomix.catalyst.buffer.BufferInput;
 import io.atomix.catalyst.buffer.Bytes;
+import io.atomix.catalyst.serializer.Serializer;
 import io.atomix.catalyst.util.Assert;
 
 /**
@@ -28,10 +29,12 @@ import io.atomix.catalyst.util.Assert;
 public class SnapshotReader implements BufferInput<SnapshotReader> {
   private final Buffer buffer;
   private final Snapshot snapshot;
+  private final Serializer serializer;
 
-  SnapshotReader(Buffer buffer, Snapshot snapshot) {
+  SnapshotReader(Buffer buffer, Snapshot snapshot, Serializer serializer) {
     this.buffer = Assert.notNull(buffer, "buffer");
     this.snapshot = Assert.notNull(snapshot, "snapshot");
+    this.serializer = Assert.notNull(serializer, "serializer");
   }
 
   @Override
@@ -48,6 +51,16 @@ public class SnapshotReader implements BufferInput<SnapshotReader> {
   public SnapshotReader skip(long bytes) {
     buffer.skip(bytes);
     return this;
+  }
+
+  /**
+   * Reads an object from the buffer.
+   *
+   * @param <T> The type of the object to read.
+   * @return The read object.
+   */
+  public <T> T readObject() {
+    return serializer.readObject(buffer);
   }
 
   @Override

--- a/server/src/main/java/io/atomix/copycat/server/storage/snapshot/SnapshotWriter.java
+++ b/server/src/main/java/io/atomix/copycat/server/storage/snapshot/SnapshotWriter.java
@@ -18,6 +18,7 @@ package io.atomix.copycat.server.storage.snapshot;
 import io.atomix.catalyst.buffer.Buffer;
 import io.atomix.catalyst.buffer.BufferOutput;
 import io.atomix.catalyst.buffer.Bytes;
+import io.atomix.catalyst.serializer.Serializer;
 import io.atomix.catalyst.util.Assert;
 
 /**
@@ -28,10 +29,23 @@ import io.atomix.catalyst.util.Assert;
 public class SnapshotWriter implements BufferOutput<SnapshotWriter> {
   final Buffer buffer;
   private final Snapshot snapshot;
+  private final Serializer serializer;
 
-  SnapshotWriter(Buffer buffer, Snapshot snapshot) {
+  SnapshotWriter(Buffer buffer, Snapshot snapshot, Serializer serializer) {
     this.buffer = Assert.notNull(buffer, "buffer");
     this.snapshot = Assert.notNull(snapshot, "snapshot");
+    this.serializer = Assert.notNull(serializer, "serializer");
+  }
+
+  /**
+   * Writes an object to the snapshot.
+   *
+   * @param object The object to write.
+   * @return The snapshot writer.
+   */
+  public SnapshotWriter writeObject(Object object) {
+    serializer.writeObject(object, buffer);
+    return this;
   }
 
   @Override


### PR DESCRIPTION
This PR adds a `writeObject` and `readObject` method to `SnapshotWriter` and `SnapshotReader` respectively to provide an easier method to serializing objects during state machine snapshotting.