### PR TITLE
Fix race condition in leader initialization

### DIFF
--- a/server/src/main/java/io/atomix/copycat/server/state/LeaderState.java
+++ b/server/src/main/java/io/atomix/copycat/server/state/LeaderState.java
@@ -86,7 +86,7 @@ final class LeaderState extends ActiveState {
     final long term = context.getTerm();
 
     // Append a no-op entry to reset session timeouts and commit entries from prior terms.
-    try (NoOpEntry entry = context.getLog().create(NoOpEntry.class)) {
+    try (InitializeEntry entry = context.getLog().create(InitializeEntry.class)) {
       entry.setTerm(term)
         .setTimestamp(appender.time());
       assert context.getLog().append(entry) == appender.index();

--- a/server/src/main/java/io/atomix/copycat/server/state/LeaderState.java
+++ b/server/src/main/java/io/atomix/copycat/server/state/LeaderState.java
@@ -59,10 +59,8 @@ final class LeaderState extends ActiveState {
     // Append initial entries to the log, including an initial no-op entry and the server's configuration.
     appendInitialEntries();
 
-    // Schedule the initial entries commit to occur after the state is opened. Attempting any communication
-    // within the open() method will result in a deadlock since RaftProtocol calls this method synchronously.
-    // What is critical about this logic is that the heartbeat timer not be started until a no-op entry has been committed.
-    context.getThreadContext().execute(this::commitInitialEntries).whenComplete((result, error) -> {
+    // Commit the initial leader entries and then schedule the append timer.
+    commitInitialEntries().whenComplete((result, error) -> {
       if (isOpen() && error == null) {
         startAppendTimer();
       }
@@ -92,6 +90,7 @@ final class LeaderState extends ActiveState {
       entry.setTerm(term)
         .setTimestamp(appender.time());
       assert context.getLog().append(entry) == appender.index();
+      LOGGER.debug("{} - Appended {}", context.getCluster().getMember().serverAddress(), entry);
     }
 
     // Append a configuration entry to propagate the leader's cluster configuration.

--- a/server/src/main/java/io/atomix/copycat/server/state/ServerStateMachine.java
+++ b/server/src/main/java/io/atomix/copycat/server/state/ServerStateMachine.java
@@ -344,8 +344,8 @@ final class ServerStateMachine implements AutoCloseable {
       return apply((KeepAliveEntry) entry);
     } else if (entry instanceof UnregisterEntry) {
       return apply((UnregisterEntry) entry, expectResult);
-    } else if (entry instanceof NoOpEntry) {
-      return apply((NoOpEntry) entry);
+    } else if (entry instanceof InitializeEntry) {
+      return apply((InitializeEntry) entry);
     } else if (entry instanceof ConnectEntry) {
       return apply((ConnectEntry) entry);
     } else if (entry instanceof ConfigurationEntry) {
@@ -950,15 +950,15 @@ final class ServerStateMachine implements AutoCloseable {
   }
 
   /**
-   * Applies a no-op entry to the state machine.
+   * Applies an initialize entry to the state machine.
    * <p>
-   * No-op entries are committed by leaders at the start of their term. Typically, no-op entries
+   * Initialize entries are committed by leaders at the start of their term. Typically, no-op entries
    * serve as a mechanism to allow leaders to commit entries from prior terms. However, we extend
    * the functionality of the no-op entry to use it as an indicator that a leadership change occurred.
    * In order to ensure timeouts do not expire during lengthy leadership changes, we use no-op entries
    * to reset timeouts for client sessions and server heartbeats.
    */
-  private CompletableFuture<Long> apply(NoOpEntry entry) {
+  private CompletableFuture<Long> apply(InitializeEntry entry) {
     // Iterate through all the server sessions and reset timestamps. This ensures that sessions do not
     // timeout during leadership changes or shortly thereafter.
     long timestamp = executor.tick(entry.getTimestamp());

--- a/server/src/main/java/io/atomix/copycat/server/storage/entry/InitializeEntry.java
+++ b/server/src/main/java/io/atomix/copycat/server/storage/entry/InitializeEntry.java
@@ -20,17 +20,17 @@ import io.atomix.catalyst.util.ReferenceManager;
 import io.atomix.copycat.server.storage.compaction.Compaction;
 
 /**
- * No-op entry.
+ * Initialize entry.
  *
  * @author <a href="http://github.com/kuujo">Jordan Halterman</a>
  */
 @SerializeWith(id=224)
-public class NoOpEntry extends TimestampedEntry<NoOpEntry> {
+public class InitializeEntry extends TimestampedEntry<InitializeEntry> {
 
-  public NoOpEntry() {
+  public InitializeEntry() {
   }
 
-  public NoOpEntry(ReferenceManager<Entry<?>> referenceManager) {
+  public InitializeEntry(ReferenceManager<Entry<?>> referenceManager) {
     super(referenceManager);
   }
 

--- a/server/src/main/resources/META-INF/services/io.atomix.catalyst.serializer.CatalystSerializable
+++ b/server/src/main/resources/META-INF/services/io.atomix.catalyst.serializer.CatalystSerializable
@@ -35,7 +35,7 @@ io.atomix.copycat.server.response.VoteResponse
 io.atomix.copycat.server.storage.entry.CommandEntry
 io.atomix.copycat.server.storage.entry.ConfigurationEntry
 io.atomix.copycat.server.storage.entry.KeepAliveEntry
-io.atomix.copycat.server.storage.entry.NoOpEntry
+io.atomix.copycat.server.storage.entry.InitializeEntry
 io.atomix.copycat.server.storage.entry.QueryEntry
 io.atomix.copycat.server.storage.entry.RegisterEntry
 io.atomix.copycat.server.storage.entry.ConnectEntry

--- a/server/src/test/java/io/atomix/copycat/server/state/ServerStateMachineTest.java
+++ b/server/src/test/java/io/atomix/copycat/server/state/ServerStateMachineTest.java
@@ -168,7 +168,7 @@ public class ServerStateMachineTest extends ConcurrentTestCase {
     callerContext.execute(() -> {
 
       long index;
-      try (NoOpEntry entry = log.create(NoOpEntry.class)) {
+      try (InitializeEntry entry = log.create(InitializeEntry.class)) {
         entry.setTerm(1)
           .setTimestamp(timestamp + 100);
         index = log.append(entry);


### PR DESCRIPTION
This PR fixes a race condition during leader initialization wherein a leader could attempt to apply its no-op entry to the state machine after it had already been applied. This was due to leaders asynchronously starting replication during the initialization phase. If the leader received another request which logged and replicated another entry, it could ultimately attempt to apply its initialization entries twice. However, starting replication asynchronously is not actually necessary, so this PR ensures that leaders synchronously append their `InitializeEntry` and `ConfigurationEntry` and begin replication during the leader initialization phase (`open`).