### PR TITLE
Fix incorrect condition in leader appender's hasMoreEntries check

### DIFF
--- a/server/src/main/java/io/atomix/copycat/server/state/AbstractAppender.java
+++ b/server/src/main/java/io/atomix/copycat/server/state/AbstractAppender.java
@@ -344,7 +344,7 @@ abstract class AbstractAppender implements AutoCloseable {
    * Returns a boolean value indicating whether there are more entries to send.
    */
   protected boolean hasMoreEntries(MemberState member) {
-    return member.getNextIndex() < context.getLog().lastIndex();
+    return member.getNextIndex() <= context.getLog().lastIndex();
   }
 
   /**

--- a/server/src/main/java/io/atomix/copycat/server/state/LeaderAppender.java
+++ b/server/src/main/java/io/atomix/copycat/server/state/LeaderAppender.java
@@ -181,7 +181,7 @@ final class LeaderAppender extends AbstractAppender {
       return;
     }
 
-    if (error != null && member.getCommitStartTime() == this.commitTime) {
+    if (error != null && member.getCommitStartTime() == commitTime) {
       int votingMemberSize = context.getCluster().getRemoteMemberStates(CopycatServer.Type.ACTIVE).size() + (context.getCluster().getMember().type() == CopycatServer.Type.ACTIVE ? 1 : 0);
       int quorumSize = context.getCluster().getQuorum();
       // If a quorum of successful responses cannot be achieved, fail this commit.
@@ -195,7 +195,7 @@ final class LeaderAppender extends AbstractAppender {
       // Sort the list of commit times. Use the quorum index to get the last time the majority of the cluster
       // was contacted. If the current commitFuture's time is less than the commit time then trigger the
       // commit future and reset it to the next commit future.
-      if (this.commitTime <= commitTime()) {
+      if (commitTime <= commitTime()) {
         commitFuture.complete(null);
         completeCommit();
       }
@@ -211,7 +211,7 @@ final class LeaderAppender extends AbstractAppender {
     commitFuture = nextCommitFuture;
     nextCommitFuture = null;
     if (commitFuture != null) {
-      this.commitTime = System.currentTimeMillis();
+      commitTime = System.currentTimeMillis();
       for (MemberState replica : context.getCluster().getRemoteMemberStates()) {
         appendEntries(replica);
       }


### PR DESCRIPTION
This PR fixes a bug in the `LeaderAppender` when determining whether more entries are waiting to be sent to a follower. The existing check was `nextIndex < log.lastIndex`, however that should be `nextIndex <= log.lastIndex`. On the surface, this seems like it wouldn't be a big deal since it's just one entry, but in practice this can cause a leader to have to step down at the beginning of its term. Leaders don't begin sending normal heartbeats until after they've committed their `InitializeEntry`. But if that entry is the only entry remaining to be sent to a majority of followers, it may never be committed because of the above condition. This caused leaders to get elected and then immediately removed.