### PR TITLE
Synchronize log index lookups

### DIFF
--- a/server/src/main/java/io/atomix/copycat/server/storage/OffsetIndex.java
+++ b/server/src/main/java/io/atomix/copycat/server/storage/OffsetIndex.java
@@ -87,7 +87,7 @@ final class OffsetIndex implements AutoCloseable {
    * @throws IllegalArgumentException if the {@code offset} is less than or equal to the last offset in the index, 
    * or {@code position} is greater than MAX_POSITION
    */
-  public void index(long offset, long position) {
+  public synchronized void index(long offset, long position) {
     Assert.argNot(offset, lastOffset > -1 && offset <= lastOffset,
       "offset cannot be less than or equal to the last offset in the index");
     Assert.argNot(position > MAX_POSITION, "position cannot be greater than " + MAX_POSITION);
@@ -134,7 +134,7 @@ final class OffsetIndex implements AutoCloseable {
    * @param offset The offset to look up.
    * @return The starting position of the given offset.
    */
-  public long position(long offset) {
+  public synchronized long position(long offset) {
     long relativeOffset = find(offset);
     return relativeOffset != -1 ? buffer.readUnsignedInt(relativeOffset * ENTRY_SIZE + OFFSET_SIZE) : -1;
   }
@@ -142,7 +142,7 @@ final class OffsetIndex implements AutoCloseable {
   /**
    * Finds the real offset for the given relative offset.
    */
-  public long find(long offset) {
+  public synchronized long find(long offset) {
     if (size == 0) {
       return -1;
     }

--- a/server/src/test/java/io/atomix/copycat/server/storage/LogTest.java
+++ b/server/src/test/java/io/atomix/copycat/server/storage/LogTest.java
@@ -15,20 +15,15 @@
  */
 package io.atomix.copycat.server.storage;
 
-import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertFalse;
-import static org.testng.Assert.assertNull;
-import static org.testng.Assert.assertNotNull;
-import static org.testng.Assert.assertTrue;
+import io.atomix.catalyst.serializer.Serializer;
+import io.atomix.catalyst.serializer.ServiceLoaderTypeResolver;
+import io.atomix.copycat.server.storage.compaction.Compaction;
+import org.testng.annotations.Test;
 
 import java.io.File;
 import java.util.List;
 
-import io.atomix.copycat.server.storage.compaction.Compaction;
-import org.testng.annotations.Test;
-
-import io.atomix.catalyst.serializer.Serializer;
-import io.atomix.catalyst.serializer.ServiceLoaderTypeResolver;
+import static org.testng.Assert.*;
 
 /**
  * Log test.


### PR DESCRIPTION
When writing to the cluster under high throughput, the log sometimes still experiences the ISEs discussed in #29. After significant testing and debugging, I found this to be a concurrency issue. After synchronizing the index methods, I'm unable to produce any more ISEs. This is not ideal, but it would be a premature optimization to try to find alternatives at this point. Log performance can be addressed in other issues.