### PR TITLE
Delete snapshot store on server delete

### DIFF
--- a/server/src/main/java/io/atomix/copycat/server/state/ServerContext.java
+++ b/server/src/main/java/io/atomix/copycat/server/state/ServerContext.java
@@ -203,6 +203,11 @@ public class ServerContext implements Managed<ServerState> {
     log.close();
     log.delete();
 
+    // Delete the snapshot store.
+    SnapshotStore snapshot = storage.openSnapshotStore(name);
+    snapshot.close();
+    snapshot.delete();
+
     return CompletableFuture.completedFuture(null);
   }
 


### PR DESCRIPTION
This PR fixes a bug wherein snapshots were not deleted when `CopycatServer.delete` was called. We simply load the snapshot store and `close` and `delete` it when `delete()` is called.