### PR TITLE
Submit no-op command when normal command fails

### DIFF
--- a/protocol/src/main/java/io/atomix/copycat/client/NoOpCommand.java
+++ b/protocol/src/main/java/io/atomix/copycat/client/NoOpCommand.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License
+ */
+package io.atomix.copycat.client;
+
+import io.atomix.catalyst.buffer.BufferInput;
+import io.atomix.catalyst.buffer.BufferOutput;
+import io.atomix.catalyst.serializer.CatalystSerializable;
+import io.atomix.catalyst.serializer.SerializeWith;
+import io.atomix.catalyst.serializer.Serializer;
+
+/**
+ * A special placeholder command.
+ *
+ * @author <a href="http://github.com/kuujo>Jordan Halterman</a>
+ */
+@SerializeWith(id=217)
+public class NoOpCommand implements Command<Void>, CatalystSerializable {
+  @Override
+  public void writeObject(BufferOutput<?> buffer, Serializer serializer) {
+  }
+
+  @Override
+  public void readObject(BufferInput<?> buffer, Serializer serializer) {
+  }
+
+  @Override
+  public String toString() {
+    return getClass().getSimpleName();
+  }
+
+}

--- a/protocol/src/main/resources/META-INF/services/io.atomix.catalyst.serializer.CatalystSerializable
+++ b/protocol/src/main/resources/META-INF/services/io.atomix.catalyst.serializer.CatalystSerializable
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+io.atomix.copycat.client.NoOpCommand
 io.atomix.copycat.client.session.Event
 io.atomix.copycat.client.request.CommandRequest
 io.atomix.copycat.client.response.CommandResponse


### PR DESCRIPTION
This PR fixes a bug in the client in cases where a client's command fails and the client is using a `RetryStrategy` that fails the command. If a command never gets submitted to the cluster and is failed, the client will continue submitting commands with sequence numbers *after* the failed command. Clients must replace the failed command with a no-op command with the appropriate sequence number to ensure the leader can properly continue to sequence commands.