### PR TITLE
Ensure client state is reset to OPEN upon successful keep-alive

### DIFF
--- a/client/src/main/java/io/atomix/copycat/client/session/ClientSessionManager.java
+++ b/client/src/main/java/io/atomix/copycat/client/session/ClientSessionManager.java
@@ -118,6 +118,7 @@ final class ClientSessionManager {
           // If the request was successful, update the address selector and schedule the next keep-alive.
           if (response.status() == Response.Status.OK) {
             connection.reset(response.leader(), response.members());
+            state.setState(Session.State.OPEN);
             keepAlive = context.schedule(interval, this::keepAlive);
           }
           // If the session is unknown, immediate expire the session.


### PR DESCRIPTION
The `ClientSessionManager` demotes the session's state to `UNSTABLE` when a keep-alive request fails, but never promotes it back to `OPEN` once it successfully re-establishes communication with the cluster.