### PR TITLE
Fix ClosedChannelException in LeaderAppender

### DIFF
--- a/server/src/main/java/io/atomix/copycat/server/state/LeaderAppender.java
+++ b/server/src/main/java/io/atomix/copycat/server/state/LeaderAppender.java
@@ -445,11 +445,11 @@ final class LeaderAppender implements AutoCloseable {
           // Remove the member from the appending set to allow the next append request.
           appending.remove(member);
 
-          // Trigger commit futures if necessary.
-          commitTime(member, error);
-
           // Log the failed attempt to contact the member.
           failAttempt(member, error);
+
+          // Trigger commit futures if necessary.
+          commitTime(member, error);
         }
       }
     });
@@ -695,11 +695,11 @@ final class LeaderAppender implements AutoCloseable {
           // Remove the member from the configuring set to allow a new configure request.
           configuring.remove(member);
 
-          // Trigger commit futures if necessary.
-          commitTime(member, error);
-
           // Log the failed attempt to contact the member.
           failAttempt(member, error);
+
+          // Trigger commit futures if necessary.
+          commitTime(member, error);
         }
       }
     });
@@ -829,11 +829,11 @@ final class LeaderAppender implements AutoCloseable {
           // Remove the member from the installing set to allow a new install request.
           installing.remove(member);
 
-          // Trigger commit futures if necessary.
-          commitTime(member, error);
-
           // Log the failed attempt to contact the member.
           failAttempt(member, error);
+
+          // Trigger commit futures if necessary.
+          commitTime(member, error);
         }
       }
     });


### PR DESCRIPTION
This PR addresses a race condition wherein the leader may close a `Connection` prior to concurrently attempting to send a new `AppendRequest` to a follower on that connection. When an `AppendRequest` sent by the leader times out or otherwise fails, the leader calls the [failAttempt](https://github.com/atomix/copycat/blob/master/server/src/main/java/io/atomix/copycat/server/state/LeaderAppender.java#L452) method which resets the connection to re-establish a new connection to the follower. However, *prior* to calling `failAttempt`, the leader calls [commitTime](https://github.com/atomix/copycat/blob/master/server/src/main/java/io/atomix/copycat/server/state/LeaderAppender.java#L449) to update the last time followers were contacted by the leader for tracking heartbeats. However, the `commitTime` method may call [completeCommit](https://github.com/atomix/copycat/blob/master/server/src/main/java/io/atomix/copycat/server/state/LeaderAppender.java#L267) which can subsequently send a next `AppendRequest` to the follower. This results in the `AppendRequest` being sent on a connection that's simultaneously being closed by the leader.