### PR TITLE
Ensure only log entries present in the log are committed to the log

### DIFF
--- a/server/src/main/java/io/atomix/copycat/server/state/ServerState.java
+++ b/server/src/main/java/io/atomix/copycat/server/state/ServerState.java
@@ -336,7 +336,7 @@ public class ServerState {
     Assert.argNot(commitIndex < 0, "commit index must be positive");
     Assert.argNot(commitIndex < this.commitIndex, "cannot decrease commit index");
     this.commitIndex = commitIndex;
-    log.commit(commitIndex);
+    log.commit(Math.min(commitIndex, log.lastIndex()));
     return this;
   }
 

--- a/server/src/main/java/io/atomix/copycat/server/storage/Log.java
+++ b/server/src/main/java/io/atomix/copycat/server/storage/Log.java
@@ -416,7 +416,10 @@ public class Log implements AutoCloseable {
    */
   public Log commit(long index) {
     assertIsOpen();
-    segments.commitIndex(index);
+    if (index > 0) {
+      assertValidIndex(index);
+      segments.commitIndex(index);
+    }
     return this;
   }
 


### PR DESCRIPTION
This is an attempt to fix the `IndexOutOfBoundsException` that occurs infrequently following a leader change while `truncate`ing entries from the log.

The prevailing theory is that the reason a follower attempts to truncate committed entries from it's log is because of the following scenario:
* Leader `A` sends entries `10-13` to follower `B` with a commitIndex of `9`
* A leadership change occurs and leader C is elected
* Leader `C` commits its own entries `10-13` via follower `A` (overwriting follower `A`’s entries) and then sends an empty `AppendRequest` to follower `B` with a commitIndex of `13`
* Leader `C` then sends the committed entries 10-13 to follower `B` who notices that they don’t match since follower `B` still has the entries from leader `A`, so it truncates its log to index `9`, but the log throws an exception since those entries were committed
...thus, this PR only allows entries that are present in the follower's logs to be committed. This ensures consistency checks are done before increasing the commit index beyond any new entries in the log.