### PR TITLE
Session event bug fixes

### DIFF
--- a/client/src/main/java/io/atomix/copycat/client/session/ClientSessionListener.java
+++ b/client/src/main/java/io/atomix/copycat/client/session/ClientSessionListener.java
@@ -147,7 +147,7 @@ final class ClientSessionListener {
 
         return PublishResponse.builder()
           .withStatus(Response.Status.OK)
-          .withIndex(state.getEventIndex())
+          .withIndex(state.getCompleteIndex())
           .build();
       }, context.executor());
   }

--- a/server/src/main/java/io/atomix/copycat/server/state/ServerState.java
+++ b/server/src/main/java/io/atomix/copycat/server/state/ServerState.java
@@ -474,6 +474,8 @@ public class ServerState {
     connection.handler(VoteRequest.class, request -> state.vote(request));
     connection.handler(CommandRequest.class, request -> state.command(request));
     connection.handler(QueryRequest.class, request -> state.query(request));
+
+    connection.closeListener(stateMachine.executor().context().sessions()::unregisterConnection);
   }
 
   /**


### PR DESCRIPTION
This PR fixes a bug with session events wherein session events may be `publish`ed to a closed connection. This was the result of a missing call to `unregisterConnection` in servers that had no separate client `Server`. When a server only exposes one `Server` to which clients and other servers both connect, this change treats all connections as client connections to ensure real client connections will be disassociated with any `ServerSession` so as not to publish event messages to closed connections and to allow new connections from clients to be re-registered.