### PR TITLE
Commit configuration changes to disk only once committed

### DIFF
--- a/server/src/main/java/io/atomix/copycat/server/cluster/Member.java
+++ b/server/src/main/java/io/atomix/copycat/server/cluster/Member.java
@@ -93,19 +93,6 @@ public interface Member {
     PASSIVE,
 
     /**
-     * Represents a member that is being caught up by the leader to be {@link #promote() promoted} to
-     * a full {@link #ACTIVE} voting member.
-     * <p>
-     * The {@code PROMOTABLE} member type is a transitive member type that is a prerequisite to becoming
-     * a full {@link #ACTIVE} voting member. While in this state, promotable nodes receive replicated
-     * log entries from leaders via normal Raft replication mechanisms, but promotable members do not
-     * participate in the Raft voting algorithm. This allows leaders to catch up promotable members without
-     * negatively impacting availability. Once a promotable member has caught up with the leader, the leader
-     * will promote the promotable member to {@link #ACTIVE}.
-     */
-    PROMOTABLE,
-
-    /**
      * Represents a full voting member of the Raft cluster which participates fully in leader election
      * and replication algorithms.
      * <p>

--- a/server/src/main/java/io/atomix/copycat/server/request/AppendRequest.java
+++ b/server/src/main/java/io/atomix/copycat/server/request/AppendRequest.java
@@ -23,7 +23,6 @@ import io.atomix.catalyst.util.Assert;
 import io.atomix.copycat.client.request.AbstractRequest;
 import io.atomix.copycat.server.storage.entry.Entry;
 
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
@@ -63,7 +62,7 @@ public class AppendRequest extends AbstractRequest {
   private int leader;
   private long logIndex;
   private long logTerm;
-  private List<Entry> entries = new ArrayList<>(128);
+  private List<Entry> entries;
   private long commitIndex = -1;
   private long globalIndex = -1;
 
@@ -307,8 +306,8 @@ public class AppendRequest extends AbstractRequest {
     }
 
     /**
-     * @throws IllegalStateException if the term, log term, log index, commit index, or global index are not positive, or 
-     * if entries is null 
+     * @throws IllegalStateException if the term, log term, log index, commit index, or global index are not positive, or
+     * if entries is null
      */
     @Override
     public AppendRequest build() {

--- a/server/src/main/java/io/atomix/copycat/server/request/AppendRequest.java
+++ b/server/src/main/java/io/atomix/copycat/server/request/AppendRequest.java
@@ -23,6 +23,7 @@ import io.atomix.catalyst.util.Assert;
 import io.atomix.copycat.client.request.AbstractRequest;
 import io.atomix.copycat.server.storage.entry.Entry;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
@@ -155,7 +156,7 @@ public class AppendRequest extends AbstractRequest {
     globalIndex = buffer.readLong();
 
     int numEntries = buffer.readInt();
-    entries.clear();
+    entries = new ArrayList<>(numEntries);
     for (int i = 0; i < numEntries; i++) {
       long index = buffer.readLong();
       Entry entry = serializer.readObject(buffer);

--- a/server/src/main/java/io/atomix/copycat/server/request/ConfigureRequest.java
+++ b/server/src/main/java/io/atomix/copycat/server/request/ConfigureRequest.java
@@ -60,8 +60,8 @@ public class ConfigureRequest extends AbstractRequest {
 
   private long term;
   private int leader;
-  protected long index;
-  protected Collection<Member> members;
+  private long index;
+  private Collection<Member> members;
 
   /**
    * Returns the requesting node's current term.

--- a/server/src/main/java/io/atomix/copycat/server/state/AbstractAppender.java
+++ b/server/src/main/java/io/atomix/copycat/server/state/AbstractAppender.java
@@ -153,9 +153,10 @@ abstract class AbstractAppender implements AutoCloseable {
     long prevIndex = getPrevIndex(member);
     Entry prevEntry = getPrevEntry(member, prevIndex);
 
+    ServerMember leader = context.getLeader();
     return AppendRequest.builder()
       .withTerm(context.getTerm())
-      .withLeader(context.getCluster().member().id())
+      .withLeader(leader != null ? leader.id() : 0)
       .withLogIndex(prevIndex)
       .withLogTerm(prevEntry != null ? prevEntry.getTerm() : 0)
       .withCommitIndex(context.getCommitIndex())
@@ -170,9 +171,10 @@ abstract class AbstractAppender implements AutoCloseable {
     long prevIndex = getPrevIndex(member);
     Entry prevEntry = getPrevEntry(member, prevIndex);
 
+    ServerMember leader = context.getLeader();
     AppendRequest.Builder builder = AppendRequest.builder()
       .withTerm(context.getTerm())
-      .withLeader(context.getCluster().member().id())
+      .withLeader(leader != null ? leader.id() : 0)
       .withLogIndex(prevIndex)
       .withLogTerm(prevEntry != null ? prevEntry.getTerm() : 0)
       .withCommitIndex(context.getCommitIndex())

--- a/server/src/main/java/io/atomix/copycat/server/state/ClusterState.java
+++ b/server/src/main/java/io/atomix/copycat/server/state/ClusterState.java
@@ -38,6 +38,7 @@ import java.util.*;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Consumer;
+import java.util.stream.Collectors;
 
 /**
  * Cluster state.
@@ -50,7 +51,7 @@ final class ClusterState implements Cluster, AutoCloseable {
   private final ServerContext context;
   private final ServerMember member;
   private final Member.Type initialType;
-  private long index = -1;
+  private Configuration configuration;
   private final Map<Integer, MemberState> membersMap = new ConcurrentHashMap<>();
   private final Map<Address, MemberState> addressMap = new ConcurrentHashMap<>();
   private final List<MemberState> members = new ArrayList<>();
@@ -62,10 +63,60 @@ final class ClusterState implements Cluster, AutoCloseable {
   private final Listeners<Member> joinListeners = new Listeners<>();
   private final Listeners<Member> leaveListeners = new Listeners<>();
 
-  ClusterState(ServerContext context, ServerMember member, Member.Type initialType) {
+  ClusterState(Member.Type type, Address serverAddress, Address clientAddress, Collection<Address> members, ServerContext context) {
+    this.initialType = Assert.notNull(type, "type");
+    this.member = new ServerMember(Member.Type.INACTIVE, serverAddress, clientAddress);
     this.context = Assert.notNull(context, "context");
-    this.member = Assert.notNull(member, "member");
-    this.initialType = Assert.notNull(initialType, "initialType");
+
+    // If a configuration is stored, use the stored configuration, otherwise configure the server with the user provided configuration.
+    configuration = context.getMetaStore().loadConfiguration();
+    if (configuration == null) {
+      Set<Member> activeMembers;
+
+      // If the provided server members set contains the local server member, create an active members
+      // list including the local member.
+      if (members.contains(serverAddress)) {
+        activeMembers = members.stream()
+          .filter(m -> !m.equals(member.serverAddress()))
+          .map(m -> new ServerMember(Member.Type.ACTIVE, m, null))
+          .collect(Collectors.toSet());
+        activeMembers.add(new ServerMember(Member.Type.ACTIVE, member.serverAddress(), member.clientAddress()));
+      }
+      // If the provided members set does not contain the local server member, exclude it from active members.
+      else {
+        activeMembers = members.stream()
+          .map(m -> new ServerMember(Member.Type.ACTIVE, m, null))
+          .collect(Collectors.toSet());
+      }
+
+      // Create a configuration for the 0 index.
+      configuration = new Configuration(0, activeMembers);
+    }
+
+    // Iterate through members in the new configuration and add remote members.
+    for (Member member : configuration.members()) {
+      if (member.equals(this.member)) {
+        this.member.update(member.type()).update(member.clientAddress());
+      } else {
+        // If the member state doesn't already exist, create it.
+        MemberState state = new MemberState(new ServerMember(member.type(), member.serverAddress(), member.clientAddress()), this);
+        state.resetState(context.getLog());
+        this.members.add(state);
+        membersMap.put(member.id(), state);
+        addressMap.put(member.address(), state);
+
+        // Add the member to a type specific map.
+        List<MemberState> memberType = memberTypes.get(member.type());
+        if (memberType == null) {
+          memberType = new ArrayList<>();
+          memberTypes.put(member.type(), memberType);
+        }
+        memberType.add(state);
+      }
+    }
+
+    // Store the configuration on disk to ensure that the cluster can fall back to the previous configuration.
+    context.getMetaStore().storeConfiguration(configuration);
   }
 
   /**
@@ -75,6 +126,15 @@ final class ClusterState implements Cluster, AutoCloseable {
    */
   ServerContext getContext() {
     return context;
+  }
+
+  /**
+   * Returns the cluster configuration.
+   *
+   * @return The cluster configuration.
+   */
+  Configuration getConfiguration() {
+    return configuration;
   }
 
   @Override
@@ -149,15 +209,6 @@ final class ClusterState implements Cluster, AutoCloseable {
    */
   int getQuorum() {
     return (int) Math.floor((getActiveMemberStates().size() + 1) / 2.0) + 1;
-  }
-
-  /**
-   * Returns the cluster state index.
-   *
-   * @return The cluster state index.
-   */
-  long getVersion() {
-    return index;
   }
 
   /**
@@ -271,23 +322,16 @@ final class ClusterState implements Cluster, AutoCloseable {
     joinFuture = new CompletableFuture<>();
 
     context.getThreadContext().executor().execute(() -> {
-      // If the server type is defined, that indicates it's a member of the current configuration and
-      // doesn't need to be added to the configuration. Immediately transition to the appropriate state.
-      // Note that we don't complete the join future when transitioning to a valid state since we need
-      // to ensure that the server's configuration has been updated in the cluster before completing the join.
-      switch (member.type()) {
-        case INACTIVE:
-          join(getActiveMemberStates().iterator(), 1);
-          break;
-        case RESERVE:
-          context.transition(CopycatServer.State.RESERVE);
-          break;
-        case PASSIVE:
-          context.transition(CopycatServer.State.PASSIVE);
-          break;
-        case ACTIVE:
-          context.transition(CopycatServer.State.FOLLOWER);
-          break;
+      // Transition the server to the appropriate state for the local member type.
+      context.transition(member.type());
+
+      // If the local member type is INACTIVE, send a join request to the cluster.
+      // The join future is not completed here in any case - even if the local server is already a member
+      // of the cluster - because the server needs to identify itself to the leader in order to complete
+      // the join. Once the server transitions to an active state, the server will identify itself to the
+      // leader upon learning of the leader. Once the server has identified itself the join will be completed.
+      if (member.type() == Member.Type.INACTIVE) {
+        join(getActiveMemberStates().iterator(), 1);
       }
     });
 
@@ -313,26 +357,17 @@ final class ClusterState implements Cluster, AutoCloseable {
             LOGGER.info("{} - Successfully joined via {}", member().address(), member.getMember().serverAddress());
 
             // Configure the cluster with the join response.
-            configure(response.index(), response.members());
+            configure(new Configuration(response.index(), response.members()));
 
             // Cancel the join timer.
             cancelJoinTimer();
 
             // If the local member type is null, that indicates it's not a part of the configuration.
             Member.Type type = member().type();
-            if (type == null) {
+            if (type == null || type == Member.Type.INACTIVE) {
               joinFuture.completeExceptionally(new IllegalStateException("not a member of the cluster"));
-            } else if (type == Member.Type.ACTIVE) {
-              context.transition(CopycatServer.State.FOLLOWER);
-              joinFuture.complete(null);
-            } else if (type == Member.Type.PASSIVE) {
-              context.transition(CopycatServer.State.PASSIVE);
-              joinFuture.complete(null);
-            } else if (type == Member.Type.RESERVE) {
-              context.transition(CopycatServer.State.RESERVE);
-              joinFuture.complete(null);
             } else {
-              joinFuture.completeExceptionally(new IllegalStateException("unknown member type: " + type));
+              joinFuture.complete(null);
             }
           } else if (response.error() == null) {
             // If the response error is null, that indicates that no error occurred but the leader was
@@ -385,7 +420,7 @@ final class ClusterState implements Cluster, AutoCloseable {
         LOGGER.debug("{} - Sending server identification to {}", member().address(), leader.address());
         context.getConnections().getConnection(leader.serverAddress()).thenCompose(connection -> {
           ReconfigureRequest request = ReconfigureRequest.builder()
-            .withIndex(getVersion())
+            .withIndex(configuration.index())
             .withMember(member())
             .build();
           return connection.<ConfigurationRequest, ConfigurationResponse>send(request);
@@ -451,8 +486,7 @@ final class ClusterState implements Cluster, AutoCloseable {
       .build()).whenComplete((response, error) -> {
       if (error == null && response.status() == Response.Status.OK) {
         cancelLeaveTimer();
-        configure(response.index(), response.members());
-        context.transition(CopycatServer.State.INACTIVE);
+        configure(new Configuration(response.index(), response.members()));
         future.complete(null);
       }
     });
@@ -470,25 +504,45 @@ final class ClusterState implements Cluster, AutoCloseable {
   }
 
   /**
-   * Configures the cluster state.
+   * Resets the cluster state to the persisted state.
    *
-   * @param index The cluster state index.
-   * @param members The cluster members.
    * @return The cluster state.
    */
-  ClusterState configure(long index, Collection<Member> members) {
-    if (index <= this.index)
-      return this;
+  ClusterState reset() {
+    configure(context.getMetaStore().loadConfiguration());
+    return this;
+  }
+
+  /**
+   * Commit the given configuration to disk.
+   *
+   * @param configuration The configuration to commit.
+   * @return The cluster state.
+   */
+  ClusterState commit(Configuration configuration) {
+    context.getMetaStore().storeConfiguration(configuration);
+    return this;
+  }
+
+  /**
+   * Configures the cluster state.
+   *
+   * @param configuration The cluster configuration.
+   * @return The cluster state.
+   */
+  ClusterState configure(Configuration configuration) {
+    Assert.notNull(configuration, "configuration");
 
     // If the configuration index is less than the currently configured index, ignore it.
     // Configurations can be persisted and applying old configurations can revert newer configurations.
-    if (index <= this.index)
+    if (this.configuration != null && configuration.index() <= this.configuration.index())
       return this;
 
     // Iterate through members in the new configuration, add any missing members, and update existing members.
-    for (Member member : members) {
+    for (Member member : configuration.members()) {
       if (member.equals(this.member)) {
         this.member.update(member.type()).update(member.clientAddress());
+        context.transition(this.member.type());
       } else {
         // If the member state doesn't already exist, create it.
         MemberState state = membersMap.get(member.id());
@@ -528,15 +582,16 @@ final class ClusterState implements Cluster, AutoCloseable {
     }
 
     // If the local member is not part of the configuration, set its type to null.
-    if (!members.contains(this.member)) {
+    if (!configuration.members().contains(this.member)) {
       this.member.update(Member.Type.INACTIVE);
+      context.transition(this.member.type());
     }
 
     // Iterate through configured members and remove any that no longer exist in the configuration.
     Iterator<MemberState> iterator = this.members.iterator();
     while (iterator.hasNext()) {
       MemberState member = iterator.next();
-      if (!members.contains(member.getMember())) {
+      if (!configuration.members().contains(member.getMember())) {
         iterator.remove();
         for (List<MemberState> memberType : memberTypes.values()) {
           memberType.remove(member);
@@ -547,10 +602,12 @@ final class ClusterState implements Cluster, AutoCloseable {
       }
     }
 
-    this.index = index;
+    this.configuration = configuration;
 
-    // Store the configuration to ensure it can be easily loaded on server restart.
-    context.getMetaStore().storeConfiguration(new Configuration(index, members));
+    // Store the configuration if it's already committed.
+    if (context.getCommitIndex() >= configuration.index()) {
+      context.getMetaStore().storeConfiguration(configuration);
+    }
 
     // Reassign members based on availability.
     reassign();

--- a/server/src/main/java/io/atomix/copycat/server/state/ClusterState.java
+++ b/server/src/main/java/io/atomix/copycat/server/state/ClusterState.java
@@ -213,27 +213,6 @@ final class ClusterState implements Cluster, AutoCloseable {
   }
 
   /**
-   * Returns a list of promotable members.
-   *
-   * @return A list of promotable members.
-   */
-  List<MemberState> getPromotableMemberStates() {
-    return getRemoteMemberStates(Member.Type.PROMOTABLE);
-  }
-
-  /**
-   * Returns a list of promotable members.
-   *
-   * @param comparator A comparator with which to sort the members list.
-   * @return The sorted members list.
-   */
-  List<MemberState> getPromotableMemberStates(Comparator<MemberState> comparator) {
-    List<MemberState> promotableMembers = getPromotableMemberStates();
-    Collections.sort(promotableMembers, comparator);
-    return promotableMembers;
-  }
-
-  /**
    * Returns a list of passive members.
    *
    * @return A list of passive members.
@@ -304,7 +283,6 @@ final class ClusterState implements Cluster, AutoCloseable {
           context.transition(CopycatServer.State.RESERVE);
           break;
         case PASSIVE:
-        case PROMOTABLE:
           context.transition(CopycatServer.State.PASSIVE);
           break;
         case ACTIVE:
@@ -347,7 +325,7 @@ final class ClusterState implements Cluster, AutoCloseable {
             } else if (type == Member.Type.ACTIVE) {
               context.transition(CopycatServer.State.FOLLOWER);
               joinFuture.complete(null);
-            } else if (type == Member.Type.PASSIVE || type == Member.Type.PROMOTABLE) {
+            } else if (type == Member.Type.PASSIVE) {
               context.transition(CopycatServer.State.PASSIVE);
               joinFuture.complete(null);
             } else if (type == Member.Type.RESERVE) {

--- a/server/src/main/java/io/atomix/copycat/server/state/FollowerAppender.java
+++ b/server/src/main/java/io/atomix/copycat/server/state/FollowerAppender.java
@@ -43,19 +43,9 @@ final class FollowerAppender extends AbstractAppender {
     if (!open)
       return;
 
-    // If the member term is less than the current term or the member's configuration index is less
-    // than the local configuration index, send a configuration update to the member.
-    // Ensure that only one configuration attempt per member is attempted at any given time by storing the
-    // member state in a set of configuring members.
-    // Once the configuration is complete sendAppendRequest will be called recursively.
-    if (member.getConfigTerm() < context.getTerm() || member.getConfigIndex() < context.getClusterState().getVersion()) {
-      if (canConfigure(member)) {
-        sendConfigureRequest(member, buildConfigureRequest(member));
-      }
-    }
     // If the member's current snapshot index is less than the latest snapshot index and the latest snapshot index
     // is less than the nextIndex, send a snapshot request.
-    else if (context.getSnapshotStore().currentSnapshot() != null
+    if (context.getSnapshotStore().currentSnapshot() != null
       && context.getSnapshotStore().currentSnapshot().index() >= member.getNextIndex()
       && context.getSnapshotStore().currentSnapshot().index() > member.getSnapshotIndex()) {
       if (canInstall(member)) {

--- a/server/src/main/java/io/atomix/copycat/server/state/FollowerState.java
+++ b/server/src/main/java/io/atomix/copycat/server/state/FollowerState.java
@@ -111,7 +111,7 @@ final class FollowerState extends ActiveState {
     // If there are no other members in the cluster, immediately transition to leader.
     if (votingMembers.isEmpty()) {
       LOGGER.debug("{} - Single member cluster. Transitioning directly to leader.", context.getCluster().member().address());
-      transition(CopycatServer.State.LEADER);
+      context.transition(CopycatServer.State.LEADER);
       return;
     }
 
@@ -119,7 +119,7 @@ final class FollowerState extends ActiveState {
       // If a majority of the cluster indicated they would vote for us then transition to candidate.
       complete.set(true);
       if (elected) {
-        transition(CopycatServer.State.CANDIDATE);
+        context.transition(CopycatServer.State.CANDIDATE);
       } else {
         resetHeartbeatTimeout();
       }

--- a/server/src/main/java/io/atomix/copycat/server/state/LeaderAppender.java
+++ b/server/src/main/java/io/atomix/copycat/server/state/LeaderAppender.java
@@ -179,7 +179,7 @@ final class LeaderAppender extends AbstractAppender {
     // Ensure that only one configuration attempt per member is attempted at any given time by storing the
     // member state in a set of configuring members.
     // Once the configuration is complete sendAppendRequest will be called recursively.
-    else if (member.getConfigTerm() < context.getTerm() || member.getConfigIndex() < context.getClusterState().getVersion()) {
+    else if (member.getConfigTerm() < context.getTerm() || member.getConfigIndex() < context.getClusterState().getConfiguration().index()) {
       if (canConfigure(member)) {
         sendConfigureRequest(member, buildConfigureRequest(member));
       }

--- a/server/src/main/java/io/atomix/copycat/server/state/LeaderAppender.java
+++ b/server/src/main/java/io/atomix/copycat/server/state/LeaderAppender.java
@@ -192,7 +192,7 @@ final class LeaderAppender extends AbstractAppender {
     }
     // If the member's current snapshot index is less than the latest snapshot index and the latest snapshot index
     // is less than the nextIndex, send a snapshot request.
-    else if (context.getSnapshotStore().currentSnapshot() != null
+    else if (member.getMember().type() == Member.Type.ACTIVE && context.getSnapshotStore().currentSnapshot() != null
       && context.getSnapshotStore().currentSnapshot().index() >= member.getNextIndex()
       && context.getSnapshotStore().currentSnapshot().index() > member.getSnapshotIndex()) {
       if (canInstall(member)) {

--- a/server/src/main/java/io/atomix/copycat/server/state/LeaderAppender.java
+++ b/server/src/main/java/io/atomix/copycat/server/state/LeaderAppender.java
@@ -96,7 +96,7 @@ final class LeaderAppender extends AbstractAppender {
    */
   public CompletableFuture<Long> appendEntries() {
     // If there are no other active members in the cluster, simply complete the append operation.
-    if (context.getClusterState().getActiveMemberStates().isEmpty() && context.getClusterState().getPromotableMemberStates().isEmpty())
+    if (context.getClusterState().getRemoteMemberStates().isEmpty())
       return CompletableFuture.completedFuture(null);
 
     // If no commit future already exists, that indicates there's no heartbeat currently under way.
@@ -137,7 +137,7 @@ final class LeaderAppender extends AbstractAppender {
       return CompletableFuture.completedFuture(index);
 
     // If there are no other stateful servers in the cluster, immediately commit the index.
-    if (context.getClusterState().getActiveMemberStates().isEmpty() && context.getClusterState().getPromotableMemberStates().isEmpty() && context.getClusterState().getPassiveMemberStates().isEmpty()) {
+    if (context.getClusterState().getActiveMemberStates().isEmpty() && context.getClusterState().getPassiveMemberStates().isEmpty()) {
       context.setCommitIndex(index);
       context.setGlobalIndex(index);
       return CompletableFuture.completedFuture(index);
@@ -372,7 +372,6 @@ final class LeaderAppender extends AbstractAppender {
     if (response.succeeded()) {
       updateMatchIndex(member, response);
       updateNextIndex(member);
-      updateConfiguration(member);
 
       // If entries were committed to the replica then check commit indexes.
       if (!request.entries().isEmpty()) {
@@ -446,16 +445,6 @@ final class LeaderAppender extends AbstractAppender {
         member.getMember().update(ServerMember.Status.UNAVAILABLE);
         leader.configure(context.getCluster().members());
       }
-    }
-  }
-
-  /**
-   * Updates the cluster configuration for the given member.
-   */
-  private void updateConfiguration(MemberState member) {
-    if (member.getMember().type() == Member.Type.PROMOTABLE && !leader.configuring() && member.getMatchIndex() >= context.getCommitIndex()) {
-      member.getMember().update(Member.Type.ACTIVE);
-      leader.configure(context.getCluster().members());
     }
   }
 

--- a/server/src/main/java/io/atomix/copycat/server/state/LeaderState.java
+++ b/server/src/main/java/io/atomix/copycat/server/state/LeaderState.java
@@ -264,9 +264,9 @@ final class LeaderState extends ActiveState {
     Member member = request.member();
 
     // Add the joining member to the members list. If the joining member's type is ACTIVE, join the member in the
-    // PROMOTABLE state to allow it to get caught up without impacting the qorum size.
+    // PROMOTABLE state to allow it to get caught up without impacting the quorum size.
     Collection<Member> members = context.getCluster().members();
-    members.add(new ServerMember(member.type() == Member.Type.ACTIVE ? Member.Type.PROMOTABLE : member.type(), member.serverAddress(), member.clientAddress()));
+    members.add(new ServerMember(member.type(), member.serverAddress(), member.clientAddress()));
 
     CompletableFuture<JoinResponse> future = new CompletableFuture<>();
     configure(members).whenComplete((index, error) -> {

--- a/server/src/main/java/io/atomix/copycat/server/state/PassiveState.java
+++ b/server/src/main/java/io/atomix/copycat/server/state/PassiveState.java
@@ -54,14 +54,18 @@ class PassiveState extends ReserveState {
 
   @Override
   public CompletableFuture<AbstractState> open() {
-    return super.open().thenRun(this::truncateUncommittedEntries).thenApply(v -> this);
+    return super.open()
+      .thenRun(this::truncateUncommittedEntries)
+      .thenApply(v -> this);
   }
 
   /**
    * Truncates uncommitted entries from the log.
    */
   private void truncateUncommittedEntries() {
-    context.getLog().truncate(Math.min(context.getCommitIndex(), context.getLog().lastIndex()));
+    if (type() == CopycatServer.State.PASSIVE) {
+      context.getLog().truncate(Math.min(context.getCommitIndex(), context.getLog().lastIndex()));
+    }
   }
 
   @Override

--- a/server/src/main/java/io/atomix/copycat/server/state/PassiveState.java
+++ b/server/src/main/java/io/atomix/copycat/server/state/PassiveState.java
@@ -53,6 +53,18 @@ class PassiveState extends ReserveState {
   }
 
   @Override
+  public CompletableFuture<AbstractState> open() {
+    return super.open().thenRun(this::truncateUncommittedEntries).thenApply(v -> this);
+  }
+
+  /**
+   * Truncates uncommitted entries from the log.
+   */
+  private void truncateUncommittedEntries() {
+    context.getLog().truncate(Math.min(context.getCommitIndex(), context.getLog().lastIndex()));
+  }
+
+  @Override
   protected CompletableFuture<AppendResponse> append(final AppendRequest request) {
     context.checkThread();
 
@@ -67,31 +79,20 @@ class PassiveState extends ReserveState {
   }
 
   /**
-   * Starts the append process.
+   * Handles an append request.
    */
-  protected AppendResponse handleAppend(AppendRequest request) {
-    // If the request term is less than the current term then immediately
-    // reply false and return our current term. The leader will receive
-    // the updated term and step down.
-    if (request.term() < context.getTerm()) {
-      LOGGER.debug("{} - Rejected {}: request term is less than the current term ({})", context.getCluster().member().address(), request, context.getTerm());
-      return AppendResponse.builder()
-        .withStatus(Response.Status.OK)
-        .withTerm(context.getTerm())
-        .withSucceeded(false)
-        .withLogIndex(context.getLog().lastIndex())
-        .build();
-    } else if (request.logIndex() != 0 && request.logTerm() != 0) {
-      return doCheckPreviousEntry(request);
+  private AppendResponse handleAppend(AppendRequest request) {
+    if (request.logIndex() > 0) {
+      return checkPreviousEntry(request);
     } else {
-      return doAppendEntries(request);
+      return appendEntries(request);
     }
   }
 
   /**
-   * Checks the previous log entry for consistency.
+   * Checks the previous entry in the append request for consistency.
    */
-  protected AppendResponse doCheckPreviousEntry(AppendRequest request) {
+  private AppendResponse checkPreviousEntry(AppendRequest request) {
     if (request.logIndex() != 0 && context.getLog().isEmpty()) {
       LOGGER.debug("{} - Rejected {}: Previous index ({}) is greater than the local log's last index ({})", context.getCluster().member().address(), request, request.logIndex(), context.getLog().lastIndex());
       return AppendResponse.builder()
@@ -109,67 +110,33 @@ class PassiveState extends ReserveState {
         .withLogIndex(context.getLog().lastIndex())
         .build();
     }
-
-    // If the previous entry term doesn't match the local previous term then reject the request.
-    try (Entry entry = context.getLog().get(request.logIndex())) {
-      if (entry == null || entry.getTerm() != request.logTerm()) {
-        LOGGER.debug("{} - Rejected {}: Request log term does not match local log term {} for the same entry", context.getCluster().member().address(), request, entry != null ? entry.getTerm() : "unknown");
-        return AppendResponse.builder()
-          .withStatus(Response.Status.OK)
-          .withTerm(context.getTerm())
-          .withSucceeded(false)
-          .withLogIndex(request.logIndex() <= context.getLog().lastIndex() ? request.logIndex() - 1 : context.getLog().lastIndex())
-          .build();
-      } else {
-        return doAppendEntries(request);
-      }
-    }
+    return appendEntries(request);
   }
 
   /**
    * Appends entries to the local log.
    */
-  protected AppendResponse doAppendEntries(AppendRequest request) {
-    // If the log contains entries after the request's previous log index
-    // then remove those entries to be replaced by the request entries.
-    if (!request.entries().isEmpty()) {
+  private AppendResponse appendEntries(AppendRequest request) {
+    // Append entries to the log starting at the last log index.
+    long commitIndex = Math.max(context.getCommitIndex(), request.commitIndex());
+    for (Entry entry : request.entries()) {
+      // If the entry index is greater than the last index and less than the commit index, append the entry.
+      // We perform no additional consistency checks here since passive members may only receive committed entries.
+      if (context.getLog().lastIndex() < entry.getIndex() && entry.getIndex() < commitIndex) {
+        context.getLog().skip(entry.getIndex() - context.getLog().lastIndex() - 1).append(entry);
+        LOGGER.debug("{} - Appended {} to log at index {}", context.getCluster().member().address(), entry, entry.getIndex());
+      }
 
-      // Iterate through request entries and append them to the log.
-      for (Entry entry : request.entries()) {
-        // If the entry index is greater than the last log index, skip missing entries.
-        if (context.getLog().lastIndex() < entry.getIndex()) {
-          context.getLog().skip(entry.getIndex() - context.getLog().lastIndex() - 1).append(entry);
-          LOGGER.debug("{} - Appended {} to log at index {}", context.getCluster().member().address(), entry, entry.getIndex());
-        } else {
-          // Compare the term of the received entry with the matching entry in the log.
-          try (Entry match = context.getLog().get(entry.getIndex())) {
-            if (match != null) {
-              if (entry.getTerm() != match.getTerm()) {
-                // We found an invalid entry in the log. Remove the invalid entry and append the new entry.
-                // If appending to the log fails, apply commits and reply false to the append request.
-                LOGGER.debug("{} - Appended entry term does not match local log, removing incorrect entries", context.getCluster().member().address());
-                context.getLog().truncate(entry.getIndex() - 1).append(entry);
-                LOGGER.debug("{} - Appended {} to log at index {}", context.getCluster().member().address(), entry, entry.getIndex());
-              }
-            } else {
-              context.getLog().truncate(entry.getIndex() - 1).append(entry);
-              LOGGER.debug("{} - Appended {} to log at index {}", context.getCluster().member().address(), entry, entry.getIndex());
-            }
-          }
-        }
-
-        // If the entry is a configuration entry then immediately configure the cluster.
-        if (entry instanceof ConnectEntry) {
-          ConnectEntry connectEntry = (ConnectEntry) entry;
-          context.getStateMachine().executor().context().sessions().registerAddress(connectEntry.getClient(), connectEntry.getAddress());
-        }
+      // If the entry is a connect entry then immediately configure the connection.
+      if (entry instanceof ConnectEntry) {
+        ConnectEntry connectEntry = (ConnectEntry) entry;
+        context.getStateMachine().executor().context().sessions().registerAddress(connectEntry.getClient(), connectEntry.getAddress());
       }
     }
 
     // If we've made it this far, apply commits and send a successful response.
     // Apply commits to the state machine asynchronously so the append request isn't blocked on I/O.
-    long commitIndex = request.commitIndex();
-    context.setCommitIndex(Math.max(context.getCommitIndex(), commitIndex));
+    context.setCommitIndex(commitIndex);
     context.getThreadContext().execute(() -> context.getStateMachine().applyAll(commitIndex));
 
     return AppendResponse.builder()

--- a/server/src/main/java/io/atomix/copycat/server/state/ReserveState.java
+++ b/server/src/main/java/io/atomix/copycat/server/state/ReserveState.java
@@ -319,7 +319,6 @@ class ReserveState extends AbstractState {
         case ACTIVE:
           context.transition(CopycatServer.State.FOLLOWER);
           break;
-        case PROMOTABLE:
         case PASSIVE:
           context.transition(CopycatServer.State.PASSIVE);
           break;

--- a/server/src/main/java/io/atomix/copycat/server/state/ReserveState.java
+++ b/server/src/main/java/io/atomix/copycat/server/state/ReserveState.java
@@ -23,6 +23,7 @@ import io.atomix.copycat.server.CopycatServer;
 import io.atomix.copycat.server.cluster.Member;
 import io.atomix.copycat.server.request.*;
 import io.atomix.copycat.server.response.*;
+import io.atomix.copycat.server.storage.system.Configuration;
 
 import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
@@ -53,38 +54,11 @@ class ReserveState extends AbstractState {
     }).thenApply(v -> this);
   }
 
-  /**
-   * Forwards the given request to the leader if possible.
-   */
-  protected <T extends Request, U extends Response> CompletableFuture<U> forward(T request) {
-    CompletableFuture<U> future = new CompletableFuture<>();
-    context.getConnections().getConnection(context.getLeader().serverAddress()).whenComplete((connection, connectError) -> {
-      if (connectError == null) {
-        connection.<T, U>send(request).whenComplete((response, responseError) -> {
-          if (responseError == null) {
-            future.complete(response);
-          } else {
-            future.completeExceptionally(responseError);
-          }
-        });
-      } else {
-        future.completeExceptionally(connectError);
-      }
-    });
-    return future;
-  }
-
   @Override
   protected CompletableFuture<AppendResponse> append(AppendRequest request) {
     context.checkThread();
     logRequest(request);
-
-    // If the request indicates a term that is greater than the current term then
-    // assign that term and leader to the current context and step down as leader.
-    if (request.term() > context.getTerm() || (request.term() == context.getTerm() && context.getLeader() == null)) {
-      context.setTerm(request.term());
-      context.setLeader(request.leader());
-    }
+    updateTermAndLeader(request.term(), request.leader());
 
     return CompletableFuture.completedFuture(logResponse(AppendResponse.builder()
       .withStatus(Response.Status.OK)
@@ -109,6 +83,7 @@ class ReserveState extends AbstractState {
   protected CompletableFuture<VoteResponse> vote(VoteRequest request) {
     context.checkThread();
     logRequest(request);
+    updateTermAndLeader(request.term(), 0);
 
     return CompletableFuture.completedFuture(logResponse(VoteResponse.builder()
       .withStatus(Response.Status.ERROR)
@@ -120,6 +95,7 @@ class ReserveState extends AbstractState {
   protected CompletableFuture<CommandResponse> command(CommandRequest request) {
     context.checkThread();
     logRequest(request);
+
     if (context.getLeader() == null) {
       return CompletableFuture.completedFuture(logResponse(CommandResponse.builder()
         .withStatus(Response.Status.ERROR)
@@ -134,6 +110,7 @@ class ReserveState extends AbstractState {
   protected CompletableFuture<QueryResponse> query(QueryRequest request) {
     context.checkThread();
     logRequest(request);
+
     if (context.getLeader() == null) {
       return CompletableFuture.completedFuture(logResponse(QueryResponse.builder()
         .withStatus(Response.Status.ERROR)
@@ -296,39 +273,11 @@ class ReserveState extends AbstractState {
   protected CompletableFuture<ConfigureResponse> configure(ConfigureRequest request) {
     context.checkThread();
     logRequest(request);
+    updateTermAndLeader(request.term(), request.leader());
 
-    // If the request indicates a term that is greater than the current term then
-    // assign that term and leader to the current context and step down as leader.
-    if (request.term() > context.getTerm() || (request.term() == context.getTerm() && context.getLeader() == null)) {
-      context.setTerm(request.term());
-      context.setLeader(request.leader());
-    }
-
-    // Store the previous member type for comparison to determine whether this node should transition.
-    Member.Type previousType = context.getCluster().member().type();
-
-    // Configure the cluster membership.
-    context.getClusterState().configure(request.index(), request.members());
-
-    // If the local member type changed, transition the state as appropriate.
-    // ACTIVE servers are initialized to the FOLLOWER state but may transition to CANDIDATE or LEADER.
-    // PASSIVE servers are transitioned to the PASSIVE state.
-    Member.Type type = context.getCluster().member().type();
-    if (previousType != type) {
-      switch (type) {
-        case ACTIVE:
-          context.transition(CopycatServer.State.FOLLOWER);
-          break;
-        case PASSIVE:
-          context.transition(CopycatServer.State.PASSIVE);
-          break;
-        case RESERVE:
-          context.transition(CopycatServer.State.RESERVE);
-          break;
-        default:
-          transition(CopycatServer.State.INACTIVE);
-      }
-    }
+    // Configure the cluster membership. This will cause this server to transition to the
+    // appropriate state if its type has changed.
+    context.getClusterState().configure(new Configuration(request.index(), request.members()));
 
     return CompletableFuture.completedFuture(logResponse(ConfigureResponse.builder()
       .withStatus(Response.Status.OK)

--- a/server/src/main/java/io/atomix/copycat/server/state/ServerContext.java
+++ b/server/src/main/java/io/atomix/copycat/server/state/ServerContext.java
@@ -351,8 +351,8 @@ public class ServerContext implements AutoCloseable {
   ServerContext setCommitIndex(long commitIndex) {
     Assert.argNot(commitIndex < 0, "commit index must be positive");
     Assert.argNot(commitIndex < this.commitIndex, "cannot decrease commit index");
-    this.commitIndex = commitIndex;
-    log.commit(Math.min(commitIndex, log.lastIndex()));
+    this.commitIndex = Math.max(this.commitIndex, commitIndex);
+    log.commit(Math.min(this.commitIndex, log.lastIndex()));
     return this;
   }
 

--- a/server/src/main/java/io/atomix/copycat/server/storage/system/MetaStore.java
+++ b/server/src/main/java/io/atomix/copycat/server/storage/system/MetaStore.java
@@ -57,7 +57,7 @@ public class MetaStore implements AutoCloseable {
    * @return The metastore.
    */
   public MetaStore storeTerm(long term) {
-    buffer.writeLong(0, term);
+    buffer.writeLong(0, term).flush();
     return this;
   }
 
@@ -77,7 +77,7 @@ public class MetaStore implements AutoCloseable {
    * @return The metastore.
    */
   public MetaStore storeVote(int vote) {
-    buffer.writeInt(8, vote);
+    buffer.writeInt(8, vote).flush();
     return this;
   }
 
@@ -99,6 +99,7 @@ public class MetaStore implements AutoCloseable {
   public MetaStore storeConfiguration(Configuration configuration) {
     buffer.position(12).writeLong(configuration.index());
     storage.serializer().writeObject(configuration.members(), buffer);
+    buffer.flush();
     return this;
   }
 

--- a/test/src/test/java/io/atomix/copycat/test/ClusterTest.java
+++ b/test/src/test/java/io/atomix/copycat/test/ClusterTest.java
@@ -290,17 +290,13 @@ public class ClusterTest extends ConcurrentTestCase {
     CopycatServer server = servers.get(0);
     server.cluster().onJoin(m -> {
       threadAssertEquals(m.address(), member.address());
-      threadAssertEquals(m.type(), Member.Type.PROMOTABLE);
-      m.onTypeChange(t -> {
-        threadAssertEquals(t, Member.Type.ACTIVE);
-        resume();
-      });
+      threadAssertEquals(m.type(), Member.Type.ACTIVE);
       resume();
     });
 
     CopycatServer joiner = createServer(members, member);
     joiner.open().thenRun(this::resume);
-    await(10000, 3);
+    await(10000, 2);
   }
 
   /**


### PR DESCRIPTION
This PR modifies the process of configuring all node types to only commit `Configuration` changes to disk once the configuration has been committed to the cluster. This allows servers to reset their configuration back to the most recent committed configuration when the leader/term changes by loading the configuration from the `MetaStore`, and it helps account for the need to apply configuration changes prior to them being committed.