### PR TITLE
Ensure leader commits configuration change before stepping down when removing itself from the cluster

### DIFF
--- a/server/src/main/java/io/atomix/copycat/server/state/ActiveState.java
+++ b/server/src/main/java/io/atomix/copycat/server/state/ActiveState.java
@@ -162,9 +162,10 @@ abstract class ActiveState extends PassiveState {
     }
 
     // If we've made it this far, apply commits and send a successful response.
-    // Apply commits to the state machine asynchronously so the append request isn't blocked on I/O.
     long commitIndex = request.commitIndex();
     context.setCommitIndex(commitIndex);
+
+    // Apply commits to the local state machine.
     context.getStateMachine().applyAll(context.getCommitIndex());
 
     return AppendResponse.builder()

--- a/server/src/main/java/io/atomix/copycat/server/state/ClusterState.java
+++ b/server/src/main/java/io/atomix/copycat/server/state/ClusterState.java
@@ -359,10 +359,8 @@ final class ClusterState implements Cluster, AutoCloseable {
             Configuration configuration = new Configuration(response.index(), response.members());
 
             // Configure the cluster with the join response.
-            configure(configuration);
-
             // Commit the configuration as we know it was committed via the successful join response.
-            commit(configuration);
+            configure(configuration).commit();
 
             // Cancel the join timer.
             cancelJoinTimer();
@@ -495,7 +493,7 @@ final class ClusterState implements Cluster, AutoCloseable {
 
         // Configure the cluster and commit the configuration as we know the successful response
         // indicates commitment.
-        configure(configuration).commit(configuration);
+        configure(configuration).commit();
         future.complete(null);
       }
     });
@@ -523,12 +521,11 @@ final class ClusterState implements Cluster, AutoCloseable {
   }
 
   /**
-   * Commit the given configuration to disk.
+   * Commit the current configuration to disk.
    *
-   * @param configuration The configuration to commit.
    * @return The cluster state.
    */
-  ClusterState commit(Configuration configuration) {
+  ClusterState commit() {
     // If the local member has been removed from the committed configuration, transition the local member.
     if (!configuration.members().contains(member))
       context.transition(Member.Type.INACTIVE);

--- a/server/src/main/java/io/atomix/copycat/server/state/LeaderAppender.java
+++ b/server/src/main/java/io/atomix/copycat/server/state/LeaderAppender.java
@@ -301,7 +301,7 @@ final class LeaderAppender extends AbstractAppender {
     long commitIndex = members.get(quorumIndex()).getMatchIndex();
 
     // If the commit index has increased then update the commit index. Note that in order to ensure
-    // the leader completeness property holds, verify that the commit index is greater than or equal to
+    // the leader completeness property holds, we verify that the commit index is greater than or equal to
     // the index of the leader's no-op entry. Update the commit index and trigger commit futures.
     long previousCommitIndex = context.getCommitIndex();
     if (commitIndex > 0 && commitIndex > previousCommitIndex && (leaderIndex > 0 && commitIndex >= leaderIndex)) {

--- a/server/src/main/java/io/atomix/copycat/server/state/ServerContext.java
+++ b/server/src/main/java/io/atomix/copycat/server/state/ServerContext.java
@@ -334,6 +334,9 @@ public class ServerContext implements AutoCloseable {
     Assert.argNot(commitIndex < 0, "commit index must be positive");
     this.commitIndex = Math.max(this.commitIndex, commitIndex);
     log.commit(Math.min(this.commitIndex, log.lastIndex()));
+    if (cluster.getConfiguration().index() <= commitIndex) {
+      cluster.commit();
+    }
     return this;
   }
 

--- a/server/src/main/java/io/atomix/copycat/server/storage/entry/ConfigurationEntry.java
+++ b/server/src/main/java/io/atomix/copycat/server/storage/entry/ConfigurationEntry.java
@@ -22,6 +22,7 @@ import io.atomix.catalyst.serializer.Serializer;
 import io.atomix.catalyst.util.Assert;
 import io.atomix.catalyst.util.ReferenceManager;
 import io.atomix.copycat.server.cluster.Member;
+import io.atomix.copycat.server.storage.compaction.Compaction;
 
 import java.util.Collection;
 
@@ -44,6 +45,11 @@ public class ConfigurationEntry extends Entry<ConfigurationEntry> {
 
   public ConfigurationEntry(ReferenceManager<Entry<?>> referenceManager) {
     super(referenceManager);
+  }
+
+  @Override
+  public Compaction.Mode getCompactionMode() {
+    return Compaction.Mode.FULL;
   }
 
   /**


### PR DESCRIPTION
The current implementation of configuration changes does not account well for leaders leaving the cluster. When a leader leaves the cluster, the leader removes itself from the configuration and fails to respond to the original request to leave, thus preventing the `CompletableFuture` returned by `Cluster.leave()` from completing. The Raft dissertation specifies that when a leader is removing itself from the cluster configuration, the leader should commit the configuration change and then step down. This PR ensures that leaders remain until a configuration change is committed by not transitioning any local sever to the `INACTIVE` state until the configuration change is committed.