### PR TITLE
Compact logs up to globalIndex - 1

### DIFF
--- a/server/src/main/java/io/atomix/copycat/server/state/ServerContext.java
+++ b/server/src/main/java/io/atomix/copycat/server/state/ServerContext.java
@@ -358,7 +358,7 @@ public class ServerContext implements AutoCloseable {
   ServerContext setGlobalIndex(long globalIndex) {
     Assert.argNot(globalIndex < 0, "global index must be positive");
     this.globalIndex = Math.max(this.globalIndex, globalIndex);
-    log.compactor().majorIndex(globalIndex);
+    log.compactor().majorIndex(this.globalIndex - 1);
     return this;
   }
 


### PR DESCRIPTION
This PR modifies the log compaction index for major compaction to ensure that at least one globally replicated entry is always retained in the log. Because the `globalIndex` is based on the `matchIndex` of all active and passive members, this ensures that for entries marked with the `FULL` or `SEQUENTIAL` compaction mode, at least one entry will always be retained for all active/passive members. This is necessary for reading and sending information about the previous entry in `AppendRequest` (i.e. the member's `matchIndex`).