### PR TITLE
Ensure globalIndex is applied in passive follower servers

### DIFF
--- a/server/src/main/java/io/atomix/copycat/server/state/ActiveState.java
+++ b/server/src/main/java/io/atomix/copycat/server/state/ActiveState.java
@@ -162,8 +162,8 @@ abstract class ActiveState extends PassiveState {
     }
 
     // If we've made it this far, apply commits and send a successful response.
-    long commitIndex = request.commitIndex();
-    context.setCommitIndex(commitIndex);
+    context.setCommitIndex(request.commitIndex());
+    context.setGlobalIndex(request.globalIndex());
 
     // Apply commits to the local state machine.
     context.getStateMachine().applyAll(context.getCommitIndex());

--- a/server/src/main/java/io/atomix/copycat/server/state/PassiveState.java
+++ b/server/src/main/java/io/atomix/copycat/server/state/PassiveState.java
@@ -133,8 +133,11 @@ class PassiveState extends ReserveState {
       }
     }
 
-    // Update the context commit index and apply commits to the state machine.
+    // Update the context commit and global indices.
     context.setCommitIndex(commitIndex);
+    context.setGlobalIndex(request.globalIndex());
+
+    // Apply commits to the state machine in batch.
     context.getStateMachine().applyAll(context.getCommitIndex());
 
     return AppendResponse.builder()


### PR DESCRIPTION
This PR replaces missing logic for updating passive and follower servers `globalIndex` when an `AppendRequest` is received.