### PR TITLE
Account for hidden entries and infinite recursion in AppendRequest/Response

### DIFF
--- a/server/src/main/java/io/atomix/copycat/server/request/AppendRequest.java
+++ b/server/src/main/java/io/atomix/copycat/server/request/AppendRequest.java
@@ -315,7 +315,11 @@ public class AppendRequest extends AbstractRequest {
       super.build();
       Assert.stateNot(request.term <= 0, "term must be positive");
       Assert.stateNot(request.logIndex < 0, "log index must not be negative");
-      Assert.stateNot(request.logTerm < 0, "log term must not be negative");
+      if (request.logIndex > 0) {
+        Assert.stateNot(request.logTerm == 0, "log term must be specified");
+      } else {
+        Assert.stateNot(request.logTerm < 0, "log term must not be negative");
+      }
       Assert.stateNot(request.entries == null, "entries cannot be null");
       Assert.stateNot(request.commitIndex < 0, "commit index must not be negative");
       Assert.stateNot(request.globalIndex < 0, "global index must not be negative");

--- a/server/src/main/java/io/atomix/copycat/server/state/AbstractAppender.java
+++ b/server/src/main/java/io/atomix/copycat/server/state/AbstractAppender.java
@@ -335,7 +335,7 @@ abstract class AbstractAppender implements AutoCloseable {
       resetNextIndex(member);
 
       // If there are more entries to send then attempt to send another commit.
-      if (hasMoreEntries(member)) {
+      if (response.logIndex() != request.logIndex() && hasMoreEntries(member)) {
         appendEntries(member);
       }
     }


### PR DESCRIPTION
This PR fixes bugs in the replication process in cases wherein entries at the `matchIndex` for a follower can be hidden or compacted and thus `term` information is missing in `AppendRequest`. We account for hidden/compacted entries by always reading the last available entry from the log when sending an `AppendRequest`. Additionally, a side effect of sending `AppendRequest` with a term of `0` was infinite recursion where the follower responds with the same index as the `matchIndex` but fails the append, causing the leader to attempt the same request again. If the `request.logIndex() == response.logIndex()` then we simply do not retry an `AppendRequest` in the event of a failure.