### PR TITLE
Ensure last log entry is always visible for elections

### DIFF
--- a/server/src/main/java/io/atomix/copycat/server/storage/Log.java
+++ b/server/src/main/java/io/atomix/copycat/server/storage/Log.java
@@ -323,6 +323,12 @@ public class Log implements AutoCloseable {
     // For non-null entries, we determine whether the entry should be exposed to the Raft algorithm
     // based on the type of entry and whether it has been cleaned.
     if (entry != null) {
+      // The last entry in the log is always visible. This is necessary to ensure that candidates
+      // can properly read the last entry term for the voting protocol.
+      if (index == lastIndex()) {
+        return entry;
+      }
+
       Compaction.Mode mode = entry.getCompactionMode();
       if (mode == Compaction.Mode.DEFAULT) {
         mode = compactor.getDefaultCompactionMode();


### PR DESCRIPTION
Log cleaning can result in the last entry in the log being hidden if committed and cleaned. However, the leader election algorithm relies on being able to read the last entry in the log and in particular its term. This PR ensures that the last log entry is always non-null for the leader election algorithm.