### PR TITLE
Fix deadlock in concurrent leader elections

### DIFF
--- a/server/src/main/java/io/atomix/copycat/server/state/AbstractState.java
+++ b/server/src/main/java/io/atomix/copycat/server/state/AbstractState.java
@@ -103,7 +103,7 @@ abstract class AbstractState implements Managed<AbstractState> {
   protected boolean updateTermAndLeader(long term, int leader) {
     // If the request indicates a term that is greater than the current term or no leader has been
     // set for the current term, update leader and term.
-    if (term > context.getTerm() || (term == context.getTerm() && context.getLeader() == null)) {
+    if (term > context.getTerm() || (term == context.getTerm() && context.getLeader() == null && leader != 0)) {
       context.setTerm(term);
       context.setLeader(leader);
 

--- a/server/src/main/java/io/atomix/copycat/server/state/ActiveState.java
+++ b/server/src/main/java/io/atomix/copycat/server/state/ActiveState.java
@@ -282,7 +282,7 @@ abstract class ActiveState extends PassiveState {
     }
     // If we already voted for the requesting server, respond successfully.
     else if (context.getLastVotedFor() == request.candidate()) {
-      LOGGER.debug("{} - Accepted {}: already voted for {}", context.getCluster().member().address(), request, context.getLastVotedFor());
+      LOGGER.debug("{} - Accepted {}: already voted for {}", context.getCluster().member().address(), request, context.getCluster().member(context.getLastVotedFor()).address());
       return VoteResponse.builder()
         .withStatus(Response.Status.OK)
         .withTerm(context.getTerm())
@@ -291,7 +291,7 @@ abstract class ActiveState extends PassiveState {
     }
     // In this case, we've already voted for someone else.
     else {
-      LOGGER.debug("{} - Rejected {}: already voted for {}", context.getCluster().member().address(), request, context.getLastVotedFor());
+      LOGGER.debug("{} - Rejected {}: already voted for {}", context.getCluster().member().address(), request, context.getCluster().member(context.getLastVotedFor()).address());
       return VoteResponse.builder()
         .withStatus(Response.Status.OK)
         .withTerm(context.getTerm())

--- a/server/src/main/java/io/atomix/copycat/server/state/CandidateState.java
+++ b/server/src/main/java/io/atomix/copycat/server/state/CandidateState.java
@@ -82,7 +82,7 @@ final class CandidateState extends ActiveState {
 
     // When the election timer is reset, increment the current term and
     // restart the election.
-    context.setTerm(context.getTerm() + 1).setLastVotedFor(context.getCluster().member().address().hashCode());
+    context.setTerm(context.getTerm() + 1).setLastVotedFor(context.getCluster().member().id());
 
     Duration delay = context.getElectionTimeout().plus(Duration.ofMillis(random.nextInt((int) context.getElectionTimeout().toMillis())));
     currentTimer = context.getThreadContext().schedule(delay, () -> {
@@ -141,7 +141,7 @@ final class CandidateState extends ActiveState {
       LOGGER.debug("{} - Requesting vote from {} for term {}", context.getCluster().member().address(), member, context.getTerm());
       VoteRequest request = VoteRequest.builder()
         .withTerm(context.getTerm())
-        .withCandidate(context.getCluster().member().address().hashCode())
+        .withCandidate(context.getCluster().member().id())
         .withLogIndex(lastIndex)
         .withLogTerm(lastTerm)
         .build();

--- a/server/src/main/java/io/atomix/copycat/server/state/FollowerState.java
+++ b/server/src/main/java/io/atomix/copycat/server/state/FollowerState.java
@@ -83,13 +83,8 @@ final class FollowerState extends ActiveState {
       heartbeatTimer = null;
       if (isOpen()) {
         context.setLeader(0);
-        if (context.getLastVotedFor() == 0) {
-          LOGGER.debug("{} - Heartbeat timed out in {}", context.getCluster().member().address(), delay);
-          sendPollRequests();
-        } else {
-          // If the node voted for a candidate then reset the election timer.
-          resetHeartbeatTimeout();
-        }
+        LOGGER.debug("{} - Heartbeat timed out in {}", context.getCluster().member().address(), delay);
+        sendPollRequests();
       }
     });
   }


### PR DESCRIPTION
When multiple nodes start a new election at the same time and a split vote occurs, servers transition back to `FOLLOWER` but cannot transition back to `CANDIDATE` once the election times out again because of faulty logic that prevents transitioning if the local server has already voted for a candidate. This PR removes that logic to allow followers to transition after voting, at which time they'll increment the term and vote for themselves.