### PR TITLE
Allow inactive servers to be reconfigured

### DIFF
--- a/server/src/main/java/io/atomix/copycat/server/CopycatServer.java
+++ b/server/src/main/java/io/atomix/copycat/server/CopycatServer.java
@@ -486,26 +486,25 @@ public class CopycatServer implements Managed<CopycatServer> {
           Function<Void, CompletionStage<CopycatServer>> completionFunction = state -> {
             CompletableFuture<CopycatServer> future = new CompletableFuture<>();
             openFuture = null;
-            cluster().join()
-              .whenComplete((result, error) -> {
-                if (error == null) {
-                  if (cluster().leader() != null) {
-                    open = true;
-                    future.complete(this);
-                  } else {
-                    electionListener = cluster().onLeaderElection(leader -> {
-                      if (electionListener != null) {
-                        open = true;
-                        future.complete(this);
-                        electionListener.close();
-                        electionListener = null;
-                      }
-                    });
-                  }
+            cluster().join().whenComplete((result, error) -> {
+              if (error == null) {
+                if (cluster().leader() != null) {
+                  open = true;
+                  future.complete(this);
                 } else {
-                  future.completeExceptionally(error);
+                  electionListener = cluster().onLeaderElection(leader -> {
+                    if (electionListener != null) {
+                      open = true;
+                      future.complete(this);
+                      electionListener.close();
+                      electionListener = null;
+                    }
+                  });
                 }
-              });
+              } else {
+                future.completeExceptionally(error);
+              }
+            });
             return future;
           };
 

--- a/test/src/test/java/io/atomix/copycat/test/ClusterTest.java
+++ b/test/src/test/java/io/atomix/copycat/test/ClusterTest.java
@@ -283,20 +283,7 @@ public class ClusterTest extends ConcurrentTestCase {
    * Tests an active member join event.
    */
   public void testActiveJoinEvent() throws Throwable {
-    List<CopycatServer> servers = createServers(3);
-
-    Member member = nextMember(Member.Type.ACTIVE);
-
-    CopycatServer server = servers.get(0);
-    server.cluster().onJoin(m -> {
-      threadAssertEquals(m.address(), member.address());
-      threadAssertEquals(m.type(), Member.Type.ACTIVE);
-      resume();
-    });
-
-    CopycatServer joiner = createServer(members, member);
-    joiner.open().thenRun(this::resume);
-    await(10000, 2);
+    testJoinEvent(Member.Type.ACTIVE);
   }
 
   /**


### PR DESCRIPTION
This PR fixes a bug wherein a new server joining a cluster cannot transition to the appropriate state when configured by the leader. We add support for configuring an `INACTIVE` server to promote it to the appropriate state to e.g. participate in the replication protocol.