### PR TITLE
Modify log to reduce duplicate terms

### DIFF
--- a/server/src/main/java/io/atomix/copycat/server/state/FollowerState.java
+++ b/server/src/main/java/io/atomix/copycat/server/state/FollowerState.java
@@ -105,8 +105,7 @@ final class FollowerState extends ActiveState {
 
     // If there are no other members in the cluster, immediately transition to leader.
     if (votingMembers.isEmpty()) {
-      LOGGER.debug("{} - Single member cluster. Transitioning directly to leader.", context.getCluster().member().address());
-      context.transition(CopycatServer.State.LEADER);
+      context.transition(CopycatServer.State.CANDIDATE);
       return;
     }
 

--- a/server/src/main/java/io/atomix/copycat/server/storage/Log.java
+++ b/server/src/main/java/io/atomix/copycat/server/storage/Log.java
@@ -289,6 +289,29 @@ public class Log implements AutoCloseable {
   }
 
   /**
+   * Returns the term for the entry at the given index.
+   * <p>
+   * This method provides a more efficient means of reading an entry term without deserializing the entire entry.
+   * Servers should use this method when performing consistency checks that don't require reading the full entry
+   * object. Terms can typically be read in O(1) time with no disk access on segments that haven't been compacted.
+   * <p>
+   * If the given index is outside of the bounds of the log then a {@link IndexOutOfBoundsException} will be thrown. If
+   * the entry at the given index has been compacted then the returned entry will be {@code null}.
+   *
+   * @param index The index for which to return the term.
+   * @return The term for the entry at the given index.
+   */
+  public long term(long index) {
+    assertIsOpen();
+    assertValidIndex(index);
+
+    Segment segment = segments.segment(index);
+    Assert.index(segment != null, "invalid index: " + index);
+
+    return segment.term(index);
+  }
+
+  /**
    * Gets an entry from the log at the given index.
    * <p>
    * If the given index is outside of the bounds of the log then a {@link IndexOutOfBoundsException} will be thrown. If

--- a/server/src/main/java/io/atomix/copycat/server/storage/TermIndex.java
+++ b/server/src/main/java/io/atomix/copycat/server/storage/TermIndex.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License
+ */
+package io.atomix.copycat.server.storage;
+
+import java.util.Map;
+import java.util.TreeMap;
+
+/**
+ * Log entry term index.
+ * <p>
+ * The term index facilitates storing terms for a group of entries by relating the term only
+ * to the first offset for all entries in the term. Because terms are monotonically increasing,
+ * we can assume that if entry {@code n}'s term is {@code t} then entry {@code n + 1}'s term
+ * will be {@code t} or greater.
+ * <p>
+ * The implementation of the term index uses a {@link TreeMap} to store a map of offsets to
+ * terms. To look up the term for any given offset, we use {@code map.floorEntry(offset)}
+ * to loop up the term for the offset.
+ * <p>
+ * This class is thread safe.
+ *
+ * @author <a href="http://github.com/kuujo>Jordan Halterman</a>
+ */
+final class TermIndex {
+  private final TreeMap<Long, Long> terms = new TreeMap<>();
+
+  /**
+   * Returns the highest term in the index.
+   *
+   * @return The highest term in the index.
+   */
+  public synchronized long term() {
+    Map.Entry<Long, Long> entry = terms.lastEntry();
+    return entry != null ? entry.getValue() : 0;
+  }
+
+  /**
+   * Indexes the given offset with the given term.
+   *
+   * @param offset The offset to index.
+   * @param term The term to index.
+   */
+  public synchronized void index(long offset, long term) {
+    if (lookup(offset) != term) {
+      terms.put(offset, term);
+    }
+  }
+
+  /**
+   * Looks up the term for the given offset.
+   *
+   * @param offset The offset for which to look up the term.
+   * @return The term for the entry at the given offset.
+   */
+  public synchronized long lookup(long offset) {
+    Map.Entry<Long, Long> entry = terms.floorEntry(offset);
+    return entry != null ? entry.getValue() : 0;
+  }
+
+  /**
+   * Truncates the index to the given offset.
+   *
+   * @param offset The offset to which to truncate the index.
+   */
+  public synchronized void truncate(long offset) {
+    terms.tailMap(offset, false).clear();
+  }
+
+  @Override
+  public String toString() {
+    return getClass().getSimpleName();
+  }
+
+}

--- a/server/src/main/java/io/atomix/copycat/server/storage/entry/Entry.java
+++ b/server/src/main/java/io/atomix/copycat/server/storage/entry/Entry.java
@@ -146,12 +146,10 @@ public abstract class Entry<T extends Entry<T>> implements ReferenceCounted<Entr
 
   @Override
   public void writeObject(BufferOutput<?> buffer, Serializer serializer) {
-    buffer.writeLong(term);
   }
 
   @Override
   public void readObject(BufferInput<?> buffer, Serializer serializer) {
-    term = buffer.readLong();
   }
 
   @Override

--- a/server/src/main/java/io/atomix/copycat/server/storage/entry/TypedEntryPool.java
+++ b/server/src/main/java/io/atomix/copycat/server/storage/entry/TypedEntryPool.java
@@ -15,10 +15,10 @@
  */
 package io.atomix.copycat.server.storage.entry;
 
-import io.atomix.copycat.server.storage.StorageException;
 import io.atomix.catalyst.serializer.SerializationException;
 import io.atomix.catalyst.util.ReferenceManager;
 import io.atomix.catalyst.util.ReferencePool;
+import io.atomix.copycat.server.storage.StorageException;
 
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;

--- a/server/src/test/java/io/atomix/copycat/server/storage/AbstractLogTest.java
+++ b/server/src/test/java/io/atomix/copycat/server/storage/AbstractLogTest.java
@@ -69,7 +69,7 @@ public abstract class AbstractLogTest {
     TestEntry entry = new TestEntry();
     entry.setPadding(entryPadding);
     serializer.writeObject(entry, buffer);
-    return (int) buffer.position() + Short.BYTES + Long.BYTES;
+    return (int) buffer.position() + Short.BYTES + Long.BYTES + Byte.BYTES;
   }
 
   @BeforeMethod

--- a/server/src/test/java/io/atomix/copycat/server/storage/LogTest.java
+++ b/server/src/test/java/io/atomix/copycat/server/storage/LogTest.java
@@ -275,30 +275,6 @@ public abstract class LogTest extends AbstractLogTest {
   }
 
   /**
-   * Tests {@link Log#size()} across segments.
-   */
-  public void testSize() {
-    assertEquals(log.size(), 64);
-
-    appendEntries(entriesPerSegment * 3);
-    assertEquals(log.segments.segments().size(), 3);
-    assertEquals(log.size(), fullSegmentSize() * 3);
-    assertFalse(log.isEmpty());
-
-    appendEntries(entriesPerSegment * 2);
-    assertEquals(log.segments.segments().size(), 5);
-    assertEquals(log.size(), fullSegmentSize() * 5);
-
-    log.commit(entriesPerSegment * 5).compactor().minorIndex(entriesPerSegment * 5).majorIndex(entriesPerSegment * 5);
-
-    // Compact 2nd and 3rd segments
-    cleanAndCompact(entriesPerSegment + 1, entriesPerSegment * 3);
-
-    // Asserts that size() is changed after compaction
-    assertEquals(log.size(), (entrySize() * entriesPerSegment * 3) + (log.segments.segments().size() * SegmentDescriptor.BYTES));
-  }
-
-  /**
    * Tests skipping entries in the log across segments.
    */
   public void testSkip() throws Throwable {


### PR DESCRIPTION
This PR modifies the binary format of the log to reduce the number of terms that need to be stored in the log and support reading terms without having to deserialize entries during consistency checks. Because Raft guarantees that terms in the log are monotonically increasing, the log only needs to store the 64-bit term the first time it's written to the log, and subsequent entries written for the same term inherit that term. Terms are stored in memory in a `TreeMap` wrapped by `TermIndex`. Once all entries in a term are compacted from a segment, the term is removed from memory. The memory usage is acceptable. If terms are changing frequently enough to consume server memory then we have bigger problems to solve.