### PR TITLE
Ensure liveness for major compaction without configuration changes

### DIFF
--- a/server/src/main/java/io/atomix/copycat/server/state/LeaderAppender.java
+++ b/server/src/main/java/io/atomix/copycat/server/state/LeaderAppender.java
@@ -274,7 +274,7 @@ final class LeaderAppender extends AbstractAppender {
     // important to ensure that tombstones are applied to their state machines.
     // If the members list is empty, use the local server's last log index as the global index.
     long globalMatchIndex = context.getClusterState().getRemoteMemberStates().stream()
-      .filter(m -> m.getMember().type() != Member.Type.RESERVE)
+      .filter(m -> m.getMember().type() != Member.Type.RESERVE && m.getMember().status() == Member.Status.AVAILABLE)
       .mapToLong(MemberState::getMatchIndex)
       .min()
       .orElse(context.getLog().lastIndex());

--- a/server/src/main/java/io/atomix/copycat/server/state/PassiveState.java
+++ b/server/src/main/java/io/atomix/copycat/server/state/PassiveState.java
@@ -80,7 +80,7 @@ class PassiveState extends ReserveState {
   /**
    * Handles an append request.
    */
-  private AppendResponse handleAppend(AppendRequest request) {
+  protected AppendResponse handleAppend(AppendRequest request) {
     // If the request term is less than the current term then immediately
     // reply false and return our current term. The leader will receive
     // the updated term and step down.
@@ -92,7 +92,31 @@ class PassiveState extends ReserveState {
         .withSucceeded(false)
         .withLogIndex(context.getLog().lastIndex())
         .build();
-    } else if (request.logIndex() != 0) {
+    } else {
+      return checkGlobalIndex(request);
+    }
+  }
+
+  /**
+   * Checks whether the log needs to be truncated based on the globalIndex.
+   */
+  protected AppendResponse checkGlobalIndex(AppendRequest request) {
+    // If the globalIndex has changed and is not present in the local log, truncate the log.
+    // This ensures that if major compaction progressed on any server beyond the entries in this
+    // server's log that this server receives all entries after compaction.
+    // If the current global index is 0 then do not perform the index check. This ensures that
+    // servers don't truncate their logs at startup.
+    // Ensure that the globalIndex is updated here to prevent endlessly truncating the log
+    // if the AppendRequest is rejected.
+    long currentGlobalIndex = context.getGlobalIndex();
+    long nextGlobalIndex = request.globalIndex();
+    if (currentGlobalIndex > 0 && nextGlobalIndex > currentGlobalIndex && !context.getLog().contains(nextGlobalIndex)) {
+      context.setGlobalIndex(nextGlobalIndex);
+      context.getLog().truncate(0);
+    }
+
+    // If an entry was provided, check the entry against the local log.
+    if (request.logIndex() != 0) {
       return checkPreviousEntry(request);
     } else {
       return appendEntries(request);
@@ -102,7 +126,7 @@ class PassiveState extends ReserveState {
   /**
    * Checks the previous entry in the append request for consistency.
    */
-  private AppendResponse checkPreviousEntry(AppendRequest request) {
+  protected AppendResponse checkPreviousEntry(AppendRequest request) {
     if (request.logIndex() != 0 && context.getLog().isEmpty()) {
       LOGGER.debug("{} - Rejected {}: Previous index ({}) is greater than the local log's last index ({})", context.getCluster().member().address(), request, request.logIndex(), context.getLog().lastIndex());
       return AppendResponse.builder()
@@ -126,7 +150,7 @@ class PassiveState extends ReserveState {
   /**
    * Appends entries to the local log.
    */
-  private AppendResponse appendEntries(AppendRequest request) {
+  protected AppendResponse appendEntries(AppendRequest request) {
     // Append entries to the log starting at the last log index.
     long commitIndex = Math.max(context.getCommitIndex(), request.commitIndex());
     for (Entry entry : request.entries()) {

--- a/server/src/main/java/io/atomix/copycat/server/state/PassiveState.java
+++ b/server/src/main/java/io/atomix/copycat/server/state/PassiveState.java
@@ -112,7 +112,7 @@ class PassiveState extends ReserveState {
     long nextGlobalIndex = request.globalIndex();
     if (currentGlobalIndex > 0 && nextGlobalIndex > currentGlobalIndex && !context.getLog().contains(nextGlobalIndex)) {
       context.setGlobalIndex(nextGlobalIndex);
-      context.getLog().truncate(0);
+      context.reset();
     }
 
     // If an entry was provided, check the entry against the local log.


### PR DESCRIPTION
This PR improves the major compaction algorithm to allow the algorithm to progress while any member of the cluster is unreachable. Previously, major compaction could not progress while any stateful server was unavailable since it requires that the `globalIndex` progresses, and the `globalIndex` can't progress if entries can't be replicated to all servers in the cluster. This PR fixes that issue by determining on followers and passive servers whether the `globalIndex` has increased independently of that server's log. If the `globalIndex` progresses beyond a server's log's `lastIndex`, that server will simply truncate its log and receive all entries again. This ensures that if major compaction was performed on any server before a server received all tombstones, that server will receive a full snapshot of the compacted state. Without performing this operation, servers could potentially compact tombstones from their logs before those tombstones are received by a server.