### PR TITLE
Ensure servers use a shared serializer for communication and logging

### DIFF
--- a/server/src/main/java/io/atomix/copycat/server/CopycatServer.java
+++ b/server/src/main/java/io/atomix/copycat/server/CopycatServer.java
@@ -404,6 +404,15 @@ public class CopycatServer implements Managed<CopycatServer> {
   }
 
   /**
+   * Returns the server serializer.
+   *
+   * @return The server serializer.
+   */
+  public Serializer serializer() {
+    return context.getSerializer();
+  }
+
+  /**
    * Returns the Copycat server state.
    * <p>
    * The initial state of a Raft server is {@link State#INACTIVE}. Once the server is {@link #open() started} and
@@ -849,18 +858,13 @@ public class CopycatServer implements Managed<CopycatServer> {
 
       // If the storage is not configured, create a new Storage instance with the configured serializer.
       if (storage == null) {
-        storage = Storage.builder()
-          .withSerializer(serializer)
-          .build();
+        storage = new Storage();
       }
-
-      storage.serializer().resolve(new ServiceLoaderTypeResolver());
-      serializer.resolve(new ServiceLoaderTypeResolver());
 
       ConnectionManager connections = new ConnectionManager(serverTransport.client());
       ThreadContext threadContext = new SingleThreadContext("copycat-server-" + serverAddress, serializer);
 
-      ServerContext context = new ServerContext(name, type, serverAddress, clientAddress, cluster, storage, stateMachineFactory, connections, threadContext);
+      ServerContext context = new ServerContext(name, type, serverAddress, clientAddress, cluster, storage, serializer, stateMachineFactory, connections, threadContext);
       context.setElectionTimeout(electionTimeout)
         .setHeartbeatInterval(heartbeatInterval)
         .setSessionTimeout(sessionTimeout);

--- a/server/src/main/java/io/atomix/copycat/server/storage/Log.java
+++ b/server/src/main/java/io/atomix/copycat/server/storage/Log.java
@@ -122,8 +122,8 @@ public class Log implements AutoCloseable {
   /**
    * @throws NullPointerException if {@code name} or {@code storage} is null
    */
-  protected Log(String name, Storage storage) {
-    this.segments = new SegmentManager(name, storage);
+  protected Log(String name, Storage storage, Serializer serializer) {
+    this.segments = new SegmentManager(name, storage, serializer);
     this.compactor = new Compactor(storage, segments, Executors.newScheduledThreadPool(storage.compactionThreads(), new CatalystThreadFactory("copycat-compactor-%d")));
   }
 

--- a/server/src/main/java/io/atomix/copycat/server/storage/snapshot/FileSnapshot.java
+++ b/server/src/main/java/io/atomix/copycat/server/storage/snapshot/FileSnapshot.java
@@ -60,7 +60,7 @@ final class FileSnapshot extends Snapshot {
     descriptor.copyTo(buffer);
 
     int length = buffer.position(SnapshotDescriptor.BYTES).readInt();
-    return openWriter(new SnapshotWriter(buffer.skip(length).mark(), this, store.storage.serializer()), descriptor);
+    return openWriter(new SnapshotWriter(buffer.skip(length).mark(), this, store.serializer()), descriptor);
   }
 
   @Override
@@ -76,7 +76,7 @@ final class FileSnapshot extends Snapshot {
     Buffer buffer = FileBuffer.allocate(file.file(), SnapshotDescriptor.BYTES, store.storage.maxSnapshotSize());
     SnapshotDescriptor descriptor = new SnapshotDescriptor(buffer);
     int length = buffer.position(SnapshotDescriptor.BYTES).readInt();
-    return openReader(new SnapshotReader(buffer.mark().limit(SnapshotDescriptor.BYTES + Integer.BYTES + length), this, store.storage.serializer()), descriptor);
+    return openReader(new SnapshotReader(buffer.mark().limit(SnapshotDescriptor.BYTES + Integer.BYTES + length), this, store.serializer()), descriptor);
   }
 
   @Override

--- a/server/src/main/java/io/atomix/copycat/server/storage/snapshot/MemorySnapshot.java
+++ b/server/src/main/java/io/atomix/copycat/server/storage/snapshot/MemorySnapshot.java
@@ -50,7 +50,7 @@ final class MemorySnapshot extends Snapshot {
   @Override
   public SnapshotWriter writer() {
     checkWriter();
-    return new SnapshotWriter(buffer.reset().slice(), this, store.storage.serializer());
+    return new SnapshotWriter(buffer.reset().slice(), this, store.serializer());
   }
 
   @Override
@@ -61,7 +61,7 @@ final class MemorySnapshot extends Snapshot {
 
   @Override
   public synchronized SnapshotReader reader() {
-    return openReader(new SnapshotReader(buffer.reset().slice(), this, store.storage.serializer()), descriptor);
+    return openReader(new SnapshotReader(buffer.reset().slice(), this, store.serializer()), descriptor);
   }
 
   @Override

--- a/server/src/main/java/io/atomix/copycat/server/storage/snapshot/SnapshotStore.java
+++ b/server/src/main/java/io/atomix/copycat/server/storage/snapshot/SnapshotStore.java
@@ -17,6 +17,7 @@ package io.atomix.copycat.server.storage.snapshot;
 
 import io.atomix.catalyst.buffer.FileBuffer;
 import io.atomix.catalyst.buffer.HeapBuffer;
+import io.atomix.catalyst.serializer.Serializer;
 import io.atomix.catalyst.util.Assert;
 import io.atomix.copycat.server.storage.Storage;
 import io.atomix.copycat.server.storage.StorageLevel;
@@ -72,12 +73,14 @@ public class SnapshotStore implements AutoCloseable {
   private static final Logger LOGGER = LoggerFactory.getLogger(SnapshotStore.class);
   private final String name;
   final Storage storage;
+  private final Serializer serializer;
   private final TreeMap<Long, Snapshot> snapshots = new TreeMap<>();
   private Snapshot currentSnapshot;
 
-  public SnapshotStore(String name, Storage storage) {
+  public SnapshotStore(String name, Storage storage, Serializer serializer) {
     this.name = Assert.notNull(name, "name");
     this.storage = Assert.notNull(storage, "storage");
+    this.serializer = Assert.notNull(serializer, "serializer");
     open();
   }
 
@@ -92,6 +95,15 @@ public class SnapshotStore implements AutoCloseable {
     if (!snapshots.isEmpty()) {
       currentSnapshot = snapshots.lastEntry().getValue();
     }
+  }
+
+  /**
+   * Returns the snapshot store serializer.
+   *
+   * @return The snapshot store serializer.
+   */
+  public Serializer serializer() {
+    return serializer;
   }
 
   /**

--- a/server/src/test/java/io/atomix/copycat/server/state/AbstractStateTest.java
+++ b/server/src/test/java/io/atomix/copycat/server/state/AbstractStateTest.java
@@ -70,11 +70,11 @@ public abstract class AbstractStateTest<T extends AbstractState> extends Concurr
     transport = new LocalTransport(new LocalServerRegistry());
 
     serverCtx = new SingleThreadContext("test-server", serializer);
-    serverCtx.executor().execute(() -> {
+    new SingleThreadContext("test", serializer.clone()).executor().execute(() -> {
       serverContext = new ServerContext("test", members.get(0).type(), members.get(0).serverAddress(), members.get(0).clientAddress(), members.stream().map(ServerMember::serverAddress).collect(Collectors.toList()), storage, serializer, TestStateMachine::new, new ConnectionManager(transport.client()), serverCtx);
       resume();
     });
-    await();
+    await(1000);
   }
 
   /**

--- a/server/src/test/java/io/atomix/copycat/server/state/AbstractStateTest.java
+++ b/server/src/test/java/io/atomix/copycat/server/state/AbstractStateTest.java
@@ -63,13 +63,18 @@ public abstract class AbstractStateTest<T extends AbstractState> extends Concurr
     serializer.resolve(new ServiceLoaderTypeResolver());
 
     storage = new Storage(StorageLevel.MEMORY);
-    storage.serializer().resolve(new ServiceLoaderTypeResolver());
+    Serializer serializer = new Serializer(new ServiceLoaderTypeResolver());
+    serializer.disableWhitelist();
 
     members = createMembers(3);
     transport = new LocalTransport(new LocalServerRegistry());
 
     serverCtx = new SingleThreadContext("test-server", serializer);
-    serverContext = new ServerContext("test", members.get(0).type(), members.get(0).serverAddress(), members.get(0).clientAddress(), members.stream().map(ServerMember::serverAddress).collect(Collectors.toList()), storage, TestStateMachine::new, new ConnectionManager(transport.client()), serverCtx);
+    serverCtx.executor().execute(() -> {
+      serverContext = new ServerContext("test", members.get(0).type(), members.get(0).serverAddress(), members.get(0).clientAddress(), members.stream().map(ServerMember::serverAddress).collect(Collectors.toList()), storage, serializer, TestStateMachine::new, new ConnectionManager(transport.client()), serverCtx);
+      resume();
+    });
+    await();
   }
 
   /**

--- a/server/src/test/java/io/atomix/copycat/server/state/ServerStateMachineTest.java
+++ b/server/src/test/java/io/atomix/copycat/server/state/ServerStateMachineTest.java
@@ -76,11 +76,11 @@ public class ServerStateMachineTest extends ConcurrentTestCase {
       new Address("localhost", 5000)
     );
 
-    callerContext.executor().execute(() -> {
+    new SingleThreadContext("test", serializer.clone()).executor().execute(() -> {
       state = new ServerContext("test", member.type(), member.serverAddress(), member.clientAddress(), members, storage, serializer, TestStateMachine::new, new ConnectionManager(new LocalTransport(registry).client()), callerContext);
       resume();
     });
-    await();
+    await(1000);
     timestamp = System.currentTimeMillis();
     sequence = new AtomicLong();
   }

--- a/server/src/test/java/io/atomix/copycat/server/storage/FileSnapshotStoreTest.java
+++ b/server/src/test/java/io/atomix/copycat/server/storage/FileSnapshotStoreTest.java
@@ -46,12 +46,11 @@ public class FileSnapshotStoreTest extends AbstractSnapshotStoreTest {
    * Returns a new snapshot store.
    */
   protected SnapshotStore createSnapshotStore() {
-    return Storage.builder()
+    Storage storage = Storage.builder()
       .withStorageLevel(StorageLevel.DISK)
-      .withSerializer(new Serializer(new ServiceLoaderTypeResolver()))
       .withDirectory(new File(String.format("target/test-logs/%s", testId)))
-      .build()
-      .openSnapshotStore("test");
+      .build();
+    return new SnapshotStore("test", storage, new Serializer(new ServiceLoaderTypeResolver()));
   }
 
   /**

--- a/server/src/test/java/io/atomix/copycat/server/storage/LogTest.java
+++ b/server/src/test/java/io/atomix/copycat/server/storage/LogTest.java
@@ -38,13 +38,12 @@ public abstract class LogTest extends AbstractLogTest {
    */
   @Override
   protected Log createLog() {
-    return tempStorageBuilder().withDirectory(new File(String.format("target/test-logs/%s", logId)))
+    Storage storage = tempStorageBuilder().withDirectory(new File(String.format("target/test-logs/%s", logId)))
         .withMaxSegmentSize(Integer.MAX_VALUE)
         .withMaxEntriesPerSegment(entriesPerSegment)
         .withStorageLevel(storageLevel())
-        .withSerializer(new Serializer(new ServiceLoaderTypeResolver()))
-        .build()
-        .openLog("copycat");
+        .build();
+    return new Log("copycat", storage, new Serializer(new ServiceLoaderTypeResolver()));
   }
 
   /**

--- a/server/src/test/java/io/atomix/copycat/server/storage/MajorCompactionTest.java
+++ b/server/src/test/java/io/atomix/copycat/server/storage/MajorCompactionTest.java
@@ -33,11 +33,10 @@ import static org.testng.Assert.*;
 public class MajorCompactionTest extends AbstractLogTest {
 
   protected Log createLog() {
-    return tempStorageBuilder()
+    Storage storage = tempStorageBuilder()
       .withMaxEntriesPerSegment(10)
-      .withSerializer(new Serializer(new ServiceLoaderTypeResolver()))
-      .build()
-      .openLog("copycat");
+      .build();
+    return new Log("copycat", storage, new Serializer(new ServiceLoaderTypeResolver()));
   }
 
   /**

--- a/server/src/test/java/io/atomix/copycat/server/storage/MemorySnapshotStoreTest.java
+++ b/server/src/test/java/io/atomix/copycat/server/storage/MemorySnapshotStoreTest.java
@@ -32,11 +32,10 @@ public class MemorySnapshotStoreTest extends AbstractSnapshotStoreTest {
    * Returns a new snapshot store.
    */
   protected SnapshotStore createSnapshotStore() {
-    return Storage.builder()
+    Storage storage = Storage.builder()
       .withStorageLevel(StorageLevel.MEMORY)
-      .withSerializer(new Serializer(new ServiceLoaderTypeResolver()))
-      .build()
-      .openSnapshotStore("test");
+      .build();
+    return new SnapshotStore("test", storage, new Serializer(new ServiceLoaderTypeResolver()));
   }
 
 }

--- a/server/src/test/java/io/atomix/copycat/server/storage/MetaStoreTest.java
+++ b/server/src/test/java/io/atomix/copycat/server/storage/MetaStoreTest.java
@@ -55,11 +55,10 @@ public class MetaStoreTest {
    * Returns a new metastore.
    */
   protected MetaStore createMetaStore() {
-    return Storage.builder()
-      .withSerializer(new Serializer(new ServiceLoaderTypeResolver()))
+    Storage storage = Storage.builder()
       .withDirectory(new File(String.format("target/test-logs/%s", testId)))
-      .build()
-      .openMetaStore("test");
+      .build();
+    return new MetaStore("test", storage, new Serializer(new ServiceLoaderTypeResolver()));
   }
 
   /**

--- a/server/src/test/java/io/atomix/copycat/server/storage/MinorCompactionTest.java
+++ b/server/src/test/java/io/atomix/copycat/server/storage/MinorCompactionTest.java
@@ -33,11 +33,10 @@ import static org.testng.Assert.*;
 public class MinorCompactionTest extends AbstractLogTest {
 
   protected Log createLog() {
-    return tempStorageBuilder()
-        .withMaxEntriesPerSegment(10)
-        .withSerializer(new Serializer(new ServiceLoaderTypeResolver()))
-        .build()
-        .openLog("copycat");
+    Storage storage = tempStorageBuilder()
+      .withMaxEntriesPerSegment(10)
+      .build();
+    return new Log("copycat", storage, new Serializer(new ServiceLoaderTypeResolver()));
   }
   
   /**

--- a/test/src/test/java/io/atomix/copycat/test/ClusterTest.java
+++ b/test/src/test/java/io/atomix/copycat/test/ClusterTest.java
@@ -1360,6 +1360,7 @@ public class ClusterTest extends ConcurrentTestCase {
     }
 
     CopycatServer server = builder.build();
+    server.serializer().disableWhitelist();
     servers.add(server);
     return server;
   }
@@ -1373,6 +1374,7 @@ public class ClusterTest extends ConcurrentTestCase {
       .withConnectionStrategy(ConnectionStrategies.FIBONACCI_BACKOFF)
       .withRetryStrategy(RetryStrategies.FIBONACCI_BACKOFF)
       .build();
+    client.serializer().disableWhitelist();
     client.open().thenRun(this::resume);
     await(30000);
     clients.add(client);


### PR DESCRIPTION
This PR improves serialization in Copycat servers by ensuring servers share the same serializer between messaging and logs. This ensures that users can register serializable types programmatically and disable whitelisting for all serializers.