### PR TITLE
Ensure leader is unset when transitioning out of the leader state

### DIFF
--- a/server/src/main/java/io/atomix/copycat/server/state/LeaderState.java
+++ b/server/src/main/java/io/atomix/copycat/server/state/LeaderState.java
@@ -941,9 +941,21 @@ final class LeaderState extends ActiveState {
     }
   }
 
+  /**
+   * Ensures the local server is not the leader.
+   */
+  private void stepDown() {
+    if (context.getLeader().equals(context.getCluster().member())) {
+      context.setLeader(0);
+    }
+  }
+
   @Override
   public synchronized CompletableFuture<Void> close() {
-    return super.close().thenRun(appender::close).thenRun(this::cancelAppendTimer);
+    return super.close()
+      .thenRun(appender::close)
+      .thenRun(this::cancelAppendTimer)
+      .thenRun(this::stepDown);
   }
 
 }


### PR DESCRIPTION
This PR fixes a bug that can occur when the leader transitions out of the `LEADER` state but the leader is not unset from the `ServerContext`. In that case, if the server receives a request that needs to be forwarded to the leader, infinite recursion will occur from the server forwarding the request to itself until its configuration has been updated with the new leader.