### PR TITLE
Retry member reconfigure requests when no leader is present

### DIFF
--- a/server/src/main/java/io/atomix/copycat/server/state/ServerMember.java
+++ b/server/src/main/java/io/atomix/copycat/server/state/ServerMember.java
@@ -25,6 +25,7 @@ import io.atomix.catalyst.util.Assert;
 import io.atomix.catalyst.util.Listener;
 import io.atomix.catalyst.util.Listeners;
 import io.atomix.catalyst.util.concurrent.Scheduled;
+import io.atomix.copycat.client.error.RaftError;
 import io.atomix.copycat.client.response.Response;
 import io.atomix.copycat.server.cluster.Member;
 import io.atomix.copycat.server.request.ReconfigureRequest;
@@ -218,7 +219,7 @@ final class ServerMember implements Member, CatalystSerializable, AutoCloseable 
           cancelConfigureTimer();
           cluster.configure(new Configuration(response.index(), response.members()));
           future.complete(null);
-        } else if (response.error() == null) {
+        } else if (response.error() == null || response.error() == RaftError.Type.NO_LEADER_ERROR) {
           cancelConfigureTimer();
           configureTimeout = cluster.getContext().getThreadContext().schedule(cluster.getContext().getElectionTimeout().multipliedBy(2), () -> configure(type, future));
         } else {


### PR DESCRIPTION
This PR ensures that members retry attempts to reconfigure when a `NO_LEADER_ERROR` is returned by the server through which they attempt to submit the configuration change. This ensures that configuration changes can continue once a leader is found.