### PR TITLE
Fix NPE when resetting leader on leader transition

### DIFF
--- a/server/src/main/java/io/atomix/copycat/server/state/LeaderState.java
+++ b/server/src/main/java/io/atomix/copycat/server/state/LeaderState.java
@@ -945,7 +945,7 @@ final class LeaderState extends ActiveState {
    * Ensures the local server is not the leader.
    */
   private void stepDown() {
-    if (context.getLeader().equals(context.getCluster().member())) {
+    if (context.getLeader() != null && context.getLeader().equals(context.getCluster().member())) {
       context.setLeader(0);
     }
   }


### PR DESCRIPTION
This PR fixes an NPE that can result from the leader being unset while it's stepping down. 