### PR TITLE
Ensure commands from expired/removed sessions are applied on log replay

### DIFF
--- a/client/src/main/java/io/atomix/copycat/client/session/ClientSessionManager.java
+++ b/client/src/main/java/io/atomix/copycat/client/session/ClientSessionManager.java
@@ -83,6 +83,7 @@ final class ClientSessionManager {
           connection.reset(response.leader(), response.members());
           state.setSessionId(response.session())
             .setState(Session.State.OPEN);
+          state.getLogger().info("Registered session {}", response.session());
           attempt.complete();
           keepAlive();
         } else {

--- a/server/src/main/java/io/atomix/copycat/server/state/DummySession.java
+++ b/server/src/main/java/io/atomix/copycat/server/state/DummySession.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License
+ */
+package io.atomix.copycat.server.state;
+
+import io.atomix.catalyst.util.Listener;
+import io.atomix.copycat.client.session.Session;
+
+import java.util.function.Consumer;
+
+/**
+ * A dummy server session used for applying commands for which no session is registered.
+ *
+ * @author <a href="http://github.com/kuujo>Jordan Halterman</a>
+ */
+final class DummySession implements Session {
+  private final long id;
+
+  DummySession(long id) {
+    this.id = id;
+  }
+
+  @Override
+  public long id() {
+    return id;
+  }
+
+  @Override
+  public State state() {
+    return State.CLOSED;
+  }
+
+  @Override
+  public Listener<State> onStateChange(Consumer<State> callback) {
+    return new DummyListener<>();
+  }
+
+  @Override
+  public Session publish(String event) {
+    return this;
+  }
+
+  @Override
+  public Session publish(String event, Object message) {
+    return this;
+  }
+
+  @Override
+  public Listener<Void> onEvent(String event, Runnable callback) {
+    return new DummyListener<>();
+  }
+
+  @Override
+  public <T> Listener<T> onEvent(String event, Consumer<T> callback) {
+    return new DummyListener<>();
+  }
+
+  /**
+   * Dummy listener.
+   */
+  private static class DummyListener<T> implements Listener<T> {
+    @Override
+    public void accept(T t) {
+    }
+    @Override
+    public void close() {
+    }
+  }
+
+}

--- a/server/src/main/java/io/atomix/copycat/server/state/ServerCommit.java
+++ b/server/src/main/java/io/atomix/copycat/server/state/ServerCommit.java
@@ -33,17 +33,15 @@ import java.time.Instant;
 final class ServerCommit implements Commit<Operation<?>> {
   private final ServerCommitPool pool;
   private final Log log;
-  private final ServerSessionManager sessions;
   private long index;
   private Session session;
   private Instant instant;
   private Operation operation;
   private volatile boolean open;
 
-  public ServerCommit(ServerCommitPool pool, Log log, ServerSessionManager sessions) {
+  public ServerCommit(ServerCommitPool pool, Log log) {
     this.pool = pool;
     this.log = log;
-    this.sessions = sessions;
   }
 
   /**
@@ -51,9 +49,9 @@ final class ServerCommit implements Commit<Operation<?>> {
    *
    * @param entry The entry.
    */
-  void reset(OperationEntry<?> entry, long timestamp) {
+  void reset(OperationEntry<?> entry, Session session, long timestamp) {
     this.index = entry.getIndex();
-    this.session = sessions.getSession(entry.getSession());
+    this.session = session;
     this.instant = Instant.ofEpochMilli(timestamp);
     this.operation = entry.getOperation();
     open = true;

--- a/server/src/main/java/io/atomix/copycat/server/state/ServerCommitPool.java
+++ b/server/src/main/java/io/atomix/copycat/server/state/ServerCommitPool.java
@@ -16,6 +16,7 @@
 package io.atomix.copycat.server.state;
 
 import io.atomix.catalyst.util.Assert;
+import io.atomix.copycat.client.session.Session;
 import io.atomix.copycat.server.storage.Log;
 import io.atomix.copycat.server.storage.entry.OperationEntry;
 import org.slf4j.Logger;
@@ -46,12 +47,12 @@ final class ServerCommitPool implements AutoCloseable {
    * @param entry The entry for which to acquire the commit.
    * @return The commit to acquire.
    */
-  public ServerCommit acquire(OperationEntry entry, long timestamp) {
+  public ServerCommit acquire(OperationEntry entry, Session session, long timestamp) {
     ServerCommit commit = pool.poll();
     if (commit == null) {
-      commit = new ServerCommit(this, log, sessions);
+      commit = new ServerCommit(this, log);
     }
-    commit.reset(entry, timestamp);
+    commit.reset(entry, session, timestamp);
     return commit;
   }
 


### PR DESCRIPTION
This PR fixes a bug wherein commands are not being properly applied to the state machine on replay if the session that submitted the command has been removed from the log. Once a session is expired or unregistered, the session's register/unregister entries will be removed from the log, but its commands may remain since they can still contribute to the state machine's state. In the event of a replay of the log after a session's registration is removed, commands are rejected due to the missing session. This PR adds a `DummySession` to be passed to the state machine in place of the real session when the session has already been removed from the log, ensuring all available commands are properly applied.