### PR TITLE
Reject connections to reserve members

### DIFF
--- a/server/src/main/java/io/atomix/copycat/server/state/ServerSession.java
+++ b/server/src/main/java/io/atomix/copycat/server/state/ServerSession.java
@@ -568,6 +568,7 @@ class ServerSession implements Session {
   ServerSession resendEvents(long index) {
     clearEvents(index);
     for (EventHolder event : events) {
+      // TODO: Sequential events cannot be sent to clients connected to reserve members
       sendSequentialEvent(event);
     }
     return this;


### PR DESCRIPTION
Clients connected to `RESERVE` members cannot receive `SEQUENTIAL` events since reserve members are stateless. This PR resolves that issue by rejecting client connections to reserve members and requiring clients to be connected only to passive/active members. Alternatively, this could have been solved by proxying sequential events to clients connected to reserve members, but clients should not communicate unnecessarily with stateless servers anyways. This is a better solution in that it forces clients to connect to servers that are more likely to be able to service their requests.