### PR TITLE
Ensure client event listeners are properly registered on new sessions

### DIFF
--- a/client/src/main/java/io/atomix/copycat/client/DefaultCopycatClient.java
+++ b/client/src/main/java/io/atomix/copycat/client/DefaultCopycatClient.java
@@ -134,7 +134,7 @@ public class DefaultCopycatClient implements CopycatClient {
     changeListener = session.onStateChange(this::onStateChange);
 
     // Register all event listeners.
-    eventListeners.forEach(EventListener::register);
+    eventListeners.forEach(l -> l.register(session));
     return session;
   }
 
@@ -249,7 +249,7 @@ public class DefaultCopycatClient implements CopycatClient {
   @Override
   public <T> Listener<T> onEvent(String event, Consumer<T> callback) {
     EventListener<T> listener = new EventListener<>(event, callback);
-    listener.register();
+    listener.register(session);
     return listener;
   }
 
@@ -399,7 +399,7 @@ public class DefaultCopycatClient implements CopycatClient {
     /**
      * Registers the session event listener.
      */
-    public void register() {
+    public void register(Session session) {
       if (ThreadContext.currentContext() == context) {
         parent = session.onEvent(event, callback);
       } else {


### PR DESCRIPTION
Clients do not properly reregister session event listeners when recovering a session. During session recovery, the client creates a new session and populates the session with event listeners for the prior session. However, because the client's `session` field is not updated until after recovery, the listeners end up getting registered only on the expired session. This PR ensures that event listeners are reregistered on the recovered `Session` object.