### PR TITLE
Prevent recursion between follower and passive servers

### DIFF
--- a/server/src/main/java/io/atomix/copycat/server/state/LeaderAppender.java
+++ b/server/src/main/java/io/atomix/copycat/server/state/LeaderAppender.java
@@ -198,8 +198,16 @@ final class LeaderAppender extends AbstractAppender {
     }
     // If no AppendRequest is already being sent, send an AppendRequest.
     else if (canAppend(member)) {
-      sendAppendRequest(member, buildAppendRequest(member));
+      sendAppendRequest(member, buildAppendRequest(member, context.getLog().lastIndex()));
     }
+  }
+
+  @Override
+  protected boolean hasMoreEntries(MemberState member) {
+    // If the member's nextIndex is an entry in the local log then more entries can be sent.
+    return member.getMember().type() != Member.Type.RESERVE
+      && member.getMember().type() != Member.Type.PASSIVE
+      && member.getNextIndex() <= context.getLog().lastIndex();
   }
 
   /**


### PR DESCRIPTION
Followers replicating to passive members can recursively send `AppendRequest`s when `commitIndex` does not progress and the passive member's `lastIndex` is less than the `commitIndex`. Additionally, followers unnecessarily send uncommitted entries to passive members. This PR resolves both issues to ensure that followers only replicate to passive members and only send committed entries in `AppendRequest`.