### PR TITLE
Delete server storage on the proper context

### DIFF
--- a/server/src/main/java/io/atomix/copycat/server/state/ServerContext.java
+++ b/server/src/main/java/io/atomix/copycat/server/state/ServerContext.java
@@ -434,13 +434,13 @@ public class ServerContext implements AutoCloseable {
     // Delete the existing log.
     if (log != null) {
       log.close();
-      log.delete();
+      storage.deleteLog(name);
     }
 
     // Delete the existing snapshot store.
     if (snapshot != null) {
       snapshot.close();
-      snapshot.delete();
+      storage.deleteSnapshotStore(name);
     }
 
     // Open the log.
@@ -630,20 +630,14 @@ public class ServerContext implements AutoCloseable {
    * Deletes the server context.
    */
   public void delete() {
-    // Delete the metadata store.
-    MetaStore meta = storage.openMetaStore(name);
-    meta.close();
-    meta.delete();
-
     // Delete the log.
-    Log log = storage.openLog(name);
-    log.close();
-    log.delete();
+    storage.deleteLog(name);
 
     // Delete the snapshot store.
-    SnapshotStore snapshot = storage.openSnapshotStore(name);
-    snapshot.close();
-    snapshot.delete();
+    storage.deleteSnapshotStore(name);
+
+    // Delete the metadata store.
+    storage.deleteMetaStore(name);
   }
 
   @Override

--- a/server/src/main/java/io/atomix/copycat/server/storage/Log.java
+++ b/server/src/main/java/io/atomix/copycat/server/storage/Log.java
@@ -544,13 +544,6 @@ public class Log implements AutoCloseable {
     return !open;
   }
 
-  /**
-   * Deletes the log.
-   */
-  public void delete() {
-    segments.delete();
-  }
-
   @Override
   public String toString() {
     return String.format("%s[segments=%s]", getClass().getSimpleName(), segments);

--- a/server/src/main/java/io/atomix/copycat/server/storage/SegmentFile.java
+++ b/server/src/main/java/io/atomix/copycat/server/storage/SegmentFile.java
@@ -24,7 +24,7 @@ import java.io.File;
  *
  * @author <a href="http://github.com/kuujo">Jordan Halterman</a>
  */
-final class SegmentFile {
+public final class SegmentFile {
   private static final char PART_SEPARATOR = '-';
   private static final char EXTENSION_SEPARATOR = '.';
   private static final String EXTENSION = "log";
@@ -35,7 +35,7 @@ final class SegmentFile {
    * 
    * @throws NullPointerException if {@code file} is null
    */
-  static boolean isSegmentFile(String name, File file) {
+  public static boolean isSegmentFile(String name, File file) {
     Assert.notNull(name, "name");
     Assert.notNull(file, "file");
     String fileName = file.getName();

--- a/server/src/main/java/io/atomix/copycat/server/storage/SegmentManager.java
+++ b/server/src/main/java/io/atomix/copycat/server/storage/SegmentManager.java
@@ -482,16 +482,6 @@ public class SegmentManager implements AutoCloseable {
     currentSegment = null;
   }
 
-  /**
-   * Deletes all segments.
-   */
-  public void delete() {
-    segments.values().forEach(s -> {
-      LOGGER.debug("Deleting segment: {}", s.descriptor().id());
-      s.delete();
-    });
-  }
-
   @Override
   public String toString() {
     return String.format("%s[directory=%s, segments=%d]", getClass().getSimpleName(), storage.directory(), segments.size());

--- a/server/src/main/java/io/atomix/copycat/server/storage/Storage.java
+++ b/server/src/main/java/io/atomix/copycat/server/storage/Storage.java
@@ -18,6 +18,7 @@ package io.atomix.copycat.server.storage;
 import io.atomix.catalyst.util.Assert;
 import io.atomix.catalyst.util.concurrent.ThreadContext;
 import io.atomix.copycat.server.storage.snapshot.Snapshot;
+import io.atomix.copycat.server.storage.snapshot.SnapshotFile;
 import io.atomix.copycat.server.storage.snapshot.SnapshotStore;
 import io.atomix.copycat.server.storage.system.MetaStore;
 
@@ -249,6 +250,16 @@ public class Storage {
   }
 
   /**
+   * Deletes a {@link MetaStore}.
+   *
+   * @param name The metastore name.
+   */
+  public void deleteMetaStore(String name) {
+    StorageCleaner cleaner = new StorageCleaner(this);
+    cleaner.cleanFiles(f -> f.getName().equals(String.format("%s.meta", name)));
+  }
+
+  /**
    * Opens a new {@link SnapshotStore}.
    *
    * @param name The snapshot store name.
@@ -259,16 +270,37 @@ public class Storage {
   }
 
   /**
+   * Deletes a {@link SnapshotStore}.
+   *
+   * @param name The snapshot store name.
+   */
+  public void deleteSnapshotStore(String name) {
+    StorageCleaner cleaner = new StorageCleaner(this);
+    cleaner.cleanFiles(f -> SnapshotFile.isSnapshotFile(name, f));
+  }
+
+  /**
    * Opens a new {@link Log}.
    * <p>
    * When a log is opened, the log will attempt to load {@link Segment}s from the storage {@link #directory()}
    * according to the provided log {@code name}. If segments for the given log name are present on disk, segments
    * will be loaded and indexes will be rebuilt from disk. If no segments are found, an empty log will be created.
    *
+   * @param name The log name.
    * @return The opened log.
    */
   public Log openLog(String name) {
     return new Log(name, this, ThreadContext.currentContextOrThrow().serializer().clone());
+  }
+
+  /**
+   * Deletes a {@link Log}.
+   *
+   * @param name The log name.
+   */
+  public void deleteLog(String name) {
+    StorageCleaner cleaner = new StorageCleaner(this);
+    cleaner.cleanFiles(f -> SegmentFile.isSegmentFile(name, f));
   }
 
   @Override

--- a/server/src/main/java/io/atomix/copycat/server/storage/StorageCleaner.java
+++ b/server/src/main/java/io/atomix/copycat/server/storage/StorageCleaner.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License
+ */
+package io.atomix.copycat.server.storage;
+
+import io.atomix.catalyst.util.Assert;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.util.function.Predicate;
+
+/**
+ * Handles deletion of files.
+ *
+ * @author <a href="http://github.com/kuujo>Jordan Halterman</a>
+ */
+public class StorageCleaner {
+  private final Storage storage;
+
+  public StorageCleaner(Storage storage) {
+    this.storage = Assert.notNull(storage, "storage");
+  }
+
+  /**
+   * Cleans up files.
+   */
+  public void cleanFiles(Predicate<File> predicate) {
+    // Ensure storage directories are created.
+    storage.directory().mkdirs();
+
+    // Iterate through all files in the storage directory.
+    for (File file : storage.directory().listFiles(f -> f.isFile() && predicate.test(f))) {
+      try {
+        Files.delete(file.toPath());
+      } catch (IOException e) {
+        // Ignore the exception.
+      }
+    }
+  }
+
+}

--- a/server/src/main/java/io/atomix/copycat/server/storage/snapshot/SnapshotFile.java
+++ b/server/src/main/java/io/atomix/copycat/server/storage/snapshot/SnapshotFile.java
@@ -26,7 +26,7 @@ import java.util.Date;
  *
  * @author <a href="http://github.com/kuujo">Jordan Halterman</a>
  */
-final class SnapshotFile {
+public final class SnapshotFile {
   private static final SimpleDateFormat TIMESTAMP_FORMAT = new SimpleDateFormat("yyyyMMddHHmmss");
   private static final char PART_SEPARATOR = '-';
   private static final char EXTENSION_SEPARATOR = '.';
@@ -38,7 +38,7 @@ final class SnapshotFile {
    *
    * @throws NullPointerException if {@code file} is null
    */
-  static boolean isSnapshotFile(String name, File file) {
+  public static boolean isSnapshotFile(String name, File file) {
     Assert.notNull(name, "name");
     Assert.notNull(file, "file");
     String fileName = file.getName();

--- a/server/src/main/java/io/atomix/copycat/server/storage/snapshot/SnapshotStore.java
+++ b/server/src/main/java/io/atomix/copycat/server/storage/snapshot/SnapshotStore.java
@@ -254,16 +254,6 @@ public class SnapshotStore implements AutoCloseable {
   public void close() {
   }
 
-  /**
-   * Deletes the metastore.
-   */
-  public void delete() {
-    loadSnapshots().forEach(s -> {
-      s.close();
-      s.delete();
-    });
-  }
-
   @Override
   public String toString() {
     return getClass().getSimpleName();

--- a/server/src/main/java/io/atomix/copycat/server/storage/system/MetaStore.java
+++ b/server/src/main/java/io/atomix/copycat/server/storage/system/MetaStore.java
@@ -140,15 +140,6 @@ public class MetaStore implements AutoCloseable {
     buffer.close();
   }
 
-  /**
-   * Deletes the metastore.
-   */
-  public synchronized void delete() {
-    if (buffer instanceof FileBuffer) {
-      ((FileBuffer) buffer).delete();
-    }
-  }
-
   @Override
   public String toString() {
     if (buffer instanceof FileBuffer) {

--- a/server/src/test/java/io/atomix/copycat/server/storage/AbstractSnapshotStoreTest.java
+++ b/server/src/test/java/io/atomix/copycat/server/storage/AbstractSnapshotStoreTest.java
@@ -30,7 +30,6 @@ import static org.testng.Assert.*;
  */
 @Test
 public abstract class AbstractSnapshotStoreTest {
-  private String testId;
 
   /**
    * Returns a new snapshot store.

--- a/server/src/test/java/io/atomix/copycat/server/storage/LogTest.java
+++ b/server/src/test/java/io/atomix/copycat/server/storage/LogTest.java
@@ -15,8 +15,6 @@
  */
 package io.atomix.copycat.server.storage;
 
-import io.atomix.catalyst.serializer.Serializer;
-import io.atomix.catalyst.serializer.ServiceLoaderTypeResolver;
 import io.atomix.copycat.server.storage.compaction.Compaction;
 import org.testng.annotations.Test;
 
@@ -33,17 +31,14 @@ import static org.testng.Assert.*;
  */
 @Test
 public abstract class LogTest extends AbstractLogTest {
-  /**
-   * Creates a new log.
-   */
+
   @Override
-  protected Log createLog() {
-    Storage storage = tempStorageBuilder().withDirectory(new File(String.format("target/test-logs/%s", logId)))
-        .withMaxSegmentSize(Integer.MAX_VALUE)
-        .withMaxEntriesPerSegment(entriesPerSegment)
-        .withStorageLevel(storageLevel())
-        .build();
-    return new Log("copycat", storage, new Serializer(new ServiceLoaderTypeResolver()));
+  protected Storage createStorage() {
+    return tempStorageBuilder().withDirectory(new File(String.format("target/test-logs/%s", logId)))
+      .withMaxSegmentSize(Integer.MAX_VALUE)
+      .withMaxEntriesPerSegment(entriesPerSegment)
+      .withStorageLevel(storageLevel())
+      .build();
   }
 
   /**

--- a/server/src/test/java/io/atomix/copycat/server/storage/MajorCompactionTest.java
+++ b/server/src/test/java/io/atomix/copycat/server/storage/MajorCompactionTest.java
@@ -15,8 +15,6 @@
  */
 package io.atomix.copycat.server.storage;
 
-import io.atomix.catalyst.serializer.Serializer;
-import io.atomix.catalyst.serializer.ServiceLoaderTypeResolver;
 import io.atomix.copycat.server.storage.compaction.Compaction;
 import org.testng.annotations.Test;
 
@@ -32,11 +30,11 @@ import static org.testng.Assert.*;
 @Test
 public class MajorCompactionTest extends AbstractLogTest {
 
-  protected Log createLog() {
-    Storage storage = tempStorageBuilder()
+  @Override
+  protected Storage createStorage() {
+    return tempStorageBuilder()
       .withMaxEntriesPerSegment(10)
       .build();
-    return new Log("copycat", storage, new Serializer(new ServiceLoaderTypeResolver()));
   }
 
   /**

--- a/server/src/test/java/io/atomix/copycat/server/storage/MetaStoreTest.java
+++ b/server/src/test/java/io/atomix/copycat/server/storage/MetaStoreTest.java
@@ -50,12 +50,13 @@ import static org.testng.Assert.assertTrue;
 @Test
 public class MetaStoreTest {
   private String testId;
+  private Storage storage;
 
   /**
    * Returns a new metastore.
    */
   protected MetaStore createMetaStore() {
-    Storage storage = Storage.builder()
+    storage = Storage.builder()
       .withDirectory(new File(String.format("target/test-logs/%s", testId)))
       .build();
     return new MetaStore("test", storage, new Serializer(new ServiceLoaderTypeResolver()));
@@ -105,7 +106,7 @@ public class MetaStoreTest {
     meta = createMetaStore();
     assertEquals(meta.loadTerm(), 1);
     assertEquals(meta.loadVote(), 2);
-    meta.delete();
+    storage.deleteMetaStore("test");
     meta = createMetaStore();
     assertEquals(meta.loadTerm(), 0);
     assertEquals(meta.loadVote(), 0);

--- a/server/src/test/java/io/atomix/copycat/server/storage/MinorCompactionTest.java
+++ b/server/src/test/java/io/atomix/copycat/server/storage/MinorCompactionTest.java
@@ -15,8 +15,6 @@
  */
 package io.atomix.copycat.server.storage;
 
-import io.atomix.catalyst.serializer.Serializer;
-import io.atomix.catalyst.serializer.ServiceLoaderTypeResolver;
 import io.atomix.copycat.server.storage.compaction.Compaction;
 import org.testng.annotations.Test;
 
@@ -32,11 +30,11 @@ import static org.testng.Assert.*;
 @Test
 public class MinorCompactionTest extends AbstractLogTest {
 
-  protected Log createLog() {
-    Storage storage = tempStorageBuilder()
+  @Override
+  protected Storage createStorage() {
+    return tempStorageBuilder()
       .withMaxEntriesPerSegment(10)
       .build();
-    return new Log("copycat", storage, new Serializer(new ServiceLoaderTypeResolver()));
   }
   
   /**


### PR DESCRIPTION
Since the storage layer was refactored to use the local `ThreadContext` for serialization, deleting server storage (logs, metastore, and snapshots) no longer works correctly. Additionally, up until now deleting server logs required first loading the logs. This PR resolves both issues by deleting log/meta/snapshot files directly without having to load the log first. This ensures that server state can be deleted from any thread and prevents the unnecessary overhead of loading data from disk just to delete it.