### PR TITLE
Fix race condition in ServerSession state

### DIFF
--- a/server/src/main/java/io/atomix/copycat/server/state/ServerSession.java
+++ b/server/src/main/java/io/atomix/copycat/server/state/ServerSession.java
@@ -46,7 +46,8 @@ class ServerSession implements Session {
   private final UUID client;
   private final LogCleaner cleaner;
   private final ServerStateMachineContext context;
-  private volatile State state = State.CLOSED;
+  private boolean open;
+  private volatile State state = State.OPEN;
   private final long timeout;
   private Connection connection;
   private Address address;
@@ -102,7 +103,7 @@ class ServerSession implements Session {
    * Opens the session.
    */
   void open() {
-    setState(State.OPEN);
+    open = true;
   }
 
   @Override
@@ -514,6 +515,7 @@ class ServerSession implements Session {
 
   @Override
   public Session publish(String event, Object message) {
+    Assert.state(open, "cannot publish events during session registration");
     Assert.stateNot(state == State.CLOSED, "session is closed");
     Assert.stateNot(state == State.EXPIRED, "session is expired");
     Assert.state(context.consistency() != null, "session events can only be published during command execution");

--- a/server/src/main/java/io/atomix/copycat/server/state/ServerStateMachine.java
+++ b/server/src/main/java/io/atomix/copycat/server/state/ServerStateMachine.java
@@ -540,7 +540,7 @@ final class ServerStateMachine implements AutoCloseable {
       executor.executor().execute(() -> keepAliveSession(index, timestamp, commandSequence, eventIndex, session, future, context));
 
       // Update the session keep alive index for log cleaning.
-      session.setKeepAliveIndex(entry.getIndex());
+      session.setKeepAliveIndex(entry.getIndex()).setRequestSequence(commandSequence);
     }
 
     return future;


### PR DESCRIPTION
`ServerSession`s are initialized with a state of `CLOSE`d and then `OPEN`ed once the session has been registered with the state machine. However, because commands for closed sessions cannot be applied to the state machine, and because commands are applied in a different thread, this results in skipping some commands when replaying the log and applying commands to the state machine quickly. This PR resolves this issue by initializing `ServerSession` state to `OPEN` and using a boolean flag to prevent publishing within the `register` method.