### PR TITLE
Remove NONE consistency for commands

### DIFF
--- a/protocol/src/main/java/io/atomix/copycat/client/Command.java
+++ b/protocol/src/main/java/io/atomix/copycat/client/Command.java
@@ -81,15 +81,6 @@ public interface Command<T> extends Operation<T> {
   enum ConsistencyLevel {
 
     /**
-     * Enforces no command consistency.
-     * <p>
-     * Lack of consistency means that no guarantees are made with respect to when, how often, or in what order a command will
-     * be applied to server state machines. Inconsistent commands require no coordination, but they may be applied more than
-     * once or out of order.
-     */
-    NONE,
-
-    /**
      * Enforces sequential command consistency.
      * <p>
      * All commands are applied to the server state machine in program order and at some point between their invocation and

--- a/server/src/main/java/io/atomix/copycat/server/state/ServerSession.java
+++ b/server/src/main/java/io/atomix/copycat/server/state/ServerSession.java
@@ -300,9 +300,9 @@ class ServerSession implements Session {
    */
   ServerSession setCommandSequence(long sequence) {
     // For each increment of the sequence number, trigger query callbacks that are dependent on the specific sequence.
-    for (long i = this.commandSequence + 1; i <= sequence; i++) {
-      this.commandSequence = i;
-      List<Runnable> queries = this.sequenceQueries.remove(this.commandSequence);
+    for (long i = commandSequence + 1; i <= sequence; i++) {
+      commandSequence = i;
+      List<Runnable> queries = this.sequenceQueries.remove(commandSequence);
       if (queries != null) {
         for (Runnable query : queries) {
           query.run();
@@ -353,9 +353,9 @@ class ServerSession implements Session {
     // Query callbacks for this session are added to the indexQueries map to be executed once the required index
     // for the query is reached. For each increment of the index, trigger query callbacks that are dependent
     // on the specific index.
-    for (long i = this.lastApplied + 1; i <= index; i++) {
-      this.lastApplied = i;
-      List<Runnable> queries = this.indexQueries.remove(this.lastApplied);
+    for (long i = lastApplied + 1; i <= index; i++) {
+      lastApplied = i;
+      List<Runnable> queries = this.indexQueries.remove(lastApplied);
       if (queries != null) {
         for (Runnable query : queries) {
           query.run();

--- a/server/src/main/java/io/atomix/copycat/server/state/ServerStateMachine.java
+++ b/server/src/main/java/io/atomix/copycat/server/state/ServerStateMachine.java
@@ -841,7 +841,7 @@ final class ServerStateMachine implements AutoCloseable {
 
     // If the command's consistency level is not LINEARIZABLE or null (which are equivalent), return the
     // cached response immediately in the server thread.
-    if (consistency == Command.ConsistencyLevel.NONE || consistency == Command.ConsistencyLevel.SEQUENTIAL) {
+    if (consistency == Command.ConsistencyLevel.SEQUENTIAL) {
       Object response = session.getResponse(sequence);
       if (response == null) {
         context.executor().execute(() -> future.complete(null));

--- a/test/src/test/java/io/atomix/copycat/test/ClusterTest.java
+++ b/test/src/test/java/io/atomix/copycat/test/ClusterTest.java
@@ -353,13 +353,6 @@ public class ClusterTest extends ConcurrentTestCase {
   /**
    * Tests submitting a command.
    */
-  public void testOneNodeSubmitCommandWithNoneConsistency() throws Throwable {
-    testSubmitCommand(1, Command.ConsistencyLevel.NONE);
-  }
-
-  /**
-   * Tests submitting a command.
-   */
   public void testOneNodeSubmitCommandWithSequentialConsistency() throws Throwable {
     testSubmitCommand(1, Command.ConsistencyLevel.SEQUENTIAL);
   }
@@ -369,13 +362,6 @@ public class ClusterTest extends ConcurrentTestCase {
    */
   public void testOneNodeSubmitCommandWithLinearizableConsistency() throws Throwable {
     testSubmitCommand(1, Command.ConsistencyLevel.LINEARIZABLE);
-  }
-
-  /**
-   * Tests submitting a command.
-   */
-  public void testTwoNodeSubmitCommandWithNoneConsistency() throws Throwable {
-    testSubmitCommand(2, Command.ConsistencyLevel.NONE);
   }
 
   /**
@@ -395,13 +381,6 @@ public class ClusterTest extends ConcurrentTestCase {
   /**
    * Tests submitting a command.
    */
-  public void testThreeNodeSubmitCommandWithNoneConsistency() throws Throwable {
-    testSubmitCommand(3, Command.ConsistencyLevel.NONE);
-  }
-
-  /**
-   * Tests submitting a command.
-   */
   public void testThreeNodeSubmitCommandWithSequentialConsistency() throws Throwable {
     testSubmitCommand(3, Command.ConsistencyLevel.SEQUENTIAL);
   }
@@ -416,13 +395,6 @@ public class ClusterTest extends ConcurrentTestCase {
   /**
    * Tests submitting a command.
    */
-  public void testFourNodeSubmitCommandWithNoneConsistency() throws Throwable {
-    testSubmitCommand(4, Command.ConsistencyLevel.NONE);
-  }
-
-  /**
-   * Tests submitting a command.
-   */
   public void testFourNodeSubmitCommandWithSequentialConsistency() throws Throwable {
     testSubmitCommand(4, Command.ConsistencyLevel.SEQUENTIAL);
   }
@@ -432,13 +404,6 @@ public class ClusterTest extends ConcurrentTestCase {
    */
   public void testFourNodeSubmitCommandWithLinearizableConsistency() throws Throwable {
     testSubmitCommand(4, Command.ConsistencyLevel.LINEARIZABLE);
-  }
-
-  /**
-   * Tests submitting a command.
-   */
-  public void testFiveNodeSubmitCommandWithNoneConsistency() throws Throwable {
-    testSubmitCommand(5, Command.ConsistencyLevel.NONE);
   }
 
   /**
@@ -473,13 +438,6 @@ public class ClusterTest extends ConcurrentTestCase {
   /**
    * Tests submitting a command.
    */
-  public void testTwoOfThreeNodeSubmitCommandWithNoneConsistency() throws Throwable {
-    testSubmitCommand(2, 3, Command.ConsistencyLevel.NONE);
-  }
-
-  /**
-   * Tests submitting a command.
-   */
   public void testTwoOfThreeNodeSubmitCommandWithSequentialConsistency() throws Throwable {
     testSubmitCommand(2, 3, Command.ConsistencyLevel.SEQUENTIAL);
   }
@@ -494,13 +452,6 @@ public class ClusterTest extends ConcurrentTestCase {
   /**
    * Tests submitting a command.
    */
-  public void testThreeOfFourNodeSubmitCommandWithNoneConsistency() throws Throwable {
-    testSubmitCommand(3, 4, Command.ConsistencyLevel.NONE);
-  }
-
-  /**
-   * Tests submitting a command.
-   */
   public void testThreeOfFourNodeSubmitCommandWithSequentialConsistency() throws Throwable {
     testSubmitCommand(3, 4, Command.ConsistencyLevel.SEQUENTIAL);
   }
@@ -510,13 +461,6 @@ public class ClusterTest extends ConcurrentTestCase {
    */
   public void testThreeOfFourNodeSubmitCommandWithLinearizableConsistency() throws Throwable {
     testSubmitCommand(3, 4, Command.ConsistencyLevel.LINEARIZABLE);
-  }
-
-  /**
-   * Tests submitting a command.
-   */
-  public void testThreeOfFiveNodeSubmitCommandWithNoneConsistency() throws Throwable {
-    testSubmitCommand(3, 5, Command.ConsistencyLevel.NONE);
   }
 
   /**


### PR DESCRIPTION
This PR removes the `NONE` consistency level for commands which isn't actually used internally.