### PR TITLE
Ensure queries are sequenced to the state machine on the proper thread

### DIFF
--- a/server/src/main/java/io/atomix/copycat/server/state/ServerStateMachine.java
+++ b/server/src/main/java/io/atomix/copycat/server/state/ServerStateMachine.java
@@ -980,10 +980,10 @@ final class ServerStateMachine implements AutoCloseable {
         if (index > session.getLastApplied()) {
           session.registerIndexQuery(index, () -> {
             context.checkThread();
-            executeQuery(commit, session, future, context);
+            executor.executor().execute(() -> executeQuery(commit, session, future, context));
           });
         } else {
-          executeQuery(commit, session, future, context);
+          executor.executor().execute(() -> executeQuery(commit, session, future, context));
         }
       });
       return future;
@@ -997,7 +997,7 @@ final class ServerStateMachine implements AutoCloseable {
       ServerCommit commit = commits.acquire(entry, session, executor.timestamp());
       session.registerIndexQuery(entry.getIndex(), () -> {
         context.checkThread();
-        executeQuery(commit, session, future, context);
+        executor.executor().execute(() -> executeQuery(commit, session, future, context));
       });
       return future;
     } else {


### PR DESCRIPTION
State machine queries which arrive out-of-order on a follower or passive node must be queued until the relevant command has been applied to the state machine. However, the state machine currently applies queued queries in the server thread rather than the state machine thread. This PR resolves that issue to ensure queued queries are properly applied in the state machine thread.