### PR TITLE
Close local client connections when a client reconnects to a differen…

### DIFF
--- a/server/src/main/java/io/atomix/copycat/server/state/ServerStateMachine.java
+++ b/server/src/main/java/io/atomix/copycat/server/state/ServerStateMachine.java
@@ -59,7 +59,7 @@ final class ServerStateMachine implements AutoCloseable {
     this.stateMachine = Assert.notNull(stateMachine, "stateMachine");
     this.state = Assert.notNull(state, "state");
     this.log = state.getLog();
-    this.executor = new ServerStateMachineExecutor(new ServerStateMachineContext(state.getConnections(), new ServerSessionManager()), executor);
+    this.executor = new ServerStateMachineExecutor(new ServerStateMachineContext(state.getConnections(), new ServerSessionManager(state)), executor);
     this.commits = new ServerCommitPool(log, this.executor.context().sessions());
     init();
   }


### PR DESCRIPTION
…t member

When a client reconnects to a different member, it is expected that any connection that client may previous have with this member is already closed. This change merely ensures that those connections are closed when a new address is registered.

For background: I have a transport implementation that is built on top of a connection-less messaging layer. Catalyst connections that are implemented on top of this connection-less layer have some limitations in that closing a connection on end does not automatically trigger a close event on the remote side. Stale connections do get garbage collected, but that typically occurs after delay.

With this change we guarantee that when a client reconnects to a different member only that member will maintain an active connection to the client thereby ensuring session events are sent to the client over the correct connection.

