### PR TITLE
Ensure single member does not shut down from uncommitted configuration

### DIFF
--- a/server/src/main/java/io/atomix/copycat/server/state/ClusterState.java
+++ b/server/src/main/java/io/atomix/copycat/server/state/ClusterState.java
@@ -483,7 +483,7 @@ final class ClusterState implements Cluster, AutoCloseable {
         joinFuture.completeExceptionally(new IllegalStateException("failed to join cluster"));
 
       // If there are no remote members to leave, simply transition the server to INACTIVE.
-      if (getActiveMemberStates().isEmpty()) {
+      if (getActiveMemberStates().isEmpty() && configuration.index() <= context.getCommitIndex()) {
         LOGGER.debug("{} - Single member cluster. Transitioning directly to inactive.", member().address());
         context.transition(CopycatServer.State.INACTIVE);
         leaveFuture.complete(null);

--- a/test/src/test/java/io/atomix/copycat/test/ClusterTest.java
+++ b/test/src/test/java/io/atomix/copycat/test/ClusterTest.java
@@ -190,6 +190,19 @@ public class ClusterTest extends ConcurrentTestCase {
   }
 
   /**
+   * Tests joining and leaving the cluster, resizing the quorum.
+   */
+  public void testResize() throws Throwable {
+    CopycatServer server = createServers(1).get(0);
+    CopycatServer joiner = createServer(members, nextMember(Member.Type.ACTIVE));
+    joiner.open().thenRun(this::resume);
+    await(10000);
+    server.close().thenRun(this::resume);
+    await(10000);
+    joiner.close().thenRun(this::resume);
+  }
+
+  /**
    * Tests an availability change of an active member.
    */
   public void testActiveAvailabilityChange() throws Throwable {


### PR DESCRIPTION
This PR fixes a bug that can occur in a two-member cluster when both members are shut down concurrently. If the leader is shut down and replicates a configuration change to the follower, the follower immediately applies that configuration change. If the follower is then closed, it will shut down immediately - assuming it's a one-member cluster - preventing the leader from committing the configuration change via `AppendRequest`s. To avoid this scenario, single-member servers only shut down immediately if the current configuration has been committed.