### PR TITLE
squid:SwitchLastCaseIsDefaultCheck - "switch" statements should end with a "default" clause

### DIFF
--- a/client/src/main/java/io/atomix/copycat/client/DefaultCopycatClient.java
+++ b/client/src/main/java/io/atomix/copycat/client/DefaultCopycatClient.java
@@ -159,6 +159,8 @@ public class DefaultCopycatClient implements CopycatClient {
       case CLOSED:
         setState(State.CLOSED);
         break;
+      default:
+        break;
     }
   }
 

--- a/protocol/src/main/java/io/atomix/copycat/client/response/Response.java
+++ b/protocol/src/main/java/io/atomix/copycat/client/response/Response.java
@@ -57,6 +57,8 @@ public interface Response extends CatalystSerializable {
           return OK;
         case 0:
           return ERROR;
+        default:
+          break;
       }
       throw new IllegalArgumentException("invalid status identifier: " + id);
     }

--- a/server/src/main/java/io/atomix/copycat/server/storage/Log.java
+++ b/server/src/main/java/io/atomix/copycat/server/storage/Log.java
@@ -382,6 +382,8 @@ public class Log implements AutoCloseable {
             return entry;
           }
           break;
+        default:
+          break;
       }
     }
     return null;

--- a/server/src/main/java/io/atomix/copycat/server/storage/compaction/MajorCompactionTask.java
+++ b/server/src/main/java/io/atomix/copycat/server/storage/compaction/MajorCompactionTask.java
@@ -260,6 +260,8 @@ public final class MajorCompactionTask implements CompactionTask {
           transferEntry(entry, compactSegment);
         }
         break;
+      default:
+        break;
     }
   }
 

--- a/server/src/main/java/io/atomix/copycat/server/storage/compaction/MinorCompactionTask.java
+++ b/server/src/main/java/io/atomix/copycat/server/storage/compaction/MinorCompactionTask.java
@@ -163,6 +163,8 @@ public final class MinorCompactionTask implements CompactionTask {
       case UNKNOWN:
         transferEntry(index, entry, compactSegment);
         break;
+      default:
+        break;
     }
   }
 


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule
squid:SwitchLastCaseIsDefaultCheck - "switch" statements should end with a "default" clause.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/coding_rules#q=squid%3ASwitchLastCaseIsDefaultCheck
Please let me know if you have any questions.
George Kankava