### PR TITLE
Reset follower state if globalIndex is greater than last log index

### DIFF
--- a/server/src/main/java/io/atomix/copycat/server/state/PassiveState.java
+++ b/server/src/main/java/io/atomix/copycat/server/state/PassiveState.java
@@ -148,7 +148,7 @@ class PassiveState extends ReserveState {
     // if the AppendRequest is rejected.
     long currentGlobalIndex = context.getGlobalIndex();
     long nextGlobalIndex = request.globalIndex();
-    if (currentGlobalIndex > 0 && nextGlobalIndex > currentGlobalIndex && !context.getLog().contains(nextGlobalIndex)) {
+    if (currentGlobalIndex > 0 && nextGlobalIndex > currentGlobalIndex && nextGlobalIndex > context.getLog().lastIndex()) {
       context.setGlobalIndex(nextGlobalIndex);
       context.reset();
     }


### PR DESCRIPTION
This PR fixes a bug associated with #158. When a follower checks if the `globalIndex` received from a leader is within the bounds of the follower's log, it currently does so using `contains`. However, `contains` excludes released and/or compacted entries in the log. Instead, this modification compares `globalIndex` against the log's `lastIndex` to simply check that the `globalIndex` is within the bounds of the log.