### PR TITLE
Prevent globalIndex from increasing until after a configurable global suspend timeout

### DIFF
--- a/server/src/main/java/io/atomix/copycat/server/CopycatServer.java
+++ b/server/src/main/java/io/atomix/copycat/server/CopycatServer.java
@@ -800,7 +800,7 @@ public class CopycatServer implements Managed<CopycatServer> {
      */
     public Builder withGlobalSuspendTimeout(Duration globalSuspendTimeout) {
       Assert.notNull(globalSuspendTimeout, "globalSuspendTimeout");
-      this.globalSuspendTimeout = Assert.argNot(globalSuspendTimeout, globalSuspendTimeout.isNegative() || globalSuspendTimeout.isZero(), "followerResetInterval must be positive");
+      this.globalSuspendTimeout = Assert.argNot(globalSuspendTimeout, globalSuspendTimeout.isNegative() || globalSuspendTimeout.isZero(), "globalSuspendTimeout must be positive");
       return this;
     }
 

--- a/server/src/main/java/io/atomix/copycat/server/CopycatServer.java
+++ b/server/src/main/java/io/atomix/copycat/server/CopycatServer.java
@@ -624,6 +624,7 @@ public class CopycatServer implements Managed<CopycatServer> {
     private static final Duration DEFAULT_ELECTION_TIMEOUT = Duration.ofMillis(750);
     private static final Duration DEFAULT_HEARTBEAT_INTERVAL = Duration.ofMillis(250);
     private static final Duration DEFAULT_SESSION_TIMEOUT = Duration.ofMillis(5000);
+    private static final Duration DEFAULT_GLOBAL_SUSPEND_TIMEOUT = Duration.ofHours(1);
 
     private String name = DEFAULT_NAME;
     private Member.Type type = Member.Type.ACTIVE;
@@ -638,6 +639,7 @@ public class CopycatServer implements Managed<CopycatServer> {
     private Duration electionTimeout = DEFAULT_ELECTION_TIMEOUT;
     private Duration heartbeatInterval = DEFAULT_HEARTBEAT_INTERVAL;
     private Duration sessionTimeout = DEFAULT_SESSION_TIMEOUT;
+    private Duration globalSuspendTimeout = DEFAULT_GLOBAL_SUSPEND_TIMEOUT;
 
     private Builder(Address clientAddress, Address serverAddress, Collection<Address> cluster) {
       this.clientAddress = Assert.notNull(clientAddress, "clientAddress");
@@ -778,7 +780,7 @@ public class CopycatServer implements Managed<CopycatServer> {
      * Sets the Raft session timeout, returning the Raft configuration for method chaining.
      *
      * @param sessionTimeout The Raft session timeout duration.
-     * @return The Raft configuration.
+     * @return The server builder.
      * @throws IllegalArgumentException If the session timeout is not positive
      * @throws NullPointerException if {@code sessionTimeout} is null
      */
@@ -786,6 +788,19 @@ public class CopycatServer implements Managed<CopycatServer> {
       Assert.argNot(sessionTimeout.isNegative() || sessionTimeout.isZero(), "sessionTimeout must be positive");
       Assert.argNot(sessionTimeout.toMillis() <= electionTimeout.toMillis(), "sessionTimeout must be greater than electionTimeout");
       this.sessionTimeout = Assert.notNull(sessionTimeout, "sessionTimeout");
+      return this;
+    }
+
+    /**
+     * Sets the timeout after which suspended global replication will resume and force a partitioned follower
+     * to truncate its log once the partition heals.
+     *
+     * @param globalSuspendTimeout The timeout after which to resume global replication.
+     * @return The server builder.
+     */
+    public Builder withGlobalSuspendTimeout(Duration globalSuspendTimeout) {
+      Assert.notNull(globalSuspendTimeout, "globalSuspendTimeout");
+      this.globalSuspendTimeout = Assert.argNot(globalSuspendTimeout, globalSuspendTimeout.isNegative() || globalSuspendTimeout.isZero(), "followerResetInterval must be positive");
       return this;
     }
 
@@ -836,7 +851,8 @@ public class CopycatServer implements Managed<CopycatServer> {
       ServerContext context = new ServerContext(name, type, serverAddress, clientAddress, cluster, storage, serializer, stateMachineFactory, connections, threadContext);
       context.setElectionTimeout(electionTimeout)
         .setHeartbeatInterval(heartbeatInterval)
-        .setSessionTimeout(sessionTimeout);
+        .setSessionTimeout(sessionTimeout)
+        .setGlobalSuspendTimeout(globalSuspendTimeout);
 
       return new CopycatServer(name, clientTransport, serverTransport, context);
     }

--- a/server/src/main/java/io/atomix/copycat/server/cluster/Member.java
+++ b/server/src/main/java/io/atomix/copycat/server/cluster/Member.java
@@ -173,6 +173,12 @@ public interface Member {
 
   /**
    * Returns the member status.
+   * <p>
+   * The status is indicative of the leader's ability to communicate with this member. If this member is a local
+   * member, the member's status will be {@link Status#AVAILABLE} while the server is alive and will not change
+   * regardless of the leader's ability to communicate with the local member. Similarly, if the local server is
+   * partitioned from the leader then changes in statuses seen on other nodes may not be visible to this node.
+   * Status changes are guaranteed to occur in the same order on all nodes but without a real-time constraint.
    *
    * @return The member status.
    */
@@ -180,6 +186,9 @@ public interface Member {
 
   /**
    * Returns the time at which the member was updated.
+   * <p>
+   * The member update time is not guaranteed to be consistent across servers or consistent across server
+   * restarts. The update time is guaranteed to be monotonically increasing.
    *
    * @return The time at which the member was updated.
    */

--- a/server/src/main/java/io/atomix/copycat/server/cluster/Member.java
+++ b/server/src/main/java/io/atomix/copycat/server/cluster/Member.java
@@ -18,6 +18,7 @@ package io.atomix.copycat.server.cluster;
 import io.atomix.catalyst.transport.Address;
 import io.atomix.catalyst.util.Listener;
 
+import java.time.Instant;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Consumer;
 
@@ -176,6 +177,13 @@ public interface Member {
    * @return The member status.
    */
   Status status();
+
+  /**
+   * Returns the time at which the member was updated.
+   *
+   * @return The time at which the member was updated.
+   */
+  Instant updated();
 
   /**
    * Registers a callback to be called when the member's status changes.

--- a/server/src/main/java/io/atomix/copycat/server/request/ConfigureRequest.java
+++ b/server/src/main/java/io/atomix/copycat/server/request/ConfigureRequest.java
@@ -59,6 +59,7 @@ public class ConfigureRequest extends AbstractRequest {
   private long term;
   private int leader;
   private long index;
+  private long timestamp;
   private Collection<Member> members;
 
   /**
@@ -89,6 +90,15 @@ public class ConfigureRequest extends AbstractRequest {
   }
 
   /**
+   * Returns the configuration timestamp.
+   *
+   * @return The configuration timestamp.
+   */
+  public long timestamp() {
+    return timestamp;
+  }
+
+  /**
    * Returns the configuration members.
    *
    * @return The configuration members.
@@ -99,7 +109,7 @@ public class ConfigureRequest extends AbstractRequest {
 
   @Override
   public void writeObject(BufferOutput<?> buffer, Serializer serializer) {
-    buffer.writeLong(term).writeInt(leader).writeLong(index);
+    buffer.writeLong(term).writeInt(leader).writeLong(index).writeLong(timestamp);
     serializer.writeObject(members, buffer);
   }
 
@@ -108,6 +118,7 @@ public class ConfigureRequest extends AbstractRequest {
     term = buffer.readLong();
     leader = buffer.readInt();
     index = buffer.readLong();
+    timestamp = buffer.readLong();
     members = serializer.readObject(buffer);
   }
 
@@ -123,6 +134,7 @@ public class ConfigureRequest extends AbstractRequest {
       return request.term == term
         && request.leader == leader
         && request.index == index
+        && request.timestamp == timestamp
         && request.members.equals(members);
     }
     return false;
@@ -130,7 +142,7 @@ public class ConfigureRequest extends AbstractRequest {
 
   @Override
   public String toString() {
-    return String.format("%s[term=%d, leader=%d, index=%d, members=%s]", getClass().getSimpleName(), term, leader, index, members);
+    return String.format("%s[term=%d, leader=%d, index=%d, timestamp=%d, members=%s]", getClass().getSimpleName(), term, leader, index, timestamp, members);
   }
 
   /**
@@ -173,6 +185,17 @@ public class ConfigureRequest extends AbstractRequest {
      */
     public Builder withIndex(long index) {
       request.index = Assert.argNot(index, index < 0, "index must be positive");
+      return this;
+    }
+
+    /**
+     * Sets the request timestamp.
+     *
+     * @param timestamp The request timestamp.
+     * @return The request builder.
+     */
+    public Builder withTimestamp(long timestamp) {
+      request.timestamp = Assert.argNot(timestamp, timestamp <= 0, "timestamp must be positive");
       return this;
     }
 

--- a/server/src/main/java/io/atomix/copycat/server/response/ConfigurationResponse.java
+++ b/server/src/main/java/io/atomix/copycat/server/response/ConfigurationResponse.java
@@ -40,6 +40,7 @@ import java.util.Objects;
  */
 public abstract class ConfigurationResponse extends AbstractResponse {
   protected long index;
+  protected long timestamp;
   protected Collection<Member> members;
 
   /**
@@ -49,6 +50,15 @@ public abstract class ConfigurationResponse extends AbstractResponse {
    */
   public long index() {
     return index;
+  }
+
+  /**
+   * Returns the response configuration time.
+   *
+   * @return The response time.
+   */
+  public long timestamp() {
+    return timestamp;
   }
 
   /**
@@ -66,6 +76,7 @@ public abstract class ConfigurationResponse extends AbstractResponse {
     if (status == Status.OK) {
       error = null;
       index = buffer.readLong();
+      timestamp = buffer.readLong();
       members = serializer.readObject(buffer);
     } else {
       int errorCode = buffer.readByte();
@@ -80,6 +91,7 @@ public abstract class ConfigurationResponse extends AbstractResponse {
     buffer.writeByte(status.id());
     if (status == Status.OK) {
       buffer.writeLong(index);
+      buffer.writeLong(timestamp);
       serializer.writeObject(members, buffer);
     } else {
       buffer.writeByte(error != null ? error.id() : 0);
@@ -97,6 +109,7 @@ public abstract class ConfigurationResponse extends AbstractResponse {
       ConfigurationResponse response = (ConfigurationResponse) object;
       return response.status == status
         && response.index == index
+        && response.timestamp == timestamp
         && response.members.equals(members);
     }
     return false;
@@ -104,7 +117,7 @@ public abstract class ConfigurationResponse extends AbstractResponse {
 
   @Override
   public String toString() {
-    return String.format("%s[status=%s, index=%d, members=%s]", getClass().getSimpleName(), status, index, members);
+    return String.format("%s[status=%s, index=%d, timestamp=%d, members=%s]", getClass().getSimpleName(), status, index, timestamp, members);
   }
 
   /**
@@ -125,6 +138,19 @@ public abstract class ConfigurationResponse extends AbstractResponse {
     @SuppressWarnings("unchecked")
     public T withIndex(long index) {
       response.index = Assert.argNot(index, index < 0, "index cannot be negative");
+      return (T) this;
+    }
+
+    /**
+     * Sets the response time.
+     *
+     * @param time The response time.
+     * @return The response builder.
+     * @throws IllegalArgumentException if {@code time} is negative
+     */
+    @SuppressWarnings("unchecked")
+    public T withTime(long time) {
+      response.timestamp = Assert.argNot(time, time <= 0, "timestamp cannot be negative");
       return (T) this;
     }
 

--- a/server/src/main/java/io/atomix/copycat/server/state/AbstractAppender.java
+++ b/server/src/main/java/io/atomix/copycat/server/state/AbstractAppender.java
@@ -346,10 +346,6 @@ abstract class AbstractAppender implements AutoCloseable {
     // If any other error occurred, increment the failure count for the member. Log the first three failures,
     // and thereafter log 1% of the failures. This keeps the log from filling up with annoying error messages
     // when attempting to send entries to down followers.
-    if (member.getFailureTime() == 0) {
-      member.setFailureTime(System.currentTimeMillis());
-    }
-
     int failures = member.incrementFailureCount();
     if (failures <= 3 || failures % 100 == 0) {
       LOGGER.warn("{} - AppendRequest to {} failed. Reason: [{}]", context.getCluster().member().address(), member.getMember().serverAddress(), response.error() != null ? response.error() : "");
@@ -361,7 +357,7 @@ abstract class AbstractAppender implements AutoCloseable {
    */
   protected void succeedAttempt(MemberState member) {
     // Reset the member failure count and time.
-    member.resetFailureCount().resetFailureTime();
+    member.resetFailureCount();
   }
 
   /**

--- a/server/src/main/java/io/atomix/copycat/server/state/AbstractAppender.java
+++ b/server/src/main/java/io/atomix/copycat/server/state/AbstractAppender.java
@@ -346,6 +346,10 @@ abstract class AbstractAppender implements AutoCloseable {
     // If any other error occurred, increment the failure count for the member. Log the first three failures,
     // and thereafter log 1% of the failures. This keeps the log from filling up with annoying error messages
     // when attempting to send entries to down followers.
+    if (member.getFailureTime() == 0) {
+      member.setFailureTime(System.currentTimeMillis());
+    }
+
     int failures = member.incrementFailureCount();
     if (failures <= 3 || failures % 100 == 0) {
       LOGGER.warn("{} - AppendRequest to {} failed. Reason: [{}]", context.getCluster().member().address(), member.getMember().serverAddress(), response.error() != null ? response.error() : "");
@@ -356,8 +360,8 @@ abstract class AbstractAppender implements AutoCloseable {
    * Succeeds an attempt to contact a member.
    */
   protected void succeedAttempt(MemberState member) {
-    // Reset the member failure count.
-    member.resetFailureCount();
+    // Reset the member failure count and time.
+    member.resetFailureCount().resetFailureTime();
   }
 
   /**

--- a/server/src/main/java/io/atomix/copycat/server/state/InactiveState.java
+++ b/server/src/main/java/io/atomix/copycat/server/state/InactiveState.java
@@ -48,7 +48,7 @@ class InactiveState extends AbstractState {
     logRequest(request);
     updateTermAndLeader(request.term(), request.leader());
 
-    Configuration configuration = new Configuration(request.index(), request.members());
+    Configuration configuration = new Configuration(request.index(), request.timestamp(), request.members());
 
     // Configure the cluster membership. This will cause this server to transition to the
     // appropriate state if its type has changed.

--- a/server/src/main/java/io/atomix/copycat/server/state/MemberState.java
+++ b/server/src/main/java/io/atomix/copycat/server/state/MemberState.java
@@ -35,6 +35,7 @@ final class MemberState {
   private long heartbeatTime;
   private long heartbeatStartTime;
   private int failures;
+  private long failureTime;
 
   public MemberState(ServerMember member, ClusterState cluster) {
     this.member = Assert.notNull(member, "member").setCluster(cluster);
@@ -51,6 +52,7 @@ final class MemberState {
     heartbeatTime = 0;
     heartbeatStartTime = 0;
     failures = 0;
+    failureTime = 0;
   }
 
   /**
@@ -267,6 +269,38 @@ final class MemberState {
    */
   MemberState resetFailureCount() {
     failures = 0;
+    return this;
+  }
+
+  /**
+   * Returns the member failure time.
+   *
+   * @return The member failure time.
+   */
+  long getFailureTime() {
+    return failureTime;
+  }
+
+  /**
+   * Sets the member failure time.
+   *
+   * @param failureTime The member failure time.
+   * @return The member state.
+   */
+  MemberState setFailureTime(long failureTime) {
+    if (this.failureTime == 0) {
+      this.failureTime = failureTime;
+    }
+    return this;
+  }
+
+  /**
+   * Resets the member failure time.
+   *
+   * @return The member state.
+   */
+  MemberState resetFailureTime() {
+    this.failureTime = 0;
     return this;
   }
 

--- a/server/src/main/java/io/atomix/copycat/server/state/MemberState.java
+++ b/server/src/main/java/io/atomix/copycat/server/state/MemberState.java
@@ -35,7 +35,6 @@ final class MemberState {
   private long heartbeatTime;
   private long heartbeatStartTime;
   private int failures;
-  private long failureTime;
 
   public MemberState(ServerMember member, ClusterState cluster) {
     this.member = Assert.notNull(member, "member").setCluster(cluster);
@@ -52,7 +51,6 @@ final class MemberState {
     heartbeatTime = 0;
     heartbeatStartTime = 0;
     failures = 0;
-    failureTime = 0;
   }
 
   /**
@@ -269,38 +267,6 @@ final class MemberState {
    */
   MemberState resetFailureCount() {
     failures = 0;
-    return this;
-  }
-
-  /**
-   * Returns the member failure time.
-   *
-   * @return The member failure time.
-   */
-  long getFailureTime() {
-    return failureTime;
-  }
-
-  /**
-   * Sets the member failure time.
-   *
-   * @param failureTime The member failure time.
-   * @return The member state.
-   */
-  MemberState setFailureTime(long failureTime) {
-    if (this.failureTime == 0) {
-      this.failureTime = failureTime;
-    }
-    return this;
-  }
-
-  /**
-   * Resets the member failure time.
-   *
-   * @return The member state.
-   */
-  MemberState resetFailureTime() {
-    this.failureTime = 0;
     return this;
   }
 

--- a/server/src/main/java/io/atomix/copycat/server/state/ServerContext.java
+++ b/server/src/main/java/io/atomix/copycat/server/state/ServerContext.java
@@ -69,6 +69,7 @@ public class ServerContext implements AutoCloseable {
   private Duration electionTimeout = Duration.ofMillis(500);
   private Duration sessionTimeout = Duration.ofMillis(5000);
   private Duration heartbeatInterval = Duration.ofMillis(150);
+  private Duration globalSuspendTimeout = Duration.ofHours(1);
   private volatile int leader;
   private volatile long term;
   private int lastVotedFor;
@@ -181,7 +182,7 @@ public class ServerContext implements AutoCloseable {
    * @return The Raft context.
    */
   public ServerContext setHeartbeatInterval(Duration heartbeatInterval) {
-    this.heartbeatInterval = heartbeatInterval;
+    this.heartbeatInterval = Assert.notNull(heartbeatInterval, "heartbeatInterval");
     return this;
   }
 
@@ -210,7 +211,27 @@ public class ServerContext implements AutoCloseable {
    * @return The Raft state machine.
    */
   public ServerContext setSessionTimeout(Duration sessionTimeout) {
-    this.sessionTimeout = sessionTimeout;
+    this.sessionTimeout = Assert.notNull(sessionTimeout, "sessionTimeout");
+    return this;
+  }
+
+  /**
+   * Returns the follower reset interval.
+   *
+   * @return The follower reset interval.
+   */
+  public Duration getGlobalSuspendTimeout() {
+    return globalSuspendTimeout;
+  }
+
+  /**
+   * Sets the global suspend timeout.
+   *
+   * @param globalSuspendTimeout The global suspend timeout.
+   * @return The Raft state machine.
+   */
+  public ServerContext setGlobalSuspendTimeout(Duration globalSuspendTimeout) {
+    this.globalSuspendTimeout = Assert.notNull(globalSuspendTimeout, "globalSuspendTimeout");
     return this;
   }
 

--- a/server/src/main/java/io/atomix/copycat/server/state/ServerMember.java
+++ b/server/src/main/java/io/atomix/copycat/server/state/ServerMember.java
@@ -30,6 +30,7 @@ import io.atomix.copycat.server.cluster.Member;
 import io.atomix.copycat.server.request.ReconfigureRequest;
 import io.atomix.copycat.server.storage.system.Configuration;
 
+import java.time.Instant;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Consumer;
 
@@ -41,6 +42,7 @@ import java.util.function.Consumer;
 final class ServerMember implements Member, CatalystSerializable, AutoCloseable {
   private Member.Type type;
   private Status status = Status.AVAILABLE;
+  private Instant updated;
   private Address serverAddress;
   private Address clientAddress;
   private transient Scheduled configureTimeout;
@@ -51,10 +53,11 @@ final class ServerMember implements Member, CatalystSerializable, AutoCloseable 
   ServerMember() {
   }
 
-  public ServerMember(Member.Type type, Address serverAddress, Address clientAddress) {
+  public ServerMember(Member.Type type, Address serverAddress, Address clientAddress, Instant updated) {
     this.type = Assert.notNull(type, "type");
     this.serverAddress = Assert.notNull(serverAddress, "serverAddress");
     this.clientAddress = clientAddress;
+    this.updated = Assert.notNull(updated, "updated");
   }
 
   /**
@@ -78,6 +81,11 @@ final class ServerMember implements Member, CatalystSerializable, AutoCloseable 
   @Override
   public Status status() {
     return status;
+  }
+
+  @Override
+  public Instant updated() {
+    return updated;
   }
 
   @Override
@@ -148,9 +156,10 @@ final class ServerMember implements Member, CatalystSerializable, AutoCloseable 
    * @param type The member type.
    * @return The member.
    */
-  ServerMember update(Member.Type type) {
+  ServerMember update(Member.Type type, Instant time) {
     if (this.type != type) {
       this.type = Assert.notNull(type, "type");
+      this.updated = Assert.notNull(time, "time");
       if (typeChangeListeners != null) {
         typeChangeListeners.accept(type);
       }
@@ -164,9 +173,10 @@ final class ServerMember implements Member, CatalystSerializable, AutoCloseable 
    * @param status The member status.
    * @return The member.
    */
-  ServerMember update(Status status) {
+  ServerMember update(Status status, Instant time) {
     if (this.status != status) {
       this.status = Assert.notNull(status, "status");
+      this.updated = Assert.notNull(time, "time");
       if (statusChangeListeners != null) {
         statusChangeListeners.accept(status);
       }
@@ -180,9 +190,10 @@ final class ServerMember implements Member, CatalystSerializable, AutoCloseable 
    * @param clientAddress The member client address.
    * @return The member.
    */
-  ServerMember update(Address clientAddress) {
+  ServerMember update(Address clientAddress, Instant time) {
     if (clientAddress != null) {
       this.clientAddress = clientAddress;
+      this.updated = Assert.notNull(time, "time");
     }
     return this;
   }
@@ -210,12 +221,12 @@ final class ServerMember implements Member, CatalystSerializable, AutoCloseable 
     // will log, replicate, and commit the reconfiguration.
     cluster.getContext().getAbstractState().reconfigure(ReconfigureRequest.builder()
       .withIndex(cluster.getConfiguration().index())
-      .withMember(new ServerMember(type, serverAddress(), clientAddress()))
+      .withMember(new ServerMember(type, serverAddress(), clientAddress(), updated))
       .build()).whenComplete((response, error) -> {
       if (error == null) {
         if (response.status() == Response.Status.OK) {
           cancelConfigureTimer();
-          cluster.configure(new Configuration(response.index(), response.members()));
+          cluster.configure(new Configuration(response.index(), response.timestamp(), response.members()));
           future.complete(null);
         } else if (response.error() == null || response.error() == RaftError.Type.NO_LEADER_ERROR) {
           cancelConfigureTimer();
@@ -242,6 +253,7 @@ final class ServerMember implements Member, CatalystSerializable, AutoCloseable 
   public void writeObject(BufferOutput<?> buffer, Serializer serializer) {
     buffer.writeByte(type.ordinal());
     buffer.writeByte(status.ordinal());
+    buffer.writeLong(updated.toEpochMilli());
     serializer.writeObject(serverAddress, buffer);
     serializer.writeObject(clientAddress, buffer);
   }
@@ -250,6 +262,7 @@ final class ServerMember implements Member, CatalystSerializable, AutoCloseable 
   public void readObject(BufferInput<?> buffer, Serializer serializer) {
     type = Member.Type.values()[buffer.readByte()];
     status = Status.values()[buffer.readByte()];
+    updated = Instant.ofEpochMilli(buffer.readLong());
     serverAddress = serializer.readObject(buffer);
     clientAddress = serializer.readObject(buffer);
   }

--- a/server/src/main/java/io/atomix/copycat/server/state/ServerMember.java
+++ b/server/src/main/java/io/atomix/copycat/server/state/ServerMember.java
@@ -159,7 +159,9 @@ final class ServerMember implements Member, CatalystSerializable, AutoCloseable 
   ServerMember update(Member.Type type, Instant time) {
     if (this.type != type) {
       this.type = Assert.notNull(type, "type");
-      this.updated = Assert.notNull(time, "time");
+      if (time.isAfter(updated)) {
+        this.updated = Assert.notNull(time, "time");
+      }
       if (typeChangeListeners != null) {
         typeChangeListeners.accept(type);
       }
@@ -176,7 +178,9 @@ final class ServerMember implements Member, CatalystSerializable, AutoCloseable 
   ServerMember update(Status status, Instant time) {
     if (this.status != status) {
       this.status = Assert.notNull(status, "status");
-      this.updated = Assert.notNull(time, "time");
+      if (time.isAfter(updated)) {
+        this.updated = Assert.notNull(time, "time");
+      }
       if (statusChangeListeners != null) {
         statusChangeListeners.accept(status);
       }
@@ -193,7 +197,9 @@ final class ServerMember implements Member, CatalystSerializable, AutoCloseable 
   ServerMember update(Address clientAddress, Instant time) {
     if (clientAddress != null) {
       this.clientAddress = clientAddress;
-      this.updated = Assert.notNull(time, "time");
+      if (time.isAfter(updated)) {
+        this.updated = Assert.notNull(time, "time");
+      }
     }
     return this;
   }

--- a/server/src/main/java/io/atomix/copycat/server/storage/compaction/Compactor.java
+++ b/server/src/main/java/io/atomix/copycat/server/storage/compaction/Compactor.java
@@ -191,8 +191,6 @@ public class Compactor implements AutoCloseable {
     if (future != null)
       return future;
 
-    LOGGER.info("Compacting log with compaction: {}", compaction);
-
     future = new CompletableFuture<>();
 
     ThreadContext compactorThread = ThreadContext.currentContext();
@@ -202,6 +200,7 @@ public class Compactor implements AutoCloseable {
 
     Collection<CompactionTask> tasks = manager.buildTasks(storage, segments);
     if (!tasks.isEmpty()) {
+      LOGGER.info("Compacting log with compaction: {}", compaction);
       LOGGER.debug("Executing {} compaction task(s)", tasks.size());
       for (CompactionTask task : tasks) {
         LOGGER.debug("Executing {}", task);

--- a/server/src/main/java/io/atomix/copycat/server/storage/entry/ConfigurationEntry.java
+++ b/server/src/main/java/io/atomix/copycat/server/storage/entry/ConfigurationEntry.java
@@ -35,7 +35,7 @@ import java.util.Collection;
  *
  * @author <a href="http://github.com/kuujo">Jordan Halterman</a>
  */
-public class ConfigurationEntry extends Entry<ConfigurationEntry> {
+public class ConfigurationEntry extends TimestampedEntry<ConfigurationEntry> {
   private Collection<Member> members;
 
   public ConfigurationEntry() {
@@ -85,7 +85,7 @@ public class ConfigurationEntry extends Entry<ConfigurationEntry> {
 
   @Override
   public String toString() {
-    return String.format("%s[index=%d, term=%d, members=%s]", getClass().getSimpleName(), getIndex(), getTerm(), members);
+    return String.format("%s[index=%d, term=%d, timestamp=%d, members=%s]", getClass().getSimpleName(), getIndex(), getTerm(), getTimestamp(), members);
   }
 
 }

--- a/server/src/main/java/io/atomix/copycat/server/storage/system/Configuration.java
+++ b/server/src/main/java/io/atomix/copycat/server/storage/system/Configuration.java
@@ -31,10 +31,12 @@ import java.util.Collection;
  */
 public class Configuration {
   private final long index;
+  private final long time;
   private final Collection<Member> members;
 
-  public Configuration(long index, Collection<Member> members) {
+  public Configuration(long index, long time, Collection<Member> members) {
     this.index = index;
+    this.time = time;
     this.members = Assert.notNull(members, "members");
   }
 
@@ -51,6 +53,15 @@ public class Configuration {
   }
 
   /**
+   * Returns the configuration time.
+   *
+   * @return The time at which the configuration was committed.
+   */
+  public long time() {
+    return time;
+  }
+
+  /**
    * Returns the cluster membership for this configuration.
    *
    * @return The cluster membership.
@@ -61,7 +72,7 @@ public class Configuration {
 
   @Override
   public String toString() {
-    return String.format("%s[index=%d, members=%s]", getClass().getSimpleName(), index, members);
+    return String.format("%s[index=%d, time=%d, members=%s]", getClass().getSimpleName(), index, time, members);
   }
 
 }

--- a/server/src/main/java/io/atomix/copycat/server/storage/system/MetaStore.java
+++ b/server/src/main/java/io/atomix/copycat/server/storage/system/MetaStore.java
@@ -115,7 +115,7 @@ public class MetaStore implements AutoCloseable {
    */
   public synchronized MetaStore storeConfiguration(Configuration configuration) {
     LOGGER.debug("Store configuration {}", configuration);
-    serializer.writeObject(configuration.members(), buffer.position(12).writeByte(1).writeLong(configuration.index()));
+    serializer.writeObject(configuration.members(), buffer.position(12).writeByte(1).writeLong(configuration.index()).writeLong(configuration.time()));
     buffer.flush();
     return this;
   }
@@ -128,6 +128,7 @@ public class MetaStore implements AutoCloseable {
   public synchronized Configuration loadConfiguration() {
     if (buffer.position(12).readByte() == 1) {
       return new Configuration(
+        buffer.readLong(),
         buffer.readLong(),
         serializer.readObject(buffer)
       );

--- a/server/src/test/java/io/atomix/copycat/server/state/AbstractStateTest.java
+++ b/server/src/test/java/io/atomix/copycat/server/state/AbstractStateTest.java
@@ -42,6 +42,7 @@ import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -159,7 +160,7 @@ public abstract class AbstractStateTest<T extends AbstractState> extends Concurr
   private List<ServerMember> createMembers(int nodes) {
     List<ServerMember> members = new ArrayList<>();
     for (int i = 0; i < nodes; i++) {
-      members.add(new ServerMember(Member.Type.ACTIVE, new Address("localhost", 5000 + i), new Address("localhost", 6000 + i)));
+      members.add(new ServerMember(Member.Type.ACTIVE, new Address("localhost", 5000 + i), new Address("localhost", 6000 + i), Instant.now()));
     }
     return members;
   }

--- a/server/src/test/java/io/atomix/copycat/server/state/ServerStateMachineTest.java
+++ b/server/src/test/java/io/atomix/copycat/server/state/ServerStateMachineTest.java
@@ -42,6 +42,7 @@ import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -81,7 +82,7 @@ public class ServerStateMachineTest extends ConcurrentTestCase {
     LocalServerRegistry registry = new LocalServerRegistry();
     transport = new LocalTransport(registry);
     Storage storage = new Storage(StorageLevel.MEMORY);
-    ServerMember member = new ServerMember(Member.Type.ACTIVE, new Address("localhost", 5000), new Address("localhost", 6000));
+    ServerMember member = new ServerMember(Member.Type.ACTIVE, new Address("localhost", 5000), new Address("localhost", 6000), Instant.now());
     Collection<Address> members = new ArrayList<>(Arrays.asList(
       new Address("localhost", 5000),
       new Address("localhost", 5000),

--- a/server/src/test/java/io/atomix/copycat/server/storage/MetaStoreTest.java
+++ b/server/src/test/java/io/atomix/copycat/server/storage/MetaStoreTest.java
@@ -34,6 +34,7 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.*;
 import java.nio.file.attribute.BasicFileAttributes;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -85,7 +86,7 @@ public class MetaStoreTest {
       new TestMember(Member.Type.ACTIVE, new Address("localhost", 5001), new Address("localhost", 6001)),
       new TestMember(Member.Type.ACTIVE, new Address("localhost", 5002), new Address("localhost", 6002))
     ));
-    meta.storeConfiguration(new Configuration(1, members));
+    meta.storeConfiguration(new Configuration(1, System.currentTimeMillis(), members));
 
     Configuration configuration = meta.loadConfiguration();
     assertEquals(configuration.index(), 1);
@@ -185,6 +186,11 @@ public class MetaStoreTest {
 
     @Override
     public Status status() {
+      return null;
+    }
+
+    @Override
+    public Instant updated() {
       return null;
     }
 

--- a/test/src/test/java/io/atomix/copycat/test/ClusterTest.java
+++ b/test/src/test/java/io/atomix/copycat/test/ClusterTest.java
@@ -38,6 +38,7 @@ import org.testng.annotations.Test;
 
 import java.io.Serializable;
 import java.time.Duration;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
@@ -1614,6 +1615,11 @@ public class ClusterTest extends ConcurrentTestCase {
 
     @Override
     public Status status() {
+      return null;
+    }
+
+    @Override
+    public Instant updated() {
       return null;
     }
 


### PR DESCRIPTION
This PR attempts to resolve the final issue discussed in #158, leaders incrementing `globalIndex` during short disconnections. Currently, if a follower is partitioned from the leader just long enough for the leader to recognize the follower is unavailable and commit a configuration change updating its status, the leader will begin incrementing `globalIndex` and that follower will be forced to truncate its log once the partition is healed.

This PR attempts to address this issue by associating an approximate time with status updates for each member. A configurable timeout called the `globalSuspendTimeout` is used to determine the amount of time a leader will wait after a follower's status has been updated before excluding it from inclusion in the `globalIndex` calculation. In order to account for leader changes, the timestamp is logged within `ConfigurationEntry` and stored in the configuration itself. When a leader change occurs, the new leader will use the configuration time to determine the last time a follower was reconfigured when calculating `globalIndex`.

The goal of time in this PR is not precision but to provide a simple approximation of time that accounts for failures and leader changes. Incrementing `globalIndex` should typically not be necessary unless a node has crashed for an extended period of time, and granularity is not important in that case. There are also no consistency issues if different servers perceive different members to have been updated at different times. I will document that in a follow up commit.