### PR TITLE
Cleanup documentation and add TOMBSTONE compaction alias

### DIFF
--- a/examples/value-state-machine/src/main/java/io/atomix/copycat/examples/DeleteCommand.java
+++ b/examples/value-state-machine/src/main/java/io/atomix/copycat/examples/DeleteCommand.java
@@ -25,6 +25,6 @@ import io.atomix.copycat.Command;
 public class DeleteCommand implements Command<Void> {
   @Override
   public CompactionMode compaction() {
-    return CompactionMode.SEQUENTIAL;
+    return CompactionMode.TOMBSTONE;
   }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
     <java.version>1.8</java.version>
     <slf4j.version>1.7.7</slf4j.version>
     <logback.version>1.1.2</logback.version>
-    <catalyst.version>1.0.1</catalyst.version>
+    <catalyst.version>1.0.2-SNAPSHOT</catalyst.version>
 
     <maven.source.plugin.version>2.2.1</maven.source.plugin.version>
     <maven.compiler.plugin.version>3.0</maven.compiler.plugin.version>

--- a/server/src/main/java/io/atomix/copycat/server/storage/Log.java
+++ b/server/src/main/java/io/atomix/copycat/server/storage/Log.java
@@ -378,6 +378,7 @@ public class Log implements AutoCloseable {
         // if the entry hasn't been cleaned.
         case FULL:
         case SEQUENTIAL:
+        case TOMBSTONE:
           if (index > compactor.minorIndex() || index > compactor.majorIndex() || !segment.isClean(index)) {
             return entry;
           }

--- a/server/src/main/java/io/atomix/copycat/server/storage/compaction/Compaction.java
+++ b/server/src/main/java/io/atomix/copycat/server/storage/compaction/Compaction.java
@@ -111,11 +111,19 @@ public enum Compaction {
 
     /**
      * The {@code SEQUENTIAL} compaction mode retains the command in the log until it has been stored and
-     * applied on all servers in the cluster. Once the commit has been appleid to a state machine and closed,
+     * applied on all servers in the cluster. Once the commit has been applied to a state machine and closed,
      * it may be removed from the log <em>only during major compaction</em> to ensure that all prior completed
      * commits are removed first.
      */
     SEQUENTIAL,
+
+    /**
+     * The {@code TOMBSTONE} compaction mode is an alias of the {@link #SEQUENTIAL} mode. Tombstone entries are
+     * retained in the log until stored and applied on all servers. Once the commit has been applied to a state
+     * machine and closed, it may be removed from the log <em>only during major compaction</em> to ensure that
+     * all prior completed commits are removed first.
+     */
+    TOMBSTONE,
 
   }
 

--- a/server/src/main/java/io/atomix/copycat/server/storage/compaction/MajorCompactionTask.java
+++ b/server/src/main/java/io/atomix/copycat/server/storage/compaction/MajorCompactionTask.java
@@ -245,6 +245,7 @@ public final class MajorCompactionTask implements CompactionTask {
       // and the entry has been cleaned.
       case FULL:
       case SEQUENTIAL:
+      case TOMBSTONE:
         if (index <= compactIndex && isClean(index, segment, cleaner)) {
           compactEntry(index, segment, compactSegment);
         } else {

--- a/server/src/main/java/io/atomix/copycat/server/storage/compaction/MinorCompactionTask.java
+++ b/server/src/main/java/io/atomix/copycat/server/storage/compaction/MinorCompactionTask.java
@@ -157,9 +157,10 @@ public final class MinorCompactionTask implements CompactionTask {
           transferEntry(index, entry, compactSegment);
         }
         break;
-      // SEQUENTIAL entries can only be compacted during major compaction.
+      // SEQUENTIAL and TOMBSTONE entries can only be compacted during major compaction.
       // UNKNOWN entries can only be compacted during major compaction.
       case SEQUENTIAL:
+      case TOMBSTONE:
       case UNKNOWN:
         transferEntry(index, entry, compactSegment);
         break;

--- a/server/src/main/java/io/atomix/copycat/server/storage/entry/UnregisterEntry.java
+++ b/server/src/main/java/io/atomix/copycat/server/storage/entry/UnregisterEntry.java
@@ -46,7 +46,7 @@ public class UnregisterEntry extends SessionEntry<UnregisterEntry> {
 
   @Override
   public Compaction.Mode getCompactionMode() {
-    return Compaction.Mode.SEQUENTIAL;
+    return Compaction.Mode.TOMBSTONE;
   }
 
   /**

--- a/server/src/test/java/io/atomix/copycat/server/storage/LogTest.java
+++ b/server/src/test/java/io/atomix/copycat/server/storage/LogTest.java
@@ -118,7 +118,7 @@ public abstract class LogTest extends AbstractLogTest {
    * Asserts that {@link Log#clean(long)} prevents tombstone entries from being read if the globalIndex is greater than the tombstone index.
    */
   public void testCleanGetTombstones() {
-    appendEntries(entriesPerSegment * 3, Compaction.Mode.SEQUENTIAL);
+    appendEntries(entriesPerSegment * 3, Compaction.Mode.TOMBSTONE);
     for (int i = entriesPerSegment; i <= entriesPerSegment * 2 + 1; i++) {
       assertFalse(log.segments.segment(i).isClean(i));
       log.clean(i);


### PR DESCRIPTION
Minor documentation improvements plus the addition of the `TOMBSTONE` compaction mode for clarity.