### PR TITLE
Include cluster name in thread name for better diagnostics

### DIFF
--- a/server/src/main/java/io/atomix/copycat/server/CopycatServer.java
+++ b/server/src/main/java/io/atomix/copycat/server/CopycatServer.java
@@ -855,7 +855,7 @@ public class CopycatServer implements Managed<CopycatServer> {
       }
 
       ConnectionManager connections = new ConnectionManager(serverTransport.client());
-      ThreadContext threadContext = new SingleThreadContext("copycat-server-" + serverAddress, serializer);
+      ThreadContext threadContext = new SingleThreadContext(String.format("copycat-server-%s-%s", serverAddress, name), serializer);
 
       ServerContext context = new ServerContext(name, type, serverAddress, clientAddress, cluster, storage, serializer, stateMachineFactory, connections, threadContext);
       context.setElectionTimeout(electionTimeout)

--- a/server/src/main/java/io/atomix/copycat/server/state/ServerContext.java
+++ b/server/src/main/java/io/atomix/copycat/server/state/ServerContext.java
@@ -84,7 +84,7 @@ public class ServerContext implements AutoCloseable {
     this.threadContext = Assert.notNull(threadContext, "threadContext");
     this.connections = Assert.notNull(connections, "connections");
     this.stateMachineFactory = Assert.notNull(stateMachineFactory, "stateMachineFactory");
-    this.stateContext = new SingleThreadContext("copycat-server-" + serverAddress + "-state-%d", threadContext.serializer().clone());
+    this.stateContext = new SingleThreadContext(String.format("copycat-server-%s-%s-state", serverAddress, name), threadContext.serializer().clone());
 
     // Open the meta store.
     threadContext.execute(() -> this.meta = storage.openMetaStore(name)).join();


### PR DESCRIPTION
When running multiple embedded copycat clusters on the same node it very useful to be able identify where individual log messages are coming from.