### PR TITLE
squid:S1213 - The members of an interface declaration or class should appear in a pre-defined order

### DIFF
--- a/server/src/main/java/io/atomix/copycat/server/storage/snapshot/SnapshotDescriptor.java
+++ b/server/src/main/java/io/atomix/copycat/server/storage/snapshot/SnapshotDescriptor.java
@@ -32,6 +32,22 @@ import io.atomix.catalyst.util.Assert;
 public final class SnapshotDescriptor implements AutoCloseable {
   public static final int BYTES = 64;
 
+  private Buffer buffer;
+  private final long index;
+  private final long timestamp;
+  private boolean locked;
+
+  /**
+   * @throws NullPointerException if {@code buffer} is null
+   */
+  public SnapshotDescriptor(Buffer buffer) {
+    this.buffer = Assert.notNull(buffer, "buffer");
+    this.index = buffer.readLong();
+    this.timestamp = buffer.readLong();
+    this.locked = buffer.readBoolean();
+    buffer.skip(BYTES - buffer.position());
+  }
+
   /**
    * Returns a descriptor builder.
    * <p>
@@ -52,22 +68,6 @@ public final class SnapshotDescriptor implements AutoCloseable {
    */
   public static Builder builder(Buffer buffer) {
     return new Builder(buffer);
-  }
-
-  private Buffer buffer;
-  private final long index;
-  private final long timestamp;
-  private boolean locked;
-
-  /**
-   * @throws NullPointerException if {@code buffer} is null
-   */
-  public SnapshotDescriptor(Buffer buffer) {
-    this.buffer = Assert.notNull(buffer, "buffer");
-    this.index = buffer.readLong();
-    this.timestamp = buffer.readLong();
-    this.locked = buffer.readBoolean();
-    buffer.skip(BYTES - buffer.position());
   }
 
   /**

--- a/server/src/main/java/io/atomix/copycat/server/storage/snapshot/SnapshotFile.java
+++ b/server/src/main/java/io/atomix/copycat/server/storage/snapshot/SnapshotFile.java
@@ -34,6 +34,13 @@ public final class SnapshotFile {
   private final File file;
 
   /**
+   * @throws IllegalArgumentException if {@code file} is not a valid snapshot file
+   */
+  SnapshotFile(File file) {
+    this.file = file;
+  }
+
+  /**
    * Returns a boolean value indicating whether the given file appears to be a parsable snapshot file.
    *
    * @throws NullPointerException if {@code file} is null
@@ -68,13 +75,6 @@ public final class SnapshotFile {
    */
   static File createSnapshotFile(String name, File directory, long index, long timestamp) {
     return new File(directory, String.format("%s-%d-%s.snapshot", Assert.notNull(name, "name"), index, TIMESTAMP_FORMAT.format(new Date(timestamp))));
-  }
-
-  /**
-   * @throws IllegalArgumentException if {@code file} is not a valid snapshot file
-   */
-  SnapshotFile(File file) {
-    this.file = file;
   }
 
   /**


### PR DESCRIPTION
This pull request is focused on resolving occurrence of Sonar rule
squid:S1213 - The members of an interface declaration or class should appear in a pre-defined order.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S1213
Please let me know if you have any questions.
George Kankava