### PR TITLE
Increase Copycat log entries length to be 32 bit

### DIFF
--- a/server/src/main/java/io/atomix/copycat/server/storage/Segment.java
+++ b/server/src/main/java/io/atomix/copycat/server/storage/Segment.java
@@ -293,7 +293,7 @@ public class Segment implements AutoCloseable {
     boolean skipTerm = term == lastTerm;
 
     // Calculate the length of the entry header bytes.
-    int headerLength = Bytes.SHORT + Bytes.LONG + Bytes.BOOLEAN + (skipTerm ? 0 : Bytes.LONG);
+    int headerLength = Bytes.INTEGER + Bytes.LONG + Bytes.BOOLEAN + (skipTerm ? 0 : Bytes.LONG);
 
     // Serialize the object into the segment buffer.
     serializer.writeObject(entry, buffer.skip(headerLength));
@@ -305,7 +305,7 @@ public class Segment implements AutoCloseable {
     entry.setSize(length);
 
     // Write the length of the entry for indexing.
-    buffer.reset().writeUnsignedShort(length).writeLong(offset);
+    buffer.reset().writeInt(length).writeLong(offset);
 
     // If the term has not yet been written, write the term to this entry.
     if (skipTerm) {
@@ -367,17 +367,17 @@ public class Segment implements AutoCloseable {
     if (position != -1) {
 
       // Read the length of the entry.
-      int length = buffer.readUnsignedShort(position);
+      int length = buffer.readInt(position);
 
       // Verify that the entry at the given offset matches.
-      long entryOffset = buffer.readLong(position + Bytes.SHORT);
+      long entryOffset = buffer.readLong(position + Bytes.INTEGER);
       Assert.state(entryOffset == offset, "inconsistent index: %s", index);
 
       // Determine whether to skip reading the term from this entry.
-      boolean skipTerm = !buffer.readBoolean(position + Bytes.SHORT + Bytes.LONG);
+      boolean skipTerm = !buffer.readBoolean(position + Bytes.INTEGER + Bytes.LONG);
 
       // Read the entry buffer and deserialize the entry.
-      try (Buffer value = buffer.slice(position + Bytes.SHORT + Bytes.LONG + Bytes.BOOLEAN + (skipTerm ? 0 : Bytes.LONG), length)) {
+      try (Buffer value = buffer.slice(position + Bytes.INTEGER + Bytes.LONG + Bytes.BOOLEAN + (skipTerm ? 0 : Bytes.LONG), length)) {
         T entry = serializer.readObject(value);
         entry.setIndex(index).setTerm(termIndex.lookup(offset)).setSize(length);
         return entry;


### PR DESCRIPTION
At the latest with https://github.com/atomix/catalyst/pull/30 copycat should support log entries that have a length that takes up full 32-bit, instead of cutting off at 16 bit.
Even without the above linked PR for catalyst, copycat still should support large entries, since users could install their own TypeSerializers which serialize to byte arrays that have a length larger than what can be displayed using 16 bit.