### PR TITLE
Fix IndexOutOfBoundsException in follower replication

### DIFF
--- a/server/src/main/java/io/atomix/copycat/server/state/FollowerAppender.java
+++ b/server/src/main/java/io/atomix/copycat/server/state/FollowerAppender.java
@@ -61,7 +61,7 @@ final class FollowerAppender extends AbstractAppender {
     }
     // If no AppendRequest is already being sent, send an AppendRequest.
     else if (canAppend(member) && hasMoreEntries(member)) {
-      sendAppendRequest(member, buildAppendRequest(member, context.getCommitIndex()));
+      sendAppendRequest(member, buildAppendRequest(member, Math.min(context.getCommitIndex(), context.getLog().lastIndex())));
     }
   }
 


### PR DESCRIPTION
When a follower's `commitIndex` is greater than its log's last index, replication can result in an `IndexOutOfBoundsException` since it tries to load entries up to the `commitIndex` rather than the last index. This PR adds a `min` call to use the lower of the two.