### PR TITLE
Reject configuration change attempts from members with stale configurations

### DIFF
--- a/protocol/src/main/java/io/atomix/copycat/error/ConfigurationException.java
+++ b/protocol/src/main/java/io/atomix/copycat/error/ConfigurationException.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License
+ */
+package io.atomix.copycat.error;
+
+/**
+ * Indicates that an error occurred while committing a write command.
+ *
+ * @author <a href="http://github.com/kuujo">Jordan Halterman</a>
+ */
+public class ConfigurationException extends OperationException {
+  private static final CopycatError.Type TYPE = CopycatError.Type.CONFIGURATION_ERROR;
+
+  public ConfigurationException(String message, Object... args) {
+    super(TYPE, message, args);
+  }
+
+  public ConfigurationException(Throwable cause, String message, Object... args) {
+    super(TYPE, cause, message, args);
+  }
+
+  public ConfigurationException(Throwable cause) {
+    super(TYPE, cause);
+  }
+
+}

--- a/protocol/src/main/java/io/atomix/copycat/error/CopycatError.java
+++ b/protocol/src/main/java/io/atomix/copycat/error/CopycatError.java
@@ -140,6 +140,16 @@ public interface CopycatError {
       public CopycatException createException() {
         return new InternalException("internal Raft error");
       }
+    },
+
+    /**
+     * Configuration error.
+     */
+    CONFIGURATION_ERROR(8) {
+      @Override
+      public CopycatException createException() {
+        return new ConfigurationException("configuration failed");
+      }
     };
 
     private final byte id;

--- a/server/src/main/java/io/atomix/copycat/server/protocol/ConfigurationResponse.java
+++ b/server/src/main/java/io/atomix/copycat/server/protocol/ConfigurationResponse.java
@@ -41,6 +41,7 @@ import java.util.Objects;
  */
 public abstract class ConfigurationResponse extends AbstractResponse {
   protected long index;
+  protected long term;
   protected long timestamp;
   protected Collection<Member> members;
 
@@ -51,6 +52,15 @@ public abstract class ConfigurationResponse extends AbstractResponse {
    */
   public long index() {
     return index;
+  }
+
+  /**
+   * Returns the configuration term.
+   *
+   * @return The configuration term.
+   */
+  public long term() {
+    return term;
   }
 
   /**
@@ -77,6 +87,7 @@ public abstract class ConfigurationResponse extends AbstractResponse {
     if (status == Status.OK) {
       error = null;
       index = buffer.readLong();
+      term = buffer.readLong();
       timestamp = buffer.readLong();
       members = serializer.readObject(buffer);
     } else {
@@ -92,6 +103,7 @@ public abstract class ConfigurationResponse extends AbstractResponse {
     buffer.writeByte(status.id());
     if (status == Status.OK) {
       buffer.writeLong(index);
+      buffer.writeLong(term);
       buffer.writeLong(timestamp);
       serializer.writeObject(members, buffer);
     } else {
@@ -101,7 +113,7 @@ public abstract class ConfigurationResponse extends AbstractResponse {
 
   @Override
   public int hashCode() {
-    return Objects.hash(getClass(), status, index, members);
+    return Objects.hash(getClass(), status, index, term, members);
   }
 
   @Override
@@ -110,6 +122,7 @@ public abstract class ConfigurationResponse extends AbstractResponse {
       ConfigurationResponse response = (ConfigurationResponse) object;
       return response.status == status
         && response.index == index
+        && response.term == term
         && response.timestamp == timestamp
         && response.members.equals(members);
     }
@@ -118,7 +131,7 @@ public abstract class ConfigurationResponse extends AbstractResponse {
 
   @Override
   public String toString() {
-    return String.format("%s[status=%s, index=%d, timestamp=%d, members=%s]", getClass().getSimpleName(), status, index, timestamp, members);
+    return String.format("%s[status=%s, index=%d, term=%d, timestamp=%d, members=%s]", getClass().getSimpleName(), status, index, term, timestamp, members);
   }
 
   /**
@@ -139,6 +152,19 @@ public abstract class ConfigurationResponse extends AbstractResponse {
     @SuppressWarnings("unchecked")
     public T withIndex(long index) {
       response.index = Assert.argNot(index, index < 0, "index cannot be negative");
+      return (T) this;
+    }
+
+    /**
+     * Sets the response term.
+     *
+     * @param term The response term.
+     * @return The response builder.
+     * @throws IllegalArgumentException if {@code term} is negative
+     */
+    @SuppressWarnings("unchecked")
+    public T withTerm(long term) {
+      response.term = Assert.argNot(term, term < 0, "term must be positive");
       return (T) this;
     }
 

--- a/server/src/main/java/io/atomix/copycat/server/protocol/ConfigureRequest.java
+++ b/server/src/main/java/io/atomix/copycat/server/protocol/ConfigureRequest.java
@@ -194,7 +194,7 @@ public class ConfigureRequest extends AbstractRequest {
      * @param timestamp The request timestamp.
      * @return The request builder.
      */
-    public Builder withTimestamp(long timestamp) {
+    public Builder withTime(long timestamp) {
       request.timestamp = Assert.argNot(timestamp, timestamp <= 0, "timestamp must be positive");
       return this;
     }

--- a/server/src/main/java/io/atomix/copycat/server/protocol/ReconfigureRequest.java
+++ b/server/src/main/java/io/atomix/copycat/server/protocol/ReconfigureRequest.java
@@ -49,6 +49,7 @@ public class ReconfigureRequest extends ConfigurationRequest {
   }
 
   private long index;
+  private long term;
 
   /**
    * Returns the configuration index.
@@ -59,15 +60,25 @@ public class ReconfigureRequest extends ConfigurationRequest {
     return index;
   }
 
+  /**
+   * Returns the configuration term.
+   *
+   * @return The configuration term.
+   */
+  public long term() {
+    return term;
+  }
+
   @Override
   public void writeObject(BufferOutput<?> buffer, Serializer serializer) {
-    buffer.writeLong(index);
+    buffer.writeLong(index).writeLong(term);
     super.writeObject(buffer, serializer);
   }
 
   @Override
   public void readObject(BufferInput<?> buffer, Serializer serializer) {
     index = buffer.readLong();
+    term = buffer.readLong();
     super.readObject(buffer, serializer);
   }
 
@@ -80,14 +91,14 @@ public class ReconfigureRequest extends ConfigurationRequest {
   public boolean equals(Object object) {
     if (object instanceof ReconfigureRequest) {
       ReconfigureRequest request = (ReconfigureRequest) object;
-      return request.index == index && request.member.equals(member);
+      return request.index == index && request.term == term && request.member.equals(member);
     }
     return false;
   }
 
   @Override
   public String toString() {
-    return String.format("%s[index=%d, member=%s]", getClass().getSimpleName(), index, member);
+    return String.format("%s[index=%d, term=%d, member=%s]", getClass().getSimpleName(), index, term, member);
   }
 
   /**
@@ -106,6 +117,17 @@ public class ReconfigureRequest extends ConfigurationRequest {
      */
     public Builder withIndex(long index) {
       request.index = Assert.argNot(index, index < 0, "index must be positive");
+      return this;
+    }
+
+    /**
+     * Sets the request term.
+     *
+     * @param term The request term.
+     * @return The request builder.
+     */
+    public Builder withTerm(long term) {
+      request.term = Assert.argNot(term, term < 0, "term must be positive");
       return this;
     }
   }

--- a/server/src/main/java/io/atomix/copycat/server/state/AbstractAppender.java
+++ b/server/src/main/java/io/atomix/copycat/server/state/AbstractAppender.java
@@ -21,12 +21,7 @@ import io.atomix.catalyst.transport.Connection;
 import io.atomix.catalyst.util.Assert;
 import io.atomix.copycat.protocol.Response;
 import io.atomix.copycat.server.CopycatServer;
-import io.atomix.copycat.server.protocol.AppendRequest;
-import io.atomix.copycat.server.protocol.ConfigureRequest;
-import io.atomix.copycat.server.protocol.InstallRequest;
-import io.atomix.copycat.server.protocol.AppendResponse;
-import io.atomix.copycat.server.protocol.ConfigureResponse;
-import io.atomix.copycat.server.protocol.InstallResponse;
+import io.atomix.copycat.server.protocol.*;
 import io.atomix.copycat.server.storage.entry.Entry;
 import io.atomix.copycat.server.storage.snapshot.Snapshot;
 import io.atomix.copycat.server.storage.snapshot.SnapshotReader;
@@ -426,6 +421,7 @@ abstract class AbstractAppender implements AutoCloseable {
       .withTerm(context.getTerm())
       .withLeader(leader != null ? leader.id() : 0)
       .withIndex(context.getClusterState().getConfiguration().index())
+      .withTime(context.getClusterState().getConfiguration().time())
       .withMembers(context.getClusterState().getConfiguration().members())
       .build();
   }

--- a/server/src/main/java/io/atomix/copycat/server/state/InactiveState.java
+++ b/server/src/main/java/io/atomix/copycat/server/state/InactiveState.java
@@ -46,7 +46,7 @@ class InactiveState extends AbstractState {
     logRequest(request);
     updateTermAndLeader(request.term(), request.leader());
 
-    Configuration configuration = new Configuration(request.index(), request.timestamp(), request.members());
+    Configuration configuration = new Configuration(request.index(), request.term(), request.timestamp(), request.members());
 
     // Configure the cluster membership. This will cause this server to transition to the
     // appropriate state if its type has changed.

--- a/server/src/main/java/io/atomix/copycat/server/state/ServerMember.java
+++ b/server/src/main/java/io/atomix/copycat/server/state/ServerMember.java
@@ -227,12 +227,13 @@ public final class ServerMember implements Member, CatalystSerializable, AutoClo
     // will log, replicate, and commit the reconfiguration.
     cluster.getContext().getAbstractState().reconfigure(ReconfigureRequest.builder()
       .withIndex(cluster.getConfiguration().index())
+      .withTerm(cluster.getConfiguration().term())
       .withMember(new ServerMember(type, serverAddress(), clientAddress(), updated))
       .build()).whenComplete((response, error) -> {
       if (error == null) {
         if (response.status() == Response.Status.OK) {
           cancelConfigureTimer();
-          cluster.configure(new Configuration(response.index(), response.timestamp(), response.members()));
+          cluster.configure(new Configuration(response.index(), response.term(), response.timestamp(), response.members()));
           future.complete(null);
         } else if (response.error() == null || response.error() == CopycatError.Type.NO_LEADER_ERROR) {
           cancelConfigureTimer();

--- a/server/src/main/java/io/atomix/copycat/server/storage/system/Configuration.java
+++ b/server/src/main/java/io/atomix/copycat/server/storage/system/Configuration.java
@@ -31,12 +31,14 @@ import java.util.Collection;
  */
 public class Configuration {
   private final long index;
+  private final long term;
   private final long time;
   private final Collection<Member> members;
 
-  public Configuration(long index, long time, Collection<Member> members) {
+  public Configuration(long index, long term, long time, Collection<Member> members) {
     this.index = index;
-    this.time = time;
+    this.term = term;
+    this.time = Assert.argNot(time, time <= 0, "time must be positive");
     this.members = Assert.notNull(members, "members");
   }
 
@@ -50,6 +52,17 @@ public class Configuration {
    */
   public long index() {
     return index;
+  }
+
+  /**
+   * Returns the configuration term.
+   * <p>
+   * The term is the term of the leader at the time the configuration change was committed.
+   *
+   * @return The configuration term.
+   */
+  public long term() {
+    return term;
   }
 
   /**

--- a/server/src/main/java/io/atomix/copycat/server/storage/system/MetaStore.java
+++ b/server/src/main/java/io/atomix/copycat/server/storage/system/MetaStore.java
@@ -115,7 +115,11 @@ public class MetaStore implements AutoCloseable {
    */
   public synchronized MetaStore storeConfiguration(Configuration configuration) {
     LOGGER.debug("Store configuration {}", configuration);
-    serializer.writeObject(configuration.members(), buffer.position(12).writeByte(1).writeLong(configuration.index()).writeLong(configuration.time()));
+    serializer.writeObject(configuration.members(), buffer.position(12)
+      .writeByte(1)
+      .writeLong(configuration.index())
+      .writeLong(configuration.term())
+      .writeLong(configuration.time()));
     buffer.flush();
     return this;
   }
@@ -128,6 +132,7 @@ public class MetaStore implements AutoCloseable {
   public synchronized Configuration loadConfiguration() {
     if (buffer.position(12).readByte() == 1) {
       return new Configuration(
+        buffer.readLong(),
         buffer.readLong(),
         buffer.readLong(),
         serializer.readObject(buffer)

--- a/server/src/test/java/io/atomix/copycat/server/storage/MetaStoreTest.java
+++ b/server/src/test/java/io/atomix/copycat/server/storage/MetaStoreTest.java
@@ -87,7 +87,7 @@ public class MetaStoreTest {
       new TestMember(Member.Type.ACTIVE, new Address("localhost", 5001), new Address("localhost", 6001)),
       new TestMember(Member.Type.ACTIVE, new Address("localhost", 5002), new Address("localhost", 6002))
     ));
-    meta.storeConfiguration(new Configuration(1, System.currentTimeMillis(), members));
+    meta.storeConfiguration(new Configuration(1, 1, System.currentTimeMillis(), members));
 
     Configuration configuration = meta.loadConfiguration();
     assertEquals(configuration.index(), 1);


### PR DESCRIPTION
Currently, configuration changes submitted by servers with stale configurations are rejected and attempts are resubmitted to the leader with the updated configuration. However, this does not allow users to fail when an attempt to reconfigure a stale configuration fails. This PR modifies the configuration change process to fail configuration change attempts from members with stale configurations. It is the responsibility of users to resubmit configuration change attempts that fail due to stale configurations.