### PR TITLE
Discard pending snapshot if a completed snapshot at same or newer ind…

### DIFF
--- a/server/src/main/java/io/atomix/copycat/server/storage/snapshot/FileSnapshot.java
+++ b/server/src/main/java/io/atomix/copycat/server/storage/snapshot/FileSnapshot.java
@@ -82,16 +82,17 @@ final class FileSnapshot extends Snapshot {
   @Override
   public Snapshot complete() {
     Buffer buffer = FileBuffer.allocate(file.file(), SnapshotDescriptor.BYTES, store.storage.maxSnapshotSize());
-    SnapshotDescriptor descriptor = new SnapshotDescriptor(buffer);
-    Assert.stateNot(descriptor.locked(), "cannot complete locked snapshot descriptor");
-    descriptor.lock();
-    descriptor.close();
+    try (SnapshotDescriptor descriptor = new SnapshotDescriptor(buffer)) {
+      Assert.stateNot(descriptor.locked(), "cannot complete locked snapshot descriptor");
+      descriptor.lock();
+    }
     return super.complete();
   }
 
   /**
    * Deletes the snapshot file.
    */
+  @Override
   public void delete() {
     Path path = file.file().toPath();
     if (Files.exists(path)) {


### PR DESCRIPTION
…ex is detected

I noticed the following exception on and off
```
2016-03-01 10:40:53,523 | DEBUG | 0.254.1.207:9876 | ServerStateMachine               | 68 - org.onosproject.onlab-thirdparty - 1.5.0.SNAPSHOT | 10.254.1.207/10.254.1.207:9876 - Completing snapshot 1
2016-03-01 10:40:53,523 | ERROR | 0.254.1.207:9876 | SingleThreadContext              | 68 - org.onosproject.onlab-thirdparty - 1.5.0.SNAPSHOT | An uncaught exception occurred
java.lang.IllegalStateException: cannot complete locked snapshot descriptor
    at io.atomix.catalyst.util.Assert.state(Assert.java:69)[68:org.onosproject.onlab-thirdparty:1.5.0.SNAPSHOT]
    at io.atomix.catalyst.util.Assert.stateNot(Assert.java:76)[68:org.onosproject.onlab-thirdparty:1.5.0.SNAPSHOT]
    at io.atomix.copycat.server.storage.snapshot.FileSnapshot.complete(FileSnapshot.java:86)[68:org.onosproject.onlab-thirdparty:1.5.0.SNAPSHOT]
    at io.atomix.copycat.server.state.ServerStateMachine.completeSnapshot(ServerStateMachine.java:150)[68:org.onosproject.onlab-thirdparty:1.5.0.SNAPSHOT]
    at io.atomix.copycat.server.state.ServerStateMachine.setLastCompleted(ServerStateMachine.java:246)[68:org.onosproject.onlab-thirdparty:1.5.0.SNAPSHOT]
    at io.atomix.copycat.server.state.ServerStateMachine.lambda$keepAliveSession$79(ServerStateMachine.java:592)[68:org.onosproject.onlab-thirdparty:1.5.0.SNAPSHOT]
```
It turns out you'll see this issue if in between starting a snapshot and completing it, a `FOLLOWER` receives a complete snapshot with the same index form the `LEADER`.
With this patch we do one last last check before completing the pending snapshot by comparing it with the current snapshot index.

Also in this patch is a fix for file descriptor leak that occurs when the above exception is observed.
