### PR TITLE
Client/Server open rename

### DIFF
--- a/client/src/main/java/io/atomix/copycat/client/CopycatClient.java
+++ b/client/src/main/java/io/atomix/copycat/client/CopycatClient.java
@@ -21,7 +21,6 @@ import io.atomix.catalyst.transport.Transport;
 import io.atomix.catalyst.util.Assert;
 import io.atomix.catalyst.util.ConfigurationException;
 import io.atomix.catalyst.util.Listener;
-import io.atomix.catalyst.util.Managed;
 import io.atomix.catalyst.util.concurrent.CatalystThreadFactory;
 import io.atomix.catalyst.util.concurrent.ThreadContext;
 import io.atomix.copycat.Command;
@@ -44,7 +43,7 @@ import java.util.function.Consumer;
  * <p>
  * Copycat clients are responsible for connecting to the cluster and submitting {@link Command commands} and {@link Query queries}
  * that operate on the cluster's replicated state machine. Copycat clients interact with one or more nodes in a Copycat cluster
- * through a session. When the client is {@link #open() opened}, the client will attempt to one of the known member
+ * through a session. When the client is {@link #connect() connected}, the client will attempt to one of the known member
  * {@link Address} provided to the builder. As long as the client can communicate with at least one correct member of the
  * cluster, it can open a session. Once the client is able to register a {@link Session}, it will receive an updated list
  * of members for the entire cluster and thereafter be allowed to communicate with all servers.
@@ -125,7 +124,7 @@ import java.util.function.Consumer;
  *
  * @author <a href="http://github.com/kuujo>Jordan Halterman</a>
  */
-public interface CopycatClient extends Managed<CopycatClient> {
+public interface CopycatClient {
 
   /**
    * Indicates the state of the client's communication with the Copycat cluster.
@@ -418,7 +417,7 @@ public interface CopycatClient extends Managed<CopycatClient> {
    *
    * @return A completable future to be completed once the client's {@link #session()} is open.
    */
-  CompletableFuture<CopycatClient> open();
+  CompletableFuture<CopycatClient> connect();
 
   /**
    * Recovers the client session.

--- a/client/src/main/java/io/atomix/copycat/client/DefaultCopycatClient.java
+++ b/client/src/main/java/io/atomix/copycat/client/DefaultCopycatClient.java
@@ -168,7 +168,7 @@ public class DefaultCopycatClient implements CopycatClient {
   }
 
   @Override
-  public synchronized CompletableFuture<CopycatClient> open() {
+  public synchronized CompletableFuture<CopycatClient> connect() {
     if (state != State.CLOSED)
       return CompletableFuture.completedFuture(this);
 
@@ -184,11 +184,6 @@ public class DefaultCopycatClient implements CopycatClient {
       }, context.executor());
     }
     return openFuture;
-  }
-
-  @Override
-  public boolean isOpen() {
-    return state != State.CLOSED;
   }
 
   @Override
@@ -309,11 +304,6 @@ public class DefaultCopycatClient implements CopycatClient {
       }, context.executor());
     }
     return closeFuture;
-  }
-
-  @Override
-  public boolean isClosed() {
-    return state == State.CLOSED;
   }
 
   /**

--- a/examples/value-client/src/main/java/io/atomix/copycat/examples/ValueClientExample.java
+++ b/examples/value-client/src/main/java/io/atomix/copycat/examples/ValueClientExample.java
@@ -49,11 +49,11 @@ public class ValueClientExample {
       .withTransport(new NettyTransport())
       .build();
 
-    client.open().join();
+    client.connect().join();
 
     recursiveSet(client);
 
-    while (client.isOpen()) {
+    while (client.state() != CopycatClient.State.CLOSED) {
       Thread.sleep(1000);
     }
   }

--- a/examples/value-state-machine/src/main/java/io/atomix/copycat/examples/ValueStateMachineExample.java
+++ b/examples/value-state-machine/src/main/java/io/atomix/copycat/examples/ValueStateMachineExample.java
@@ -60,9 +60,9 @@ public class ValueStateMachineExample {
         .build())
       .build();
 
-    server.open().join();
+    server.start().join();
 
-    while (server.isOpen()) {
+    while (server.isRunning()) {
       Thread.sleep(1000);
     }
   }

--- a/test/src/test/java/io/atomix/copycat/test/ClusterTest.java
+++ b/test/src/test/java/io/atomix/copycat/test/ClusterTest.java
@@ -161,7 +161,7 @@ public class ClusterTest extends ConcurrentTestCase {
     createServers(3);
     CopycatClient client = createClient();
     Thread.sleep(Duration.ofSeconds(10).toMillis());
-    threadAssertTrue(client.isOpen());
+    threadAssertTrue(client.state() == CopycatClient.State.CONNECTED);
   }
 
   /**
@@ -1362,7 +1362,7 @@ public class ClusterTest extends ConcurrentTestCase {
       .withRetryStrategy(RetryStrategies.FIBONACCI_BACKOFF)
       .build();
     client.serializer().disableWhitelist();
-    client.open().thenRun(this::resume);
+    client.connect().thenRun(this::resume);
     await(30000);
     clients.add(client);
     return client;


### PR DESCRIPTION
This PR renames some of the `CopycatClient` and `CopycatServer` methods for consistency with their behaviors and modifies the process with which servers join the cluster to abstract some of the details of the cluster configuration. In particular, servers will *always* now try to join an existing cluster. If a server can't join an existing cluster it will timeout and attempt to get elected leader. This ensures that servers can form a new cluster when initially started. If the server is attempting to join an existing cluster then it can't be elected leader since existing members will reject its election attempt so long as its configuration indicates that active members of the cluster make up a majority. For instance, if node `c` is joining a cluster with nodes `a` and `b`, node `c` cannot by itself get elected leader even if it's partitioned, so this is fine.