### PR TITLE
Ensure single-node cluster does not attempt to join

### DIFF
--- a/server/src/main/java/io/atomix/copycat/server/state/ClusterState.java
+++ b/server/src/main/java/io/atomix/copycat/server/state/ClusterState.java
@@ -327,7 +327,12 @@ final class ClusterState implements Cluster, AutoCloseable {
 
       // Attempt to join the cluster. If the local member is ACTIVE then failing to join the cluster
       // will result in the member attempting to get elected. This allows initial clusters to form.
-      join(getActiveMemberStates().iterator());
+      List<MemberState> activeMembers = getActiveMemberStates();
+      if (!activeMembers.isEmpty()) {
+        join(getActiveMemberStates().iterator());
+      } else {
+        joinFuture.complete(null);
+      }
     });
 
     return joinFuture.whenComplete((result, error) -> joinFuture = null);


### PR DESCRIPTION
Single nodes in a single node cluster will attempt to join a cluster that doesn't exist. This adds a condition to check the active members size and complete the join immediately for single-member clusters.