### PR TITLE
Ensure internal server proxies return error responses rather than exceptions

### DIFF
--- a/server/src/main/java/io/atomix/copycat/server/state/PassiveState.java
+++ b/server/src/main/java/io/atomix/copycat/server/state/PassiveState.java
@@ -102,6 +102,10 @@ class PassiveState extends ReserveState {
             .filter(m -> m != null)
             .collect(Collectors.toList()))
           .build())
+        .exceptionally(error -> ConnectResponse.builder()
+          .withStatus(Response.Status.ERROR)
+          .withError(CopycatError.Type.NO_LEADER_ERROR)
+          .build())
         .thenApply(this::logResponse);
     }
   }
@@ -263,7 +267,12 @@ class PassiveState extends ReserveState {
     }
 
     LOGGER.debug("{} - Forwarded {}", context.getCluster().member().address(), request);
-    return this.<QueryRequest, QueryResponse>forward(request).thenApply(this::logResponse);
+    return this.<QueryRequest, QueryResponse>forward(request)
+      .exceptionally(error -> QueryResponse.builder()
+        .withStatus(Response.Status.ERROR)
+        .withError(CopycatError.Type.NO_LEADER_ERROR)
+        .build())
+      .thenApply(this::logResponse);
   }
 
   /**

--- a/server/src/main/java/io/atomix/copycat/server/state/ReserveState.java
+++ b/server/src/main/java/io/atomix/copycat/server/state/ReserveState.java
@@ -101,7 +101,12 @@ class ReserveState extends InactiveState {
         .withError(CopycatError.Type.NO_LEADER_ERROR)
         .build()));
     } else {
-      return this.<CommandRequest, CommandResponse>forward(request).thenApply(this::logResponse);
+      return this.<CommandRequest, CommandResponse>forward(request)
+        .exceptionally(error -> CommandResponse.builder()
+          .withStatus(Response.Status.ERROR)
+          .withError(CopycatError.Type.NO_LEADER_ERROR)
+          .build())
+        .thenApply(this::logResponse);
     }
   }
 
@@ -116,7 +121,12 @@ class ReserveState extends InactiveState {
         .withError(CopycatError.Type.NO_LEADER_ERROR)
         .build()));
     } else {
-      return this.<QueryRequest, QueryResponse>forward(request).thenApply(this::logResponse);
+      return this.<QueryRequest, QueryResponse>forward(request)
+        .exceptionally(error -> QueryResponse.builder()
+          .withStatus(Response.Status.ERROR)
+          .withError(CopycatError.Type.NO_LEADER_ERROR)
+          .build())
+        .thenApply(this::logResponse);
     }
   }
 
@@ -131,7 +141,12 @@ class ReserveState extends InactiveState {
         .withError(CopycatError.Type.NO_LEADER_ERROR)
         .build()));
     } else {
-      return this.<RegisterRequest, RegisterResponse>forward(request).thenApply(this::logResponse);
+      return this.<RegisterRequest, RegisterResponse>forward(request)
+        .exceptionally(error -> RegisterResponse.builder()
+          .withStatus(Response.Status.ERROR)
+          .withError(CopycatError.Type.NO_LEADER_ERROR)
+          .build())
+        .thenApply(this::logResponse);
     }
   }
 
@@ -167,7 +182,12 @@ class ReserveState extends InactiveState {
         .withError(CopycatError.Type.NO_LEADER_ERROR)
         .build()));
     } else {
-      return this.<KeepAliveRequest, KeepAliveResponse>forward(request).thenApply(this::logResponse);
+      return this.<KeepAliveRequest, KeepAliveResponse>forward(request)
+        .exceptionally(error -> KeepAliveResponse.builder()
+          .withStatus(Response.Status.ERROR)
+          .withError(CopycatError.Type.NO_LEADER_ERROR)
+          .build())
+        .thenApply(this::logResponse);
     }
   }
 
@@ -183,7 +203,20 @@ class ReserveState extends InactiveState {
         .withError(CopycatError.Type.ILLEGAL_MEMBER_STATE_ERROR)
         .build()));
     } else {
-      return session.getConnection().<PublishRequest, PublishResponse>send(request);
+      CompletableFuture<PublishResponse> future = new CompletableFuture<>();
+      session.getConnection().<PublishRequest, PublishResponse>send(request).whenComplete((result, error) -> {
+        if (isOpen()) {
+          if (error == null) {
+            future.complete(result);
+          } else {
+            future.complete(logResponse(PublishResponse.builder()
+              .withStatus(Response.Status.ERROR)
+              .withError(CopycatError.Type.INTERNAL_ERROR)
+              .build()));
+          }
+        }
+      });
+      return future;
     }
   }
 
@@ -198,7 +231,12 @@ class ReserveState extends InactiveState {
         .withError(CopycatError.Type.NO_LEADER_ERROR)
         .build()));
     } else {
-      return this.<UnregisterRequest, UnregisterResponse>forward(request).thenApply(this::logResponse);
+      return this.<UnregisterRequest, UnregisterResponse>forward(request)
+        .exceptionally(error -> UnregisterResponse.builder()
+          .withStatus(Response.Status.ERROR)
+          .withError(CopycatError.Type.NO_LEADER_ERROR)
+          .build())
+        .thenApply(this::logResponse);
     }
   }
 
@@ -213,7 +251,12 @@ class ReserveState extends InactiveState {
         .withError(CopycatError.Type.NO_LEADER_ERROR)
         .build()));
     } else {
-      return this.<JoinRequest, JoinResponse>forward(request).thenApply(this::logResponse);
+      return this.<JoinRequest, JoinResponse>forward(request)
+        .exceptionally(error -> JoinResponse.builder()
+          .withStatus(Response.Status.ERROR)
+          .withError(CopycatError.Type.NO_LEADER_ERROR)
+          .build())
+        .thenApply(this::logResponse);
     }
   }
 
@@ -228,7 +271,12 @@ class ReserveState extends InactiveState {
         .withError(CopycatError.Type.NO_LEADER_ERROR)
         .build()));
     } else {
-      return this.<ReconfigureRequest, ReconfigureResponse>forward(request).thenApply(this::logResponse);
+      return this.<ReconfigureRequest, ReconfigureResponse>forward(request)
+        .exceptionally(error -> ReconfigureResponse.builder()
+          .withStatus(Response.Status.ERROR)
+          .withError(CopycatError.Type.NO_LEADER_ERROR)
+          .build())
+        .thenApply(this::logResponse);
     }
   }
 
@@ -243,7 +291,12 @@ class ReserveState extends InactiveState {
         .withError(CopycatError.Type.NO_LEADER_ERROR)
         .build()));
     } else {
-      return this.<LeaveRequest, LeaveResponse>forward(request).thenApply(this::logResponse);
+      return this.<LeaveRequest, LeaveResponse>forward(request)
+        .exceptionally(error -> LeaveResponse.builder()
+          .withStatus(Response.Status.ERROR)
+          .withError(CopycatError.Type.NO_LEADER_ERROR)
+          .build())
+        .thenApply(this::logResponse);
     }
   }
 


### PR DESCRIPTION
When servers proxy requests to the leader, if a transport-level exception occurs then the servers will respond to the original request with the returned exception. This PR modifies all internal request proxying logic to instead translate exceptions to `Response` objects with a `NO_LEADER_ERROR`. This ensures the original source of the request (a client or another node) can properly interpret the response rather than receiving an often meaningless exception, and exceptions don't need to be serialized on the wire.