### PR TITLE
Automatically fail non-timeout or response exceptions

### DIFF
--- a/client/src/main/java/io/atomix/copycat/client/session/ClientSessionSubmitter.java
+++ b/client/src/main/java/io/atomix/copycat/client/session/ClientSessionSubmitter.java
@@ -22,21 +22,16 @@ import io.atomix.copycat.Command;
 import io.atomix.copycat.NoOpCommand;
 import io.atomix.copycat.Operation;
 import io.atomix.copycat.Query;
-import io.atomix.copycat.client.*;
-import io.atomix.copycat.error.CommandException;
-import io.atomix.copycat.error.QueryException;
-import io.atomix.copycat.error.CopycatError;
-import io.atomix.copycat.protocol.CommandRequest;
-import io.atomix.copycat.protocol.OperationRequest;
-import io.atomix.copycat.protocol.QueryRequest;
-import io.atomix.copycat.protocol.CommandResponse;
-import io.atomix.copycat.protocol.OperationResponse;
-import io.atomix.copycat.protocol.QueryResponse;
-import io.atomix.copycat.protocol.Response;
+import io.atomix.copycat.client.RetryStrategy;
 import io.atomix.copycat.client.util.ClientSequencer;
+import io.atomix.copycat.error.CommandException;
+import io.atomix.copycat.error.CopycatError;
+import io.atomix.copycat.error.QueryException;
+import io.atomix.copycat.protocol.*;
 import io.atomix.copycat.session.ClosedSessionException;
 import io.atomix.copycat.session.Session;
 
+import java.net.ConnectException;
 import java.time.Duration;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeoutException;
@@ -196,7 +191,7 @@ final class ClientSessionSubmitter {
         } else if (response.error() != CopycatError.Type.UNKNOWN_SESSION_ERROR) {
           strategy.attemptFailed(this, response.error().createException());
         }
-      } else if (error instanceof TimeoutException) {
+      } else if (error instanceof ConnectException || error instanceof TimeoutException) {
         strategy.attemptFailed(this, error);
       } else {
         fail(error);

--- a/client/src/main/java/io/atomix/copycat/client/session/ClientSessionSubmitter.java
+++ b/client/src/main/java/io/atomix/copycat/client/session/ClientSessionSubmitter.java
@@ -16,6 +16,7 @@
 package io.atomix.copycat.client.session;
 
 import io.atomix.catalyst.transport.Connection;
+import io.atomix.catalyst.transport.TransportException;
 import io.atomix.catalyst.util.Assert;
 import io.atomix.catalyst.util.concurrent.ThreadContext;
 import io.atomix.copycat.Command;
@@ -191,7 +192,7 @@ final class ClientSessionSubmitter {
         } else if (response.error() != CopycatError.Type.UNKNOWN_SESSION_ERROR) {
           strategy.attemptFailed(this, response.error().createException());
         }
-      } else if (error instanceof ConnectException || error instanceof TimeoutException) {
+      } else if (error instanceof ConnectException || error instanceof TimeoutException || error instanceof TransportException) {
         strategy.attemptFailed(this, error);
       } else {
         fail(error);

--- a/client/src/main/java/io/atomix/copycat/client/session/ClientSessionSubmitter.java
+++ b/client/src/main/java/io/atomix/copycat/client/session/ClientSessionSubmitter.java
@@ -39,6 +39,7 @@ import io.atomix.copycat.session.Session;
 
 import java.time.Duration;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeoutException;
 import java.util.function.BiConsumer;
 
 /**
@@ -195,8 +196,10 @@ final class ClientSessionSubmitter {
         } else if (response.error() != CopycatError.Type.UNKNOWN_SESSION_ERROR) {
           strategy.attemptFailed(this, response.error().createException());
         }
-      } else {
+      } else if (error instanceof TimeoutException) {
         strategy.attemptFailed(this, error);
+      } else {
+        fail(error);
       }
     }
 

--- a/client/src/main/java/io/atomix/copycat/client/util/ClientConnection.java
+++ b/client/src/main/java/io/atomix/copycat/client/util/ClientConnection.java
@@ -15,10 +15,7 @@
  */
 package io.atomix.copycat.client.util;
 
-import io.atomix.catalyst.transport.Address;
-import io.atomix.catalyst.transport.Client;
-import io.atomix.catalyst.transport.Connection;
-import io.atomix.catalyst.transport.MessageHandler;
+import io.atomix.catalyst.transport.*;
 import io.atomix.catalyst.util.Assert;
 import io.atomix.catalyst.util.Listener;
 import io.atomix.copycat.error.CopycatError;
@@ -149,7 +146,7 @@ public class ClientConnection implements Connection {
         } else {
           next().whenComplete((c, e) -> sendRequest(request, c, e, future));
         }
-      } else if (error instanceof ConnectException || error instanceof TimeoutException) {
+      } else if (error instanceof ConnectException || error instanceof TimeoutException || error instanceof TransportException) {
         next().whenComplete((c, e) -> sendRequest(request, c, e, future));
       } else {
         future.completeExceptionally(error);

--- a/client/src/main/java/io/atomix/copycat/client/util/ClientConnection.java
+++ b/client/src/main/java/io/atomix/copycat/client/util/ClientConnection.java
@@ -35,6 +35,7 @@ import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeoutException;
 import java.util.function.Consumer;
 
 /**
@@ -148,8 +149,10 @@ public class ClientConnection implements Connection {
         } else {
           next().whenComplete((c, e) -> sendRequest(request, c, e, future));
         }
-      } else {
+      } else if (error instanceof TimeoutException) {
         next().whenComplete((c, e) -> sendRequest(request, c, e, future));
+      } else {
+        future.completeExceptionally(error);
       }
     }
   }

--- a/client/src/main/java/io/atomix/copycat/client/util/ClientConnection.java
+++ b/client/src/main/java/io/atomix/copycat/client/util/ClientConnection.java
@@ -23,8 +23,8 @@ import io.atomix.catalyst.util.Assert;
 import io.atomix.catalyst.util.Listener;
 import io.atomix.copycat.error.CopycatError;
 import io.atomix.copycat.protocol.ConnectRequest;
-import io.atomix.copycat.protocol.Request;
 import io.atomix.copycat.protocol.ConnectResponse;
+import io.atomix.copycat.protocol.Request;
 import io.atomix.copycat.protocol.Response;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -149,7 +149,7 @@ public class ClientConnection implements Connection {
         } else {
           next().whenComplete((c, e) -> sendRequest(request, c, e, future));
         }
-      } else if (error instanceof TimeoutException) {
+      } else if (error instanceof ConnectException || error instanceof TimeoutException) {
         next().whenComplete((c, e) -> sendRequest(request, c, e, future));
       } else {
         future.completeExceptionally(error);


### PR DESCRIPTION
This PR modifies the logic for handling exceptions in the client to immediately fail all exceptions other than `Response` errors or `TimeoutException`. Additionally, it ensures that such exceptions bubble up to the user code so users can properly react to serialization failures in particular.