### PR TITLE
Log compaction improvements

### DIFF
--- a/examples/value-state-machine/src/main/java/io/atomix/copycat/examples/ValueStateMachineExample.java
+++ b/examples/value-state-machine/src/main/java/io/atomix/copycat/examples/ValueStateMachineExample.java
@@ -54,11 +54,15 @@ public class ValueStateMachineExample {
       .withTransport(new NettyTransport())
       .withStorage(Storage.builder()
         .withDirectory(args[0])
-        .withMaxEntriesPerSegment(1024)
-        .withMinorCompactionInterval(Duration.ofSeconds(27))
-        .withMajorCompactionInterval(Duration.ofSeconds(31))
+        .withMaxSegmentSize(1024 * 1024 * 32)
+        .withMinorCompactionInterval(Duration.ofMinutes(1))
+        .withMajorCompactionInterval(Duration.ofHours(1))
         .build())
       .build();
+
+    server.serializer().register(SetCommand.class, 1);
+    server.serializer().register(GetQuery.class, 2);
+    server.serializer().register(DeleteCommand.class, 3);
 
     server.start().join();
 

--- a/examples/value-state-machine/src/main/java/io/atomix/copycat/examples/ValueStateMachineExample.java
+++ b/examples/value-state-machine/src/main/java/io/atomix/copycat/examples/ValueStateMachineExample.java
@@ -56,7 +56,7 @@ public class ValueStateMachineExample {
         .withDirectory(args[0])
         .withMaxSegmentSize(1024 * 1024 * 32)
         .withMinorCompactionInterval(Duration.ofMinutes(1))
-        .withMajorCompactionInterval(Duration.ofHours(1))
+        .withMajorCompactionInterval(Duration.ofMinutes(15))
         .build())
       .build();
 

--- a/server/src/main/java/io/atomix/copycat/server/storage/compaction/MajorCompactionManager.java
+++ b/server/src/main/java/io/atomix/copycat/server/storage/compaction/MajorCompactionManager.java
@@ -62,16 +62,9 @@ public final class MajorCompactionManager implements CompactionManager {
   public List<List<Segment>> getCompactableGroups(Storage storage, SegmentManager manager) {
     List<List<Segment>> compact = new ArrayList<>();
     List<Segment> segments = null;
-    Segment previousSegment = null;
     for (Segment segment : getCompactableSegments(manager)) {
       // If this is the first segment in a segments list, add the segment.
       if (segments == null) {
-        segments = new ArrayList<>();
-        segments.add(segment);
-      }
-      // If the previous segment is undefined or of a different version, reset the segments.
-      else if (previousSegment != null && previousSegment.descriptor().version() != segment.descriptor().version()) {
-        compact.add(segments);
         segments = new ArrayList<>();
         segments.add(segment);
       }
@@ -86,7 +79,6 @@ public final class MajorCompactionManager implements CompactionManager {
         segments = new ArrayList<>();
         segments.add(segment);
       }
-      previousSegment = segment;
     }
 
     // Ensure all compactable segments have been added to the compact segments list.

--- a/server/src/main/java/io/atomix/copycat/server/storage/compaction/MinorCompactionTask.java
+++ b/server/src/main/java/io/atomix/copycat/server/storage/compaction/MinorCompactionTask.java
@@ -23,7 +23,7 @@ import io.atomix.copycat.server.storage.entry.Entry;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.List;
+import java.util.Collections;
 
 /**
  * Removes {@link io.atomix.copycat.server.storage.Log#release(long) released} entries from an individual
@@ -46,14 +46,14 @@ import java.util.List;
 public final class MinorCompactionTask implements CompactionTask {
   private static final Logger LOGGER = LoggerFactory.getLogger(MinorCompactionTask.class);
   private final SegmentManager manager;
-  private final List<Segment> segments;
+  private final Segment segment;
   private final long snapshotIndex;
   private final long compactIndex;
   private final Compaction.Mode defaultCompactionMode;
 
-  MinorCompactionTask(SegmentManager manager, List<Segment> segments, long snapshotIndex, long compactIndex, Compaction.Mode defaultCompactionMode) {
+  MinorCompactionTask(SegmentManager manager, Segment segment, long snapshotIndex, long compactIndex, Compaction.Mode defaultCompactionMode) {
     this.manager = Assert.notNull(manager, "manager");
-    this.segments = Assert.notNull(segments, "segments");
+    this.segment = Assert.notNull(segment, "segment");
     this.snapshotIndex = snapshotIndex;
     this.compactIndex = compactIndex;
     this.defaultCompactionMode = Assert.notNull(defaultCompactionMode, "defaultCompactionMode");
@@ -68,40 +68,26 @@ public final class MinorCompactionTask implements CompactionTask {
    * Compacts all compactable segments.
    */
   private void compactSegments() {
-    Segment firstSegment = segments.get(0);
-
     // Create a compact segment with a newer version to which to rewrite the segment entries.
     Segment compactSegment = manager.createSegment(SegmentDescriptor.builder()
-      .withId(firstSegment.descriptor().id())
-      .withVersion(firstSegment.descriptor().version() + 1)
-      .withIndex(firstSegment.descriptor().index())
-      .withMaxSegmentSize(firstSegment.descriptor().maxSegmentSize())
-      .withMaxEntries(firstSegment.descriptor().maxEntries())
+      .withId(segment.descriptor().id())
+      .withVersion(segment.descriptor().version() + 1)
+      .withIndex(segment.descriptor().index())
+      .withMaxSegmentSize(segment.descriptor().maxSegmentSize())
+      .withMaxEntries(segment.descriptor().maxEntries())
       .build());
 
-    compactSegments(segments, compactSegment);
+    compactEntries(segment, compactSegment);
 
     // Replace the old segment with the compact segment.
-    manager.replaceSegments(segments, compactSegment);
+    manager.replaceSegments(Collections.singletonList(segment), compactSegment);
 
-    // Merge released entries from uncompacted segments into compacted segments.
-    mergeReleasedEntries(segments, compactSegment);
+    // Update the new segment with offsets that were released during compaction.
+    mergeReleasedEntries(segment, compactSegment);
 
-    // Delete uncompacted segments.
-    deleteSegments(segments);
-  }
-
-  /**
-   * Compacts segments in a group sequentially.
-   *
-   * @param segments The segments to compact.
-   * @param compactSegment The compact segment.
-   */
-  private void compactSegments(List<Segment> segments, Segment compactSegment) {
-    // Iterate through all segments being compacted and write entries to a single compact segment.
-    for (int i = 0; i < segments.size(); i++) {
-      compactSegment(segments.get(i), compactSegment);
-    }
+    // Delete the old segment.
+    segment.close();
+    segment.delete();
   }
 
   /**
@@ -110,7 +96,7 @@ public final class MinorCompactionTask implements CompactionTask {
    * @param segment The segment to compact.
    * @param compactSegment The compact segment.
    */
-  private void compactSegment(Segment segment, Segment compactSegment) {
+  private void compactEntries(Segment segment, Segment compactSegment) {
     for (long i = segment.firstIndex(); i <= segment.lastIndex(); i++) {
       checkEntry(i, segment, compactSegment);
     }
@@ -154,7 +140,7 @@ public final class MinorCompactionTask implements CompactionTask {
         if (index <= snapshotIndex && !segment.isLive(index)) {
           compactEntry(index, segment, compactSegment);
         } else {
-          transferEntry(index, entry, segment, compactSegment);
+          transferEntry(index, entry, compactSegment);
         }
         break;
       // QUORUM entries are compacted if the entry has been released in the segment.
@@ -162,7 +148,7 @@ public final class MinorCompactionTask implements CompactionTask {
         if (!segment.isLive(index)) {
           compactEntry(index, segment, compactSegment);
         } else {
-          transferEntry(index, entry, segment, compactSegment);
+          transferEntry(index, entry, compactSegment);
         }
         break;
       // FULL entries are compacted if the major compact index is greater than the entry index
@@ -171,7 +157,7 @@ public final class MinorCompactionTask implements CompactionTask {
         if (index <= compactIndex && !segment.isLive(index)) {
           compactEntry(index, segment, compactSegment);
         } else {
-          transferEntry(index, entry, segment, compactSegment);
+          transferEntry(index, entry, compactSegment);
         }
         break;
       // SEQUENTIAL and TOMBSTONE entries can only be compacted during major compaction.
@@ -179,7 +165,7 @@ public final class MinorCompactionTask implements CompactionTask {
       case SEQUENTIAL:
       case TOMBSTONE:
       case UNKNOWN:
-        transferEntry(index, entry, segment, compactSegment);
+        transferEntry(index, entry, compactSegment);
         break;
       default:
         break;
@@ -197,21 +183,12 @@ public final class MinorCompactionTask implements CompactionTask {
   /**
    * Transfers an entry to the given compact segment.
    */
-  private void transferEntry(long index, Entry entry, Segment segment, Segment compactSegment) {
+  private void transferEntry(long index, Entry entry, Segment compactSegment) {
     compactSegment.append(entry);
 
     // If the entry was released in the prior segment, mark it as released in the compact segment.
     if (!segment.isLive(index)) {
       compactSegment.release(index);
-    }
-  }
-
-  /**
-   * Updates the new compact segment with entries that were released during compaction.
-   */
-  private void mergeReleasedEntries(List<Segment> segments, Segment compactSegment) {
-    for (int i = 0; i < segments.size(); i++) {
-      mergeReleasedEntries(segments.get(i), compactSegment);
     }
   }
 
@@ -223,17 +200,6 @@ public final class MinorCompactionTask implements CompactionTask {
       if (!segment.isLive(i)) {
         compactSegment.release(i);
       }
-    }
-  }
-
-  /**
-   * Completes compaction by deleting old segments.
-   */
-  private void deleteSegments(List<Segment> group) {
-    // Delete the old segments.
-    for (Segment oldSegment : group) {
-      oldSegment.close();
-      oldSegment.delete();
     }
   }
 


### PR DESCRIPTION
This PR makes a number of improvements to Copycat's log compaction algorithms. 

The combination of segments is now performed *only* during major compaction. This is because there is currently no way for the minor compaction process to intelligently determine when it should combine multiple segments, so it ended up rewriting the log much more frequently than is necessary. By moving the combination of segments only to major compaction, we allow the user to control that expensive operation through the frequency of major compactions.

The process with which segments are read from disk after compaction was also improved. Some bugs existed in the previous algorithm. When multiple segments are combined, a new segment is created with the ID and starting index of the first segment in the combination group, and the combined segment can overlap other segments on disk in the event that a failure occurs during major compaction. The algorithm for loading segment files from disk now accounts for the overlaps in segments and will always choose the earlier segment when entries in multiple segments overlap.

Finally, in cases where the minor compaction interval was a factor of the major compaction interval, often minor compaction would prevent major compaction from running since both cannot run concurrently. The `Compactor` will now enqueue requests to compact the log for both minor and major compaction. This means if both compaction processes are run concurrently, one will be run after the other rather than one preventing the other.