### PR TITLE
Check for retryable cause when error is a  CompletionException

### DIFF
--- a/client/src/main/java/io/atomix/copycat/client/session/ClientSessionSubmitter.java
+++ b/client/src/main/java/io/atomix/copycat/client/session/ClientSessionSubmitter.java
@@ -191,10 +191,8 @@ final class ClientSessionSubmitter {
         state.getLogger().debug("{} - Received {}", state.getSessionId(), response);
         if (response.status() == Response.Status.OK) {
           complete(response);
-        } else if (response.error() == CopycatError.Type.APPLICATION_ERROR) {
+        } else if (response.error() == CopycatError.Type.COMMAND_ERROR || response.error() == CopycatError.Type.QUERY_ERROR || response.error() == CopycatError.Type.APPLICATION_ERROR) {
           complete(response.error().createException());
-        } else if (response.error() == CopycatError.Type.COMMAND_ERROR || response.error() == CopycatError.Type.QUERY_ERROR) {
-          strategy.attemptFailed(this, error);
         } else if (response.error() != CopycatError.Type.UNKNOWN_SESSION_ERROR) {
           strategy.attemptFailed(this, response.error().createException());
         }


### PR DESCRIPTION
`CompletableFuture::join` can throw a `CompletionException` and when that happens subsequent completion stages complete with a `CompletionException` as well. For retry logic to correctly work we need to check the cause when error is a `CompletionException`

This PR also reverts a change that was accidentally pushed to master branch.