### PR TITLE
Set command and query errors as retryable

### DIFF
--- a/client/src/main/java/io/atomix/copycat/client/session/ClientSessionSubmitter.java
+++ b/client/src/main/java/io/atomix/copycat/client/session/ClientSessionSubmitter.java
@@ -191,7 +191,7 @@ final class ClientSessionSubmitter {
         state.getLogger().debug("{} - Received {}", state.getSessionId(), response);
         if (response.status() == Response.Status.OK) {
           complete(response);
-        } else if (response.error() == CopycatError.Type.COMMAND_ERROR || response.error() == CopycatError.Type.QUERY_ERROR || response.error() == CopycatError.Type.APPLICATION_ERROR) {
+        } else if (response.error() == CopycatError.Type.APPLICATION_ERROR) {
           complete(response.error().createException());
         } else if (response.error() != CopycatError.Type.UNKNOWN_SESSION_ERROR) {
           strategy.attemptFailed(this, response.error().createException());


### PR DESCRIPTION
We currently fail on `QUERY_ERROR` and `COMMAND_ERROR`. These errors are encountered when the leader fails to get a quorum. However, these errors are potentially recoverable. This PR will (re-)enable retries for these errors.