### PR TITLE
Session related bugfixes + logging improvements

### DIFF
--- a/client/src/main/java/io/atomix/copycat/client/session/ClientSessionManager.java
+++ b/client/src/main/java/io/atomix/copycat/client/session/ClientSessionManager.java
@@ -119,8 +119,6 @@ final class ClientSessionManager {
       .withEventIndex(state.getCompleteIndex())
       .build();
 
-    scheduleKeepAlive();
-
     state.getLogger().debug("{} - Sending {}", sessionId, request);
     connection.<KeepAliveRequest, KeepAliveResponse>send(request).whenComplete((response, error) -> {
       if (state.getState() != Session.State.CLOSED) {

--- a/protocol/src/main/java/io/atomix/copycat/protocol/KeepAliveResponse.java
+++ b/protocol/src/main/java/io/atomix/copycat/protocol/KeepAliveResponse.java
@@ -123,7 +123,7 @@ public class KeepAliveResponse extends SessionResponse {
 
   @Override
   public String toString() {
-    return String.format("%s[status=%s, leader=%s, members=%s]", getClass().getSimpleName(), status, leader, members);
+    return String.format("%s[status=%s, error=%s, leader=%s, members=%s]", getClass().getSimpleName(), status, error, leader, members);
   }
 
   /**

--- a/server/src/main/java/io/atomix/copycat/server/state/AbstractAppender.java
+++ b/server/src/main/java/io/atomix/copycat/server/state/AbstractAppender.java
@@ -367,7 +367,7 @@ abstract class AbstractAppender implements AutoCloseable {
     // when attempting to send entries to down followers.
     int failures = member.incrementFailureCount();
     if (failures <= 3 || failures % 100 == 0) {
-      LOGGER.warn("{} - {}", context.getCluster().member().address(), error.getMessage());
+      LOGGER.warn("{} - AppendRequest to {} failed. Reason: {}", context.getCluster().member().address(), member.getMember().address(), error.getMessage());
     }
   }
 

--- a/server/src/main/java/io/atomix/copycat/server/state/ServerSessionContext.java
+++ b/server/src/main/java/io/atomix/copycat/server/state/ServerSessionContext.java
@@ -730,11 +730,12 @@ class ServerSessionContext implements ServerSession {
       log.release(keepAliveIndex);
     }
 
+    context.sessions().unregisterSession(id);
+
     // If no references to session commands are open, release session-related entries.
     if (references == 0) {
       log.release(id);
       log.release(index);
-      context.sessions().unregisterSession(id);
     } else {
       this.closeIndex = index;
     }


### PR DESCRIPTION
This PR addresses the following issues:
- Ensure server side session state is appropriately cleaned up on session expiration. This helps prevent invalid session state transitions.
- On the client side do not schedule a recurrent keep alive task up front. This helps prevent sending keep alives for sessions the server no longer recognizes.
- Misc logging improvements for better diagnostics