### PR TITLE
Ensure EventHolder previousIndex is >= completeIndex

### DIFF
--- a/server/src/main/java/io/atomix/copycat/server/state/ServerSessionContext.java
+++ b/server/src/main/java/io/atomix/copycat/server/state/ServerSessionContext.java
@@ -640,7 +640,7 @@ class ServerSessionContext implements ServerSession {
     PublishRequest request = PublishRequest.builder()
       .withSession(id())
       .withEventIndex(event.eventIndex)
-      .withPreviousIndex(event.previousIndex)
+      .withPreviousIndex(Math.max(event.previousIndex, completeIndex))
       .withEvents(event.events)
       .build();
 


### PR DESCRIPTION
This PR fixes a issue that was identified with event publishing around leadership transfers. If the new leader has previously not published any events or if it has not even buffered any of the previously published events, the first event it publishes (after assuming leadership) will potentially have a `previousIndex` that is smaller than the last received event index (represented by `completeIndex`). When this condition occurs the event publishing to that client locks up.