### PR TITLE
Performance improvements

### DIFF
--- a/server/src/main/java/io/atomix/copycat/server/state/AbstractAppender.java
+++ b/server/src/main/java/io/atomix/copycat/server/state/AbstractAppender.java
@@ -112,7 +112,7 @@ abstract class AbstractAppender implements AutoCloseable {
     final long index = prevEntry != null ? prevEntry.getIndex() + 1 : context.getLog().firstIndex();
 
     // Build a list of entries to send to the member.
-    List<Entry> entries = new ArrayList<>((int) Math.min(8, context.getLog().lastIndex() - index + 1));
+    List<Entry> entries = new ArrayList<>((int) Math.min(8, lastIndex - index + 1));
 
     // Build a list of entries up to the MAX_BATCH_SIZE. Note that entries in the log may
     // be null if they've been compacted and the member to which we're sending entries is just
@@ -206,11 +206,6 @@ abstract class AbstractAppender implements AutoCloseable {
         }
       }
     });
-
-    updateNextIndex(member, request);
-    if (!request.entries().isEmpty() && hasMoreEntries(member)) {
-      appendEntries(member);
-    }
   }
 
   /**
@@ -327,11 +322,9 @@ abstract class AbstractAppender implements AutoCloseable {
   /**
    * Updates the next index when the match index is updated.
    */
-  protected void updateNextIndex(MemberState member, AppendRequest request) {
+  protected void updateNextIndex(MemberState member) {
     // If the match index was set, update the next index to be greater than the match index if necessary.
-    if (!request.entries().isEmpty()) {
-      member.setNextIndex(request.entries().get(request.entries().size()-1).getIndex()+1);
-    }
+    member.setNextIndex(Math.max(member.getMatchIndex() + 1, 1));
   }
 
   /**

--- a/server/src/main/java/io/atomix/copycat/server/state/ActiveState.java
+++ b/server/src/main/java/io/atomix/copycat/server/state/ActiveState.java
@@ -128,6 +128,9 @@ abstract class ActiveState extends PassiveState {
           context.getStateMachine().executor().context().sessions().registerAddress(connectEntry.getClient(), connectEntry.getAddress());
         }
       }
+
+      // Flush the log entries to disk.
+      context.getLog().flush();
     }
 
     // If we've made it this far, apply commits and send a successful response.

--- a/server/src/main/java/io/atomix/copycat/server/state/FollowerAppender.java
+++ b/server/src/main/java/io/atomix/copycat/server/state/FollowerAppender.java
@@ -55,12 +55,12 @@ final class FollowerAppender extends AbstractAppender {
     if (context.getSnapshotStore().currentSnapshot() != null
       && context.getSnapshotStore().currentSnapshot().index() >= member.getNextIndex()
       && context.getSnapshotStore().currentSnapshot().index() > member.getSnapshotIndex()) {
-      if (canInstall(member)) {
+      if (member.canInstall()) {
         sendInstallRequest(member, buildInstallRequest(member));
       }
     }
     // If no AppendRequest is already being sent, send an AppendRequest.
-    else if (canAppend(member) && hasMoreEntries(member)) {
+    else if (member.canAppend() && hasMoreEntries(member)) {
       sendAppendRequest(member, buildAppendRequest(member, Math.min(context.getCommitIndex(), context.getLog().lastIndex())));
     }
   }

--- a/server/src/main/java/io/atomix/copycat/server/state/LeaderAppender.java
+++ b/server/src/main/java/io/atomix/copycat/server/state/LeaderAppender.java
@@ -392,6 +392,7 @@ final class LeaderAppender extends AbstractAppender {
     // If replication succeeded then trigger commit futures.
     if (response.succeeded()) {
       updateMatchIndex(member, response);
+      updateNextIndex(member);
 
       // If entries were committed to the replica then check commit indexes.
       if (!request.entries().isEmpty()) {

--- a/server/src/main/java/io/atomix/copycat/server/state/LeaderAppender.java
+++ b/server/src/main/java/io/atomix/copycat/server/state/LeaderAppender.java
@@ -391,7 +391,6 @@ final class LeaderAppender extends AbstractAppender {
     // If replication succeeded then trigger commit futures.
     if (response.succeeded()) {
       updateMatchIndex(member, response);
-      updateNextIndex(member);
 
       // If entries were committed to the replica then check commit indexes.
       if (!request.entries().isEmpty()) {

--- a/server/src/main/java/io/atomix/copycat/server/state/LeaderAppender.java
+++ b/server/src/main/java/io/atomix/copycat/server/state/LeaderAppender.java
@@ -323,6 +323,7 @@ final class LeaderAppender extends AbstractAppender {
     // the index of the leader's no-op entry. Update the commit index and trigger commit futures.
     long previousCommitIndex = context.getCommitIndex();
     if (commitIndex > 0 && commitIndex > previousCommitIndex && (leaderIndex > 0 && commitIndex >= leaderIndex)) {
+      context.getLog().flush();
       context.setCommitIndex(commitIndex);
       completeCommits(previousCommitIndex, commitIndex);
     }

--- a/server/src/main/java/io/atomix/copycat/server/state/LeaderState.java
+++ b/server/src/main/java/io/atomix/copycat/server/state/LeaderState.java
@@ -95,9 +95,6 @@ final class LeaderState extends ActiveState {
       LOGGER.debug("{} - Appended {}", context.getCluster().member().address(), entry);
     }
 
-    // Flush the log entries to disk.
-    context.getLog().flush();
-
     // Append a configuration entry to propagate the leader's cluster configuration.
     configure(context.getCluster().members());
   }
@@ -189,9 +186,6 @@ final class LeaderState extends ActiveState {
         // Mark the session as being unregistered in order to ensure this leader doesn't attempt
         // to unregister it again.
         session.unregister();
-
-        // Flush the log entries to disk.
-        context.getLog().flush();
       }
     }
   }
@@ -234,9 +228,6 @@ final class LeaderState extends ActiveState {
       configuring = index;
       context.getClusterState().configure(new Configuration(entry.getIndex(), entry.getTerm(), entry.getTimestamp(), entry.getMembers()));
     }
-
-    // Flush the log entries to disk.
-    context.getLog().flush();
 
     return appender.appendEntries(index).whenComplete((commitIndex, commitError) -> {
       context.checkThread();
@@ -559,9 +550,6 @@ final class LeaderState extends ActiveState {
     // Set the last processed request for the session. This will cause sequential command callbacks to be executed.
     session.setRequestSequence(request.sequence());
 
-    // Flush the log entries to disk.
-    context.getLog().flush();
-
     return future;
   }
 
@@ -742,9 +730,6 @@ final class LeaderState extends ActiveState {
       }
     });
 
-    // Flush the log entries to disk.
-    context.getLog().flush();
-
     return future;
   }
 
@@ -829,9 +814,6 @@ final class LeaderState extends ActiveState {
       }
     });
 
-    // Flush the log entries to disk.
-    context.getLog().flush();
-
     return future;
   }
 
@@ -900,9 +882,6 @@ final class LeaderState extends ActiveState {
       }
     });
 
-    // Flush the log entries to disk.
-    context.getLog().flush();
-
     return future;
   }
 
@@ -961,9 +940,6 @@ final class LeaderState extends ActiveState {
         }
       }
     });
-
-    // Flush the log entries to disk.
-    context.getLog().flush();
 
     return future;
   }

--- a/server/src/main/java/io/atomix/copycat/server/state/LeaderState.java
+++ b/server/src/main/java/io/atomix/copycat/server/state/LeaderState.java
@@ -95,6 +95,9 @@ final class LeaderState extends ActiveState {
       LOGGER.debug("{} - Appended {}", context.getCluster().member().address(), entry);
     }
 
+    // Flush the log entries to disk.
+    context.getLog().flush();
+
     // Append a configuration entry to propagate the leader's cluster configuration.
     configure(context.getCluster().members());
   }
@@ -186,6 +189,9 @@ final class LeaderState extends ActiveState {
         // Mark the session as being unregistered in order to ensure this leader doesn't attempt
         // to unregister it again.
         session.unregister();
+
+        // Flush the log entries to disk.
+        context.getLog().flush();
       }
     }
   }
@@ -228,6 +234,9 @@ final class LeaderState extends ActiveState {
       configuring = index;
       context.getClusterState().configure(new Configuration(entry.getIndex(), entry.getTerm(), entry.getTimestamp(), entry.getMembers()));
     }
+
+    // Flush the log entries to disk.
+    context.getLog().flush();
 
     return appender.appendEntries(index).whenComplete((commitIndex, commitError) -> {
       context.checkThread();
@@ -550,6 +559,9 @@ final class LeaderState extends ActiveState {
     // Set the last processed request for the session. This will cause sequential command callbacks to be executed.
     session.setRequestSequence(request.sequence());
 
+    // Flush the log entries to disk.
+    context.getLog().flush();
+
     return future;
   }
 
@@ -729,6 +741,10 @@ final class LeaderState extends ActiveState {
         }
       }
     });
+
+    // Flush the log entries to disk.
+    context.getLog().flush();
+
     return future;
   }
 
@@ -812,6 +828,10 @@ final class LeaderState extends ActiveState {
         }
       }
     });
+
+    // Flush the log entries to disk.
+    context.getLog().flush();
+
     return future;
   }
 
@@ -879,6 +899,10 @@ final class LeaderState extends ActiveState {
         }
       }
     });
+
+    // Flush the log entries to disk.
+    context.getLog().flush();
+
     return future;
   }
 
@@ -937,6 +961,10 @@ final class LeaderState extends ActiveState {
         }
       }
     });
+
+    // Flush the log entries to disk.
+    context.getLog().flush();
+
     return future;
   }
 

--- a/server/src/main/java/io/atomix/copycat/server/state/MemberState.java
+++ b/server/src/main/java/io/atomix/copycat/server/state/MemberState.java
@@ -34,6 +34,9 @@ final class MemberState {
   private long nextIndex;
   private long heartbeatTime;
   private long heartbeatStartTime;
+  private boolean appending;
+  private boolean configuring;
+  private boolean installing;
   private int failures;
 
   public MemberState(ServerMember member, ClusterState cluster) {
@@ -50,6 +53,9 @@ final class MemberState {
     nextIndex = log.lastIndex() + 1;
     heartbeatTime = 0;
     heartbeatStartTime = 0;
+    appending = false;
+    configuring = false;
+    installing = false;
     failures = 0;
   }
 
@@ -199,6 +205,93 @@ final class MemberState {
    */
   MemberState setNextIndex(long nextIndex) {
     this.nextIndex = Assert.argNot(nextIndex, nextIndex <= 0, "nextIndex cannot be less than or equal to 0");
+    return this;
+  }
+
+  /**
+   * Returns a boolean indicating whether an append request can be sent to the member.
+   *
+   * @return Indicates whether an append request can be sent to the member.
+   */
+  boolean canAppend() {
+    return !appending;
+  }
+
+  /**
+   * Starts an append request to the member.
+   *
+   * @return The member state.
+   */
+  MemberState startAppend() {
+    appending = true;
+    return this;
+  }
+
+  /**
+   * Completes an append request to the member.
+   *
+   * @return The member state.
+   */
+  MemberState completeAppend() {
+    appending = false;
+    return this;
+  }
+
+  /**
+   * Returns a boolean indicating whether a configure request can be sent to the member.
+   *
+   * @return Indicates whether a configure request can be sent to the member.
+   */
+  boolean canConfigure() {
+    return !configuring;
+  }
+
+  /**
+   * Starts a configure request to the member.
+   *
+   * @return The member state.
+   */
+  MemberState startConfigure() {
+    configuring = true;
+    return this;
+  }
+
+  /**
+   * Completes a configure request to the member.
+   *
+   * @return The member state.
+   */
+  MemberState completeConfigure() {
+    configuring = false;
+    return this;
+  }
+
+  /**
+   * Returns a boolean indicating whether an install request can be sent to the member.
+   *
+   * @return Indicates whether an install request can be sent to the member.
+   */
+  boolean canInstall() {
+    return !installing;
+  }
+
+  /**
+   * Starts an install request to the member.
+   *
+   * @return The member state.
+   */
+  MemberState startInstall() {
+    installing = true;
+    return this;
+  }
+
+  /**
+   * Completes an install request to the member.
+   *
+   * @return The member state.
+   */
+  MemberState completeInstall() {
+    installing = false;
     return this;
   }
 

--- a/server/src/main/java/io/atomix/copycat/server/state/MemberState.java
+++ b/server/src/main/java/io/atomix/copycat/server/state/MemberState.java
@@ -24,6 +24,7 @@ import io.atomix.copycat.server.storage.Log;
  * @author <a href="http://github.com/kuujo">Jordan Halterman</a>
  */
 final class MemberState {
+  private static final int MAX_APPENDS = 2;
   private final ServerMember member;
   private long term;
   private long configIndex;
@@ -34,7 +35,7 @@ final class MemberState {
   private long nextIndex;
   private long heartbeatTime;
   private long heartbeatStartTime;
-  private boolean appending;
+  private int appending;
   private boolean configuring;
   private boolean installing;
   private int failures;
@@ -53,7 +54,7 @@ final class MemberState {
     nextIndex = log.lastIndex() + 1;
     heartbeatTime = 0;
     heartbeatStartTime = 0;
-    appending = false;
+    appending = 0;
     configuring = false;
     installing = false;
     failures = 0;
@@ -214,7 +215,7 @@ final class MemberState {
    * @return Indicates whether an append request can be sent to the member.
    */
   boolean canAppend() {
-    return !appending;
+    return appending < MAX_APPENDS;
   }
 
   /**
@@ -223,7 +224,7 @@ final class MemberState {
    * @return The member state.
    */
   MemberState startAppend() {
-    appending = true;
+    appending++;
     return this;
   }
 
@@ -233,7 +234,7 @@ final class MemberState {
    * @return The member state.
    */
   MemberState completeAppend() {
-    appending = false;
+    appending--;
     return this;
   }
 

--- a/server/src/main/java/io/atomix/copycat/server/state/MemberState.java
+++ b/server/src/main/java/io/atomix/copycat/server/state/MemberState.java
@@ -24,7 +24,6 @@ import io.atomix.copycat.server.storage.Log;
  * @author <a href="http://github.com/kuujo">Jordan Halterman</a>
  */
 final class MemberState {
-  private static final int MAX_APPENDS = 2;
   private final ServerMember member;
   private long term;
   private long configIndex;
@@ -35,7 +34,7 @@ final class MemberState {
   private long nextIndex;
   private long heartbeatTime;
   private long heartbeatStartTime;
-  private int appending;
+  private boolean appending;
   private boolean configuring;
   private boolean installing;
   private int failures;
@@ -54,7 +53,7 @@ final class MemberState {
     nextIndex = log.lastIndex() + 1;
     heartbeatTime = 0;
     heartbeatStartTime = 0;
-    appending = 0;
+    appending = false;
     configuring = false;
     installing = false;
     failures = 0;
@@ -215,7 +214,7 @@ final class MemberState {
    * @return Indicates whether an append request can be sent to the member.
    */
   boolean canAppend() {
-    return appending < MAX_APPENDS;
+    return !appending;
   }
 
   /**
@@ -224,7 +223,7 @@ final class MemberState {
    * @return The member state.
    */
   MemberState startAppend() {
-    appending++;
+    appending = true;
     return this;
   }
 
@@ -234,7 +233,7 @@ final class MemberState {
    * @return The member state.
    */
   MemberState completeAppend() {
-    appending--;
+    appending = false;
     return this;
   }
 

--- a/server/src/main/java/io/atomix/copycat/server/storage/Log.java
+++ b/server/src/main/java/io/atomix/copycat/server/storage/Log.java
@@ -247,6 +247,7 @@ public class Log implements AutoCloseable {
    */
   private void checkRoll() {
     if (segments.currentSegment().isFull()) {
+      segments.currentSegment().flush();
       segments.nextSegment();
     }
   }

--- a/server/src/main/java/io/atomix/copycat/server/storage/Segment.java
+++ b/server/src/main/java/io/atomix/copycat/server/storage/Segment.java
@@ -521,9 +521,10 @@ public class Segment implements AutoCloseable {
    * @return The segment.
    */
   public Segment commit() {
+    Buffer buffer = this.buffer instanceof SlicedBuffer ? ((SlicedBuffer) this.buffer).root() : this.buffer;
     if (buffer instanceof MappedBuffer) {
       buffer.close();
-      buffer = FileBuffer.allocate(file.file());
+      this.buffer = FileBuffer.allocate(file.file());
     }
     return this;
   }

--- a/server/src/main/java/io/atomix/copycat/server/storage/Segment.java
+++ b/server/src/main/java/io/atomix/copycat/server/storage/Segment.java
@@ -60,7 +60,7 @@ public class Segment implements AutoCloseable {
   private final SegmentFile file;
   private final SegmentDescriptor descriptor;
   private final Serializer serializer;
-  private volatile Buffer buffer;
+  private final Buffer buffer;
   private final OffsetIndex offsetIndex;
   private final OffsetPredicate offsetPredicate;
   private final TermIndex termIndex = new TermIndex();
@@ -93,6 +93,15 @@ public class Segment implements AutoCloseable {
       length = buffer.mark().readInt();
     }
     buffer.reset();
+  }
+
+  /**
+   * Returns the segment file.
+   *
+   * @return The segment file.
+   */
+  public SegmentFile file() {
+    return file;
   }
 
   /**
@@ -512,20 +521,6 @@ public class Segment implements AutoCloseable {
   public Segment flush() {
     buffer.flush();
     offsetIndex.flush();
-    return this;
-  }
-
-  /**
-   * Commits the segment to disk.
-   *
-   * @return The segment.
-   */
-  public Segment commit() {
-    Buffer buffer = this.buffer instanceof SlicedBuffer ? ((SlicedBuffer) this.buffer).root() : this.buffer;
-    if (buffer instanceof MappedBuffer) {
-      buffer.close();
-      this.buffer = FileBuffer.allocate(file.file());
-    }
     return this;
   }
 

--- a/server/src/main/java/io/atomix/copycat/server/storage/SegmentManager.java
+++ b/server/src/main/java/io/atomix/copycat/server/storage/SegmentManager.java
@@ -289,7 +289,11 @@ public class SegmentManager implements AutoCloseable {
       case MEMORY:
         return createMemorySegment(descriptor);
       case MAPPED:
-        return createMappedSegment(descriptor);
+        if (descriptor.version() == 1) {
+          return createMappedSegment(descriptor);
+        } else {
+          return createDiskSegment(descriptor);
+        }
       case DISK:
         return createDiskSegment(descriptor);
       default:

--- a/server/src/main/java/io/atomix/copycat/server/storage/SegmentManager.java
+++ b/server/src/main/java/io/atomix/copycat/server/storage/SegmentManager.java
@@ -78,14 +78,7 @@ public class SegmentManager implements AutoCloseable {
    * @return The segment manager.
    */
   SegmentManager commitIndex(long commitIndex) {
-    if (commitIndex > this.commitIndex) {
-      long previousIndex = this.commitIndex;
-      this.commitIndex = commitIndex;
-      Segment segment = segment(previousIndex);
-      if (segment != null && segment.lastIndex() < commitIndex) {
-        segment.commit();
-      }
-    }
+    this.commitIndex = Math.max(this.commitIndex, commitIndex);
     return this;
   }
 

--- a/server/src/main/java/io/atomix/copycat/server/storage/SegmentManager.java
+++ b/server/src/main/java/io/atomix/copycat/server/storage/SegmentManager.java
@@ -82,7 +82,7 @@ public class SegmentManager implements AutoCloseable {
       long previousIndex = this.commitIndex;
       this.commitIndex = commitIndex;
       Segment segment = segment(previousIndex);
-      if (segment.lastIndex() < commitIndex) {
+      if (segment != null && segment.lastIndex() < commitIndex) {
         segment.commit();
       }
     }


### PR DESCRIPTION
This PR adds various performance improvements to logging and replication in Copycat. The performance improvements are primarily with memory mapped files. `flush`ing files to disk was moved to ensure it only occurs when the commit index is increased rather than on each write. This allows memory mapped files to provide very fast random access to writes while still maintaining consistency flushing to disk prior to completing writes. I also experimented with pipelining in this branch, however no simplistic implementation of pipelining performed better than simple batching, and indeed in most cases it performed worse due to significantly smaller batches.

In my tests, I've seen a cluster of three nodes with `MAPPED` storage receive up to 60k writes/sec from a single client.