### PR TITLE
Implement pipelining

### DIFF
--- a/server/src/main/java/io/atomix/copycat/server/state/AbstractAppender.java
+++ b/server/src/main/java/io/atomix/copycat/server/state/AbstractAppender.java
@@ -191,13 +191,13 @@ abstract class AbstractAppender implements AutoCloseable {
    * Sends a commit message.
    */
   protected void sendAppendRequest(Connection connection, MemberState member, AppendRequest request) {
-    long timestamp = System.currentTimeMillis();
+    long timestamp = System.nanoTime();
     connection.<AppendRequest, AppendResponse>send(request).whenComplete((response, error) -> {
       context.checkThread();
 
       // Complete the append to the member.
       if (!request.entries().isEmpty()) {
-        member.completeAppend(System.currentTimeMillis() - timestamp);
+        member.completeAppend(System.nanoTime() - timestamp);
       } else {
         member.completeAppend();
       }

--- a/server/src/main/java/io/atomix/copycat/server/state/LeaderAppender.java
+++ b/server/src/main/java/io/atomix/copycat/server/state/LeaderAppender.java
@@ -392,7 +392,6 @@ final class LeaderAppender extends AbstractAppender {
     // If replication succeeded then trigger commit futures.
     if (response.succeeded()) {
       updateMatchIndex(member, response);
-      updateNextIndex(member);
 
       // If entries were committed to the replica then check commit indexes.
       if (!request.entries().isEmpty()) {

--- a/server/src/main/java/io/atomix/copycat/server/state/MemberState.java
+++ b/server/src/main/java/io/atomix/copycat/server/state/MemberState.java
@@ -218,7 +218,7 @@ final class MemberState {
    * @return Indicates whether an append request can be sent to the member.
    */
   boolean canAppend() {
-    return appending < MAX_APPENDS && System.currentTimeMillis() - (timeBuffer.average() / MAX_APPENDS) >= appendTime;
+    return appending < MAX_APPENDS && System.nanoTime() - (timeBuffer.average() / MAX_APPENDS) >= appendTime;
   }
 
   /**
@@ -228,7 +228,7 @@ final class MemberState {
    */
   MemberState startAppend() {
     appending++;
-    appendTime = System.currentTimeMillis();
+    appendTime = System.nanoTime();
     return this;
   }
 


### PR DESCRIPTION
This PR is an initial implementation of pipelining on Copycat. I took two approaches to attempting pipelining. The first approach was a naive one in which leaders simply pipelined `n` number of requests. The assumption is that under high load, batch sizes will reach an equilibrium. The second approach that was attempted was one alluded to in the Raft dissertation. This approach attempted to estimate the round trip time for an `AppendRequest` to each individual member and use that to optimize batch sizes.

Ultimately, after significant benchmarks using both approaches, I decided to use the latter, more intelligent approach as it proved to be significantly faster than the naive approach in tests. To estimate optimal batch sizes, the round trip time for each request is stored in the `MemberState`, and the last `8` round trip times are averaged to determine when a batch should be sent. Once an append is attempted after 1/2 the average round trip time, pending entries will be batched and sent to the follower. Because of the way the logic is written, this should have no negative impact on write latency during period of low load. In the event a write is made under low load, the `AppendRequest` will immediately be sent since `System.currentTimeMillis()` will normally already be past the required half round trip time.

@madjam can you review?