### PR TITLE
Multi threaded appender

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
     <java.version>1.8</java.version>
     <slf4j.version>1.7.7</slf4j.version>
     <logback.version>1.1.2</logback.version>
-    <catalyst.version>1.0.5</catalyst.version>
+    <catalyst.version>1.0.6-SNAPSHOT</catalyst.version>
 
     <maven.source.plugin.version>2.2.1</maven.source.plugin.version>
     <maven.compiler.plugin.version>3.0</maven.compiler.plugin.version>

--- a/server/src/main/java/io/atomix/copycat/server/CopycatServer.java
+++ b/server/src/main/java/io/atomix/copycat/server/CopycatServer.java
@@ -23,6 +23,7 @@ import io.atomix.catalyst.transport.Transport;
 import io.atomix.catalyst.util.Assert;
 import io.atomix.catalyst.util.ConfigurationException;
 import io.atomix.catalyst.util.Listener;
+import io.atomix.catalyst.util.concurrent.CatalystThreadFactory;
 import io.atomix.catalyst.util.concurrent.Futures;
 import io.atomix.catalyst.util.concurrent.SingleThreadContext;
 import io.atomix.catalyst.util.concurrent.ThreadContext;
@@ -50,6 +51,8 @@ import java.util.HashSet;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Supplier;
@@ -968,7 +971,8 @@ public class CopycatServer {
       ConnectionManager connections = new ConnectionManager(serverTransport.client());
       ThreadContext threadContext = new SingleThreadContext(String.format("copycat-server-%s-%s", serverAddress, name), serializer);
 
-      ServerContext context = new ServerContext(name, type, serverAddress, clientAddress, cluster, storage, serializer, stateMachineFactory, connections, threadContext);
+      ScheduledExecutorService threadPool = Executors.newScheduledThreadPool(Runtime.getRuntime().availableProcessors(), new CatalystThreadFactory("copycat-server-" + serverAddress + "-" + name + "-appender-%d"));
+      ServerContext context = new ServerContext(name, type, serverAddress, clientAddress, cluster, storage, serializer, stateMachineFactory, connections, threadContext, threadPool);
       context.setElectionTimeout(electionTimeout)
         .setHeartbeatInterval(heartbeatInterval)
         .setSessionTimeout(sessionTimeout)

--- a/server/src/main/java/io/atomix/copycat/server/state/AbstractAppender.java
+++ b/server/src/main/java/io/atomix/copycat/server/state/AbstractAppender.java
@@ -171,7 +171,7 @@ abstract class AbstractAppender implements AutoCloseable {
 
     LOGGER.debug("{} - Sent {} to {}", context.getCluster().member().address(), request, member.getMember().address());
     context.getConnections().getConnection(member.getMember().address()).whenComplete((connection, error) -> {
-      context.checkThread();
+      member.getContext().checkThread();
 
       if (open) {
         if (error == null) {
@@ -193,7 +193,7 @@ abstract class AbstractAppender implements AutoCloseable {
   protected void sendAppendRequest(Connection connection, MemberState member, AppendRequest request) {
     long timestamp = System.currentTimeMillis();
     connection.<AppendRequest, AppendResponse>send(request).whenComplete((response, error) -> {
-      context.checkThread();
+      member.getContext().checkThread();
 
       // Complete the append to the member.
       if (!request.entries().isEmpty()) {
@@ -381,7 +381,7 @@ abstract class AbstractAppender implements AutoCloseable {
     member.startConfigure();
 
     context.getConnections().getConnection(member.getMember().serverAddress()).whenComplete((connection, error) -> {
-      context.checkThread();
+      member.getContext().checkThread();
 
       if (open) {
         if (error == null) {
@@ -403,7 +403,7 @@ abstract class AbstractAppender implements AutoCloseable {
   protected void sendConfigureRequest(Connection connection, MemberState member, ConfigureRequest request) {
     LOGGER.debug("{} - Sent {} to {}", context.getCluster().member().address(), request, member.getMember().serverAddress());
     connection.<ConfigureRequest, ConfigureResponse>send(request).whenComplete((response, error) -> {
-      context.checkThread();
+      member.getContext().checkThread();
 
       // Complete the configure to the member.
       member.completeConfigure();
@@ -514,7 +514,7 @@ abstract class AbstractAppender implements AutoCloseable {
     member.startInstall();
 
     context.getConnections().getConnection(member.getMember().serverAddress()).whenComplete((connection, error) -> {
-      context.checkThread();
+      member.getContext().checkThread();
 
       if (open) {
         if (error == null) {
@@ -536,7 +536,7 @@ abstract class AbstractAppender implements AutoCloseable {
   protected void sendInstallRequest(Connection connection, MemberState member, InstallRequest request) {
     LOGGER.debug("{} - Sent {} to {}", context.getCluster().member().address(), request, member.getMember().serverAddress());
     connection.<InstallRequest, InstallResponse>send(request).whenComplete((response, error) -> {
-      context.checkThread();
+      member.getContext().checkThread();
 
       // Complete the install to the member.
       member.completeInstall();

--- a/server/src/main/java/io/atomix/copycat/server/state/FollowerAppender.java
+++ b/server/src/main/java/io/atomix/copycat/server/state/FollowerAppender.java
@@ -34,7 +34,7 @@ final class FollowerAppender extends AbstractAppender {
   public void appendEntries() {
     if (open) {
       for (MemberState member : context.getClusterState().getAssignedPassiveMemberStates()) {
-        appendEntries(member);
+        member.getContext().executor().execute(() -> appendEntries(member));
       }
     }
   }

--- a/server/src/main/java/io/atomix/copycat/server/state/LeaderAppender.java
+++ b/server/src/main/java/io/atomix/copycat/server/state/LeaderAppender.java
@@ -244,10 +244,12 @@ final class LeaderAppender extends AbstractAppender {
       // heartbeat was being sent.
       if (member.getMember().type() == Member.Type.ACTIVE && ++heartbeatFailures > votingMemberSize - quorumSize) {
         CompletableFuture<Long> heartbeatFuture = this.heartbeatFuture;
-        context.getThreadContext().executor().execute(() -> {
-          heartbeatFuture.completeExceptionally(new InternalException("Failed to reach consensus"));
-          completeHeartbeat();
-        });
+        if (heartbeatFuture != null) {
+          context.getThreadContext().executor().execute(() -> {
+            heartbeatFuture.completeExceptionally(new InternalException("Failed to reach consensus"));
+            completeHeartbeat();
+          });
+        }
       }
     } else {
       member.setHeartbeatTime(System.currentTimeMillis());

--- a/server/src/main/java/io/atomix/copycat/server/state/MemberState.java
+++ b/server/src/main/java/io/atomix/copycat/server/state/MemberState.java
@@ -16,6 +16,7 @@
 package io.atomix.copycat.server.state;
 
 import io.atomix.catalyst.util.Assert;
+import io.atomix.catalyst.util.concurrent.ThreadContext;
 import io.atomix.copycat.server.storage.Log;
 
 /**
@@ -26,24 +27,26 @@ import io.atomix.copycat.server.storage.Log;
 final class MemberState {
   private static final int MAX_APPENDS = 2;
   private final ServerMember member;
-  private long term;
-  private long configIndex;
-  private long snapshotIndex;
-  private long nextSnapshotIndex;
-  private int nextSnapshotOffset;
-  private long matchIndex;
-  private long nextIndex;
-  private long heartbeatTime;
-  private long heartbeatStartTime;
+  private final ThreadContext context;
+  private volatile long term;
+  private volatile long configIndex;
+  private volatile long snapshotIndex;
+  private volatile long nextSnapshotIndex;
+  private volatile int nextSnapshotOffset;
+  private volatile long matchIndex;
+  private volatile long nextIndex;
+  private volatile long heartbeatTime;
+  private volatile long heartbeatStartTime;
   private int appending;
   private long appendTime;
   private boolean configuring;
   private boolean installing;
-  private int failures;
+  private volatile int failures;
   private final TimeBuffer timeBuffer = new TimeBuffer(8);
 
-  public MemberState(ServerMember member, ClusterState cluster) {
+  public MemberState(ServerMember member, ClusterState cluster, ThreadContext context) {
     this.member = Assert.notNull(member, "member").setCluster(cluster);
+    this.context = context;
   }
 
   /**
@@ -70,6 +73,15 @@ final class MemberState {
    */
   public ServerMember getMember() {
     return member;
+  }
+
+  /**
+   * Returns the member context.
+   *
+   * @return The member context.
+   */
+  public ThreadContext getContext() {
+    return context;
   }
 
   /**

--- a/server/src/main/java/io/atomix/copycat/server/state/ServerContext.java
+++ b/server/src/main/java/io/atomix/copycat/server/state/ServerContext.java
@@ -41,6 +41,7 @@ import org.slf4j.LoggerFactory;
 import java.time.Duration;
 import java.util.Collection;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ScheduledExecutorService;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
 
@@ -80,7 +81,7 @@ public class ServerContext implements AutoCloseable {
   private long globalIndex;
 
   @SuppressWarnings("unchecked")
-  public ServerContext(String name, Member.Type type, Address serverAddress, Address clientAddress, Collection<Address> members, Storage storage, Serializer serializer, Supplier<StateMachine> stateMachineFactory, ConnectionManager connections, ThreadContext threadContext) {
+  public ServerContext(String name, Member.Type type, Address serverAddress, Address clientAddress, Collection<Address> members, Storage storage, Serializer serializer, Supplier<StateMachine> stateMachineFactory, ConnectionManager connections, ThreadContext threadContext, ScheduledExecutorService threadPool) {
     this.name = Assert.notNull(name, "name");
     this.storage = Assert.notNull(storage, "storage");
     this.serializer = Assert.notNull(serializer, "serializer");
@@ -99,7 +100,7 @@ public class ServerContext implements AutoCloseable {
     // Reset the state machine.
     threadContext.execute(this::reset).join();
 
-    this.cluster = new ClusterState(type, serverAddress, clientAddress, members, this);
+    this.cluster = new ClusterState(type, serverAddress, clientAddress, members, this, threadPool);
   }
 
   /**

--- a/server/src/main/java/io/atomix/copycat/server/storage/Segment.java
+++ b/server/src/main/java/io/atomix/copycat/server/storage/Segment.java
@@ -65,7 +65,7 @@ public class Segment implements AutoCloseable {
   private final OffsetPredicate offsetPredicate;
   private final TermIndex termIndex = new TermIndex();
   private final SegmentManager manager;
-  private long skip = 0;
+  private volatile long skip = 0;
   private boolean open = true;
 
   /**
@@ -279,7 +279,7 @@ public class Segment implements AutoCloseable {
    * @throws IllegalStateException if the segment is full
    * @throws IndexOutOfBoundsException if the {@code entry} index does not match the next index
    */
-  public long append(Entry entry) {
+  public synchronized long append(Entry entry) {
     Assert.notNull(entry, "entry");
     Assert.stateNot(isFull(), "segment is full");
 

--- a/server/src/main/java/io/atomix/copycat/server/storage/util/OffsetIndex.java
+++ b/server/src/main/java/io/atomix/copycat/server/storage/util/OffsetIndex.java
@@ -60,11 +60,11 @@ public final class OffsetIndex implements AutoCloseable {
   private static final int OFFSET_SIZE = 8;
 
   private final Buffer buffer;
-  private boolean skipped;
-  private int size;
-  private long lastOffset = -1;
-  private long currentOffset = -1;
-  private long currentMatch = -1;
+  private volatile boolean skipped;
+  private volatile int size;
+  private volatile long lastOffset = -1;
+  private volatile long currentOffset = -1;
+  private volatile long currentMatch = -1;
 
   /**
    * @throws NullPointerException if {@code buffer} is null

--- a/server/src/test/java/io/atomix/copycat/server/state/AbstractStateTest.java
+++ b/server/src/test/java/io/atomix/copycat/server/state/AbstractStateTest.java
@@ -19,6 +19,7 @@ import io.atomix.catalyst.serializer.Serializer;
 import io.atomix.catalyst.transport.Address;
 import io.atomix.catalyst.transport.LocalServerRegistry;
 import io.atomix.catalyst.transport.LocalTransport;
+import io.atomix.catalyst.util.concurrent.CatalystThreadFactory;
 import io.atomix.catalyst.util.concurrent.SingleThreadContext;
 import io.atomix.catalyst.util.concurrent.ThreadContext;
 import io.atomix.copycat.error.CopycatError;
@@ -81,7 +82,7 @@ public abstract class AbstractStateTest<T extends AbstractState> extends Concurr
 
     serverCtx = new SingleThreadContext("test-server", serializer);
     new SingleThreadContext("test", serializer.clone()).executor().execute(() -> {
-      serverContext = new ServerContext("test", members.get(0).type(), members.get(0).serverAddress(), members.get(0).clientAddress(), members.stream().map(ServerMember::serverAddress).collect(Collectors.toList()), storage, serializer, TestStateMachine::new, new ConnectionManager(transport.client()), serverCtx, Executors.newScheduledThreadPool(2));
+      serverContext = new ServerContext("test", members.get(0).type(), members.get(0).serverAddress(), members.get(0).clientAddress(), members.stream().map(ServerMember::serverAddress).collect(Collectors.toList()), storage, serializer, TestStateMachine::new, new ConnectionManager(transport.client()), serverCtx, Executors.newScheduledThreadPool(2, new CatalystThreadFactory("test")));
       resume();
     });
     await(1000);

--- a/server/src/test/java/io/atomix/copycat/server/state/AbstractStateTest.java
+++ b/server/src/test/java/io/atomix/copycat/server/state/AbstractStateTest.java
@@ -44,6 +44,7 @@ import org.testng.annotations.Test;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.Executors;
 import java.util.stream.Collectors;
 
 /**
@@ -80,7 +81,7 @@ public abstract class AbstractStateTest<T extends AbstractState> extends Concurr
 
     serverCtx = new SingleThreadContext("test-server", serializer);
     new SingleThreadContext("test", serializer.clone()).executor().execute(() -> {
-      serverContext = new ServerContext("test", members.get(0).type(), members.get(0).serverAddress(), members.get(0).clientAddress(), members.stream().map(ServerMember::serverAddress).collect(Collectors.toList()), storage, serializer, TestStateMachine::new, new ConnectionManager(transport.client()), serverCtx);
+      serverContext = new ServerContext("test", members.get(0).type(), members.get(0).serverAddress(), members.get(0).clientAddress(), members.stream().map(ServerMember::serverAddress).collect(Collectors.toList()), storage, serializer, TestStateMachine::new, new ConnectionManager(transport.client()), serverCtx, Executors.newScheduledThreadPool(2));
       resume();
     });
     await(1000);

--- a/server/src/test/java/io/atomix/copycat/server/state/ServerStateMachineTest.java
+++ b/server/src/test/java/io/atomix/copycat/server/state/ServerStateMachineTest.java
@@ -47,6 +47,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.UUID;
+import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicLong;
 
 import static org.testng.Assert.*;
@@ -88,7 +89,7 @@ public class ServerStateMachineTest extends ConcurrentTestCase {
     ));
 
     new SingleThreadContext("test", serializer.clone()).executor().execute(() -> {
-      state = new ServerContext("test", member.type(), member.serverAddress(), member.clientAddress(), members, storage, serializer, TestStateMachine::new, new ConnectionManager(new LocalTransport(registry).client()), callerContext);
+      state = new ServerContext("test", member.type(), member.serverAddress(), member.clientAddress(), members, storage, serializer, TestStateMachine::new, new ConnectionManager(new LocalTransport(registry).client()), callerContext, Executors.newScheduledThreadPool(2));
       resume();
     });
     await(1000);

--- a/server/src/test/java/io/atomix/copycat/server/state/ServerStateMachineTest.java
+++ b/server/src/test/java/io/atomix/copycat/server/state/ServerStateMachineTest.java
@@ -20,6 +20,7 @@ import io.atomix.catalyst.transport.Address;
 import io.atomix.catalyst.transport.LocalServerRegistry;
 import io.atomix.catalyst.transport.LocalTransport;
 import io.atomix.catalyst.transport.Transport;
+import io.atomix.catalyst.util.concurrent.CatalystThreadFactory;
 import io.atomix.catalyst.util.concurrent.SingleThreadContext;
 import io.atomix.catalyst.util.concurrent.ThreadContext;
 import io.atomix.copycat.Command;
@@ -89,7 +90,7 @@ public class ServerStateMachineTest extends ConcurrentTestCase {
     ));
 
     new SingleThreadContext("test", serializer.clone()).executor().execute(() -> {
-      state = new ServerContext("test", member.type(), member.serverAddress(), member.clientAddress(), members, storage, serializer, TestStateMachine::new, new ConnectionManager(new LocalTransport(registry).client()), callerContext, Executors.newScheduledThreadPool(2));
+      state = new ServerContext("test", member.type(), member.serverAddress(), member.clientAddress(), members, storage, serializer, TestStateMachine::new, new ConnectionManager(new LocalTransport(registry).client()), callerContext, Executors.newScheduledThreadPool(2, new CatalystThreadFactory("test")));
       resume();
     });
     await(1000);


### PR DESCRIPTION
This PR adds performance improvements to appenders in Copycat. Each appender has a thread pool, and each member operates on a single thread in the pool at any given time. `ThreadContext`s are multiplexed across the thread pool such that available threads are used rather than assigning each specific context to a specific thread. This is done with `ThreadPoolContext`. Creating a thread-per-follower has proved to increase the performance of replication after recent performance fixes in the `NettyTransport`.