### PR TITLE
Separate bootstrap and join APIs

### DIFF
--- a/client/src/main/java/io/atomix/copycat/client/ConnectionStrategy.java
+++ b/client/src/main/java/io/atomix/copycat/client/ConnectionStrategy.java
@@ -27,7 +27,7 @@ import java.time.Duration;
  * strategy will dictate how to handle the failure.
  * <p>
  * Connection strategies are used in the same manner when attempting to recover a lost session. In
- * the event that a client's connection to the cluster is lost and the client must open a new session,
+ * the event that a client's connection to the cluster is lost and the client must register a new session,
  * if recovering the client's session fails then the connection strategy will again dictate how to
  * handle the failure.
  *

--- a/client/src/main/java/io/atomix/copycat/client/CopycatClient.java
+++ b/client/src/main/java/io/atomix/copycat/client/CopycatClient.java
@@ -455,7 +455,7 @@ public interface CopycatClient {
    * @return A completable future to be completed once the client's {@link #session()} is registered.
    */
   default CompletableFuture<CopycatClient> connect(Address... members) {
-    if (members == null) {
+    if (members == null || members.length == 0) {
       return connect();
     } else {
       return connect(Arrays.asList(members));

--- a/client/src/main/java/io/atomix/copycat/client/CopycatClient.java
+++ b/client/src/main/java/io/atomix/copycat/client/CopycatClient.java
@@ -455,7 +455,11 @@ public interface CopycatClient {
    * @return A completable future to be completed once the client's {@link #session()} is registered.
    */
   default CompletableFuture<CopycatClient> connect(Address... members) {
-    return connect(Arrays.asList(Assert.notNull(members, "members")));
+    if (members == null) {
+      return connect();
+    } else {
+      return connect(Arrays.asList(members));
+    }
   }
 
   /**

--- a/client/src/main/java/io/atomix/copycat/client/util/AddressSelector.java
+++ b/client/src/main/java/io/atomix/copycat/client/util/AddressSelector.java
@@ -53,20 +53,13 @@ public class AddressSelector implements Iterator<Address> {
   }
 
   private Address leader;
-  private Collection<Address> servers;
+  private Collection<Address> servers = new ArrayList<>();
   private final ServerSelectionStrategy strategy;
-  private Collection<Address> selections;
+  private Collection<Address> selections = new ArrayList<>();
   private Iterator<Address> selectionsIterator;
 
-  public AddressSelector(Collection<Address> servers, ServerSelectionStrategy selectionStrategy) {
-    this(null, servers, selectionStrategy);
-  }
-
-  public AddressSelector(Address leader, Collection<Address> servers, ServerSelectionStrategy strategy) {
-    this.leader = leader;
-    this.servers = Assert.argNot(servers, Assert.notNull(servers, "servers").isEmpty(), "servers list cannot be empty");
+  public AddressSelector(ServerSelectionStrategy strategy) {
     this.strategy = Assert.notNull(strategy, "strategy");
-    this.selections = strategy.selectConnections(leader, new ArrayList<>(servers));
   }
 
   /**

--- a/client/src/test/java/io/atomix/copycat/client/util/AddressSelectorTest.java
+++ b/client/src/test/java/io/atomix/copycat/client/util/AddressSelectorTest.java
@@ -42,7 +42,8 @@ public class AddressSelectorTest {
       new Address("localhost", 5002)
     );
 
-    AddressSelector selector = new AddressSelector(servers, ServerSelectionStrategies.ANY);
+    AddressSelector selector = new AddressSelector(ServerSelectionStrategies.ANY);
+    selector.reset(null, servers);
     assertNull(selector.leader());
     assertEquals(selector.servers(), servers);
     assertEquals(selector.state(), AddressSelector.State.RESET);
@@ -67,7 +68,8 @@ public class AddressSelectorTest {
       new Address("localhost", 5002)
     );
 
-    AddressSelector selector = new AddressSelector(servers, ServerSelectionStrategies.ANY);
+    AddressSelector selector = new AddressSelector(ServerSelectionStrategies.ANY);
+    selector.reset(null, servers);
     selector.next();
     selector.next();
     selector.next();
@@ -89,7 +91,8 @@ public class AddressSelectorTest {
       new Address("localhost", 5002)
     );
 
-    AddressSelector selector = new AddressSelector(servers, ServerSelectionStrategies.ANY);
+    AddressSelector selector = new AddressSelector(ServerSelectionStrategies.ANY);
+    selector.reset(null, servers);
     assertNull(selector.leader());
     assertEquals(selector.servers(), servers);
     selector.next();

--- a/examples/value-client/src/main/java/io/atomix/copycat/examples/ValueClientExample.java
+++ b/examples/value-client/src/main/java/io/atomix/copycat/examples/ValueClientExample.java
@@ -47,7 +47,7 @@ public class ValueClientExample {
       members.add(new Address(parts[0], Integer.valueOf(parts[1])));
     }
 
-    CopycatClient client = CopycatClient.builder(members)
+    CopycatClient client = CopycatClient.builder()
       .withTransport(new NettyTransport())
       .withConnectionStrategy(ConnectionStrategies.FIBONACCI_BACKOFF)
       .withRetryStrategy(RetryStrategies.FIBONACCI_BACKOFF)
@@ -59,7 +59,7 @@ public class ValueClientExample {
     client.serializer().register(GetQuery.class, 2);
     client.serializer().register(DeleteCommand.class, 3);
 
-    client.connect().join();
+    client.connect(members).join();
 
     AtomicInteger counter = new AtomicInteger();
     AtomicLong timer = new AtomicLong();

--- a/examples/value-state-machine/src/main/java/io/atomix/copycat/examples/ValueStateMachineExample.java
+++ b/examples/value-state-machine/src/main/java/io/atomix/copycat/examples/ValueStateMachineExample.java
@@ -49,7 +49,7 @@ public class ValueStateMachineExample {
       members.add(new Address(parts[0], Integer.valueOf(parts[1])));
     }
 
-    CopycatServer server = CopycatServer.builder(address, members)
+    CopycatServer server = CopycatServer.builder(address)
       .withStateMachine(ValueStateMachine::new)
       .withTransport(new NettyTransport())
       .withStorage(Storage.builder()
@@ -64,7 +64,7 @@ public class ValueStateMachineExample {
     server.serializer().register(GetQuery.class, 2);
     server.serializer().register(DeleteCommand.class, 3);
 
-    server.start().join();
+    server.bootstrap(members).join();
 
     while (server.isRunning()) {
       Thread.sleep(1000);

--- a/server/src/main/java/io/atomix/copycat/server/CopycatServer.java
+++ b/server/src/main/java/io/atomix/copycat/server/CopycatServer.java
@@ -46,8 +46,7 @@ import org.slf4j.LoggerFactory;
 import java.time.Duration;
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.HashSet;
-import java.util.Set;
+import java.util.Collections;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import java.util.function.Consumer;
@@ -70,7 +69,7 @@ import java.util.function.Supplier;
  *   Address address = new Address("123.456.789.0", 5000);
  *   Collection<Address> members = Arrays.asList(new Address("123.456.789.1", 5000), new Address("123.456.789.2", 5000));
  *
- *   CopycatServer server = CopycatServer.builder(address, members)
+ *   CopycatServer server = CopycatServer.builder(address)
  *     .withStateMachine(MyStateMachine::new)
  *     .build();
  *   }
@@ -86,7 +85,7 @@ import java.util.function.Supplier;
  * {@code io.atomix.catalyst:catalyst-netty} jar on your classpath.
  * <pre>
  * {@code
- * CopycatServer server = CopycatServer.builder(address, members)
+ * CopycatServer server = CopycatServer.builder(address)
  *   .withStateMachine(MyStateMachine::new)
  *   .withTransport(NettyTransport.builder()
  *     .withThreads(4)
@@ -101,7 +100,7 @@ import java.util.function.Supplier;
  * memory instead of disk, configure the {@link StorageLevel}.
  * <pre>
  * {@code
- * CopycatServer server = CopycatServer.builder(address, members)
+ * CopycatServer server = CopycatServer.builder(address)
  *   .withStateMachine(MyStateMachine::new)
  *   .withStorage(Storage.builder()
  *     .withDirectory(new File("logs"))
@@ -134,29 +133,77 @@ import java.util.function.Supplier;
  *   server.serializer().register(MySerializable.class, 123, MySerializableSerializer.class);
  *   }
  * </pre>
- * <h2>Running the server</h2>
- * Once the server has been created, to connect to a cluster simply {@link #start() start} the server. The server API is
- * fully asynchronous and relies on {@link CompletableFuture} to provide promises:
+ * <h2>Bootstrapping the cluster</h2>
+ * Once a server has been built, it must either be {@link #bootstrap() bootstrapped} to form a new cluster or
+ * {@link #join(Address...) joined} to an existing cluster. The simplest way to bootstrap a new cluster is to bootstrap
+ * a single server to which additional servers can be joined.
  * <pre>
- * {@code
- * server.open().thenRun(() -> {
- *   System.out.println("Server started successfully!");
- * });
- * }
- * </pre>
- * When the server is started, it will attempt to connect to an existing cluster. If the server cannot find any
- * existing members, it will attempt to form its own cluster.
- * <p>
- * Once the server is started, it will communicate with the rest of the nodes in the cluster, periodically
- * transitioning between states. Users can listen for state transitions via {@link #onStateChange(Consumer)}:
- * <pre>
- * {@code
- * server.onStateChange(state -> {
- *   if (state == CopycatServer.State.LEADER) {
- *     System.out.println("Server elected leader!");
+ *   {@code
+ *   CompletableFuture<CopycatServer> future = server.bootstrap();
+ *   future.thenRun(() -> {
+ *     System.out.println("Server bootstrapped!");
+ *   });
  *   }
- * });
- * }
+ * </pre>
+ * Alternatively, the bootstrapped cluster can include multiple servers by providing an initial configuration to the
+ * {@link #bootstrap(Address...)} method on each server. When bootstrapping a multi-node cluster, the bootstrap configuration
+ * must be identical on all servers for safety.
+ * <pre>
+ *   {@code
+ *     List<Address> cluster = Arrays.asList(
+ *       new Address("123.456.789.0", 5000),
+ *       new Address("123.456.789.1", 5000),
+ *       new Address("123.456.789.2", 5000)
+ *     );
+ *
+ *     CompletableFuture<CopycatServer> future = server.bootstrap(cluster);
+ *     future.thenRun(() -> {
+ *       System.out.println("Cluster bootstrapped");
+ *     });
+ *   }
+ * </pre>
+ * <h2>Adding a server to an existing cluster</h2>
+ * Once a single- or multi-node cluster has been {@link #bootstrap() bootstrapped}, often times users need to
+ * add additional servers to the cluster. For example, some users prefer to bootstrap a single-node cluster and
+ * add additional nodes to that server. Servers can join existing bootstrapped clusters using the {@link #join(Address...)}
+ * method. When joining an existing cluster, the server simply needs to specify at least one reachable server in the
+ * existing cluster.
+ * <pre>
+ *   {@code
+ *     CopycatServer server = CopycatServer.builder(new Address("123.456.789.3", 5000))
+ *       .withTransport(NettyTransport.builder().withThreads(4).build())
+ *       .build();
+ *
+ *     List<Address> cluster = Arrays.asList(
+ *       new Address("123.456.789.0", 5000),
+ *       new Address("123.456.789.1", 5000),
+ *       new Address("123.456.789.2", 5000)
+ *     );
+ *
+ *     CompletableFuture<CopycatServer> future = server.join(cluster);
+ *     future.thenRun(() -> {
+ *       System.out.println("Server joined successfully!");
+ *     });
+ *   }
+ * </pre>
+ * <h2>Server types</h2>
+ * Servers form new clusters and join existing clusters as active Raft voting members by default. However, for
+ * large deployments Copycat also supports alternative types of nodes which are configured by setting the server
+ * {@link Member.Type}. For example, the {@link Member.Type#PASSIVE PASSIVE} server type does not participate
+ * directly in the Raft consensus algorithm and instead receives state changes via an asynchronous gossip protocol.
+ * This allows passive members to scale sequential reads beyond the typical three- or five-node Raft cluster. The
+ * {@link Member.Type#RESERVE RESERVE} server type is a stateless server that can act as a standby to the stateful
+ * servers in the cluster, being {@link Member#promote(Member.Type) promoted} to a stateful state when necessary.
+ * <p>
+ * Server types are defined in the server builder simply by passing the initial {@link Member.Type} to the
+ * {@link Builder#withType(Member.Type)} setter:
+ * <pre>
+ *   {@code
+ *   CopycatServer server = CopycatServer.builder(address)
+ *     .withType(Member.Type.PASSIVE)
+ *     .withTransport(new NettyTransport())
+ *     .build();
+ *   }
  * </pre>
  *
  * @see StateMachine
@@ -170,129 +217,27 @@ public class CopycatServer {
   /**
    * Returns a new Raft server builder.
    * <p>
-   * The provided {@link Address} is the address to which to bind the server being constructed. The provided set of
-   * members will be used to connect to the other members in the Raft cluster. The local server {@link Address} does
-   * not have to be present in the address list.
+   * The provided {@link Address} is the address to which to bind the server being constructed.
    *
    * @param address The address through which clients and servers connect to this server.
-   * @param cluster The cluster members to which to connect.
    * @return The server builder.
    */
-  public static Builder builder(Address address, Address... cluster) {
-    return builder(address, address, Arrays.asList(cluster));
+  public static Builder builder(Address address) {
+    return new Builder(address, address);
   }
 
   /**
    * Returns a new Raft server builder.
    * <p>
-   * The provided {@link Address} is the address to which to bind the server being constructed. The provided set of
-   * members will be used to connect to the other members in the Raft cluster. The local server {@link Address} does
-   * not have to be present in the address list.
-   *
-   * @param address The address through which clients and servers connect to this server.
-   * @param cluster The cluster members to which to connect.
-   * @return The server builder.
-   */
-  public static Builder builder(Address address, Collection<Address> cluster) {
-    return new Builder(address, address, cluster);
-  }
-
-  /**
-   * Returns a new Raft server builder.
-   * <p>
-   * The provided {@link Address} is the address to which to bind the server being constructed. The provided set of
-   * members will be used to connect to the other members in the Raft cluster. The local server {@link Address} does
-   * not have to be present in the address list.
-   *
-   * @param type The server member type.
-   * @param address The address through which clients and servers connect to this server.
-   * @param cluster The cluster members to which to connect.
-   * @return The server builder.
-   */
-  public static Builder builder(Member.Type type, Address address, Address... cluster) {
-    return builder(address, address, Arrays.asList(cluster)).withType(type);
-  }
-
-  /**
-   * Returns a new Raft server builder.
-   * <p>
-   * The provided {@link Address} is the address to which to bind the server being constructed. The provided set of
-   * members will be used to connect to the other members in the Raft cluster. The local server {@link Address} does
-   * not have to be present in the address list.
-   *
-   * @param type The server member type.
-   * @param address The address through which clients and servers connect to this server.
-   * @param cluster The cluster members to which to connect.
-   * @return The server builder.
-   */
-  public static Builder builder(Member.Type type, Address address, Collection<Address> cluster) {
-    return new Builder(address, address, cluster).withType(type);
-  }
-
-  /**
-   * Returns a new Raft server builder.
-   * <p>
-   * The provided {@link Address} is the address to which to bind the server being constructed. The provided set of
-   * members will be used to connect to the other members in the Raft cluster. The local server {@link Address} does
-   * not have to be present in the address list.
+   * The provided {@link Address}es are the client and server address to which to bind the server being
+   * constructed respectively.
    *
    * @param clientAddress The address through which clients connect to the server.
    * @param serverAddress The local server member address.
-   * @param cluster The cluster members to which to connect.
    * @return The server builder.
    */
-  public static Builder builder(Address clientAddress, Address serverAddress, Address... cluster) {
-    return builder(clientAddress, serverAddress, Arrays.asList(cluster));
-  }
-
-  /**
-   * Returns a new Raft server builder.
-   * <p>
-   * The provided {@link Address} is the address to which to bind the server being constructed. The provided set of
-   * members will be used to connect to the other members in the Raft cluster. The local server {@link Address} does
-   * not have to be present in the address list.
-   *
-   * @param clientAddress The address through which clients connect to the server.
-   * @param serverAddress The local server member address.
-   * @param cluster The cluster members to which to connect.
-   * @return The server builder.
-   */
-  public static Builder builder(Address clientAddress, Address serverAddress, Collection<Address> cluster) {
-    return new Builder(clientAddress, serverAddress, cluster);
-  }
-
-  /**
-   * Returns a new Raft server builder.
-   * <p>
-   * The provided {@link Address} is the address to which to bind the server being constructed. The provided set of
-   * members will be used to connect to the other members in the Raft cluster. The local server {@link Address} does
-   * not have to be present in the address list.
-   *
-   * @param type The server member type.
-   * @param clientAddress The address through which clients connect to the server.
-   * @param serverAddress The local server member address.
-   * @param cluster The cluster members to which to connect.
-   * @return The server builder.
-   */
-  public static Builder builder(Member.Type type, Address clientAddress, Address serverAddress, Address... cluster) {
-    return builder(clientAddress, serverAddress, Arrays.asList(cluster)).withType(type);
-  }
-
-  /**
-   * Returns a new Raft server builder.
-   * <p>
-   * The provided {@link Address} is the address to which to bind the server being constructed. The provided set of
-   * members will be used to connect to the other members in the Raft cluster. The local server {@link Address} does
-   * not have to be present in the address list.
-   *
-   * @param type The server member type.
-   * @param clientAddress The address through which clients connect to the server.
-   * @param serverAddress The local server member address.
-   * @param cluster The cluster members to which to connect.
-   * @return The server builder.
-   */
-  public static Builder builder(Member.Type type, Address clientAddress, Address serverAddress, Collection<Address> cluster) {
-    return new Builder(clientAddress, serverAddress, cluster).withType(type);
+  public static Builder builder(Address clientAddress, Address serverAddress) {
+    return new Builder(clientAddress, serverAddress);
   }
 
   /**
@@ -308,7 +253,7 @@ public class CopycatServer {
     /**
      * Represents the state of an inactive server.
      * <p>
-     * All servers start in this state and return to this state when {@link #stop() stopped}.
+     * All servers start in this state and return to this state when {@link #leave() stopped}.
      */
     INACTIVE,
 
@@ -396,9 +341,6 @@ public class CopycatServer {
    * configuration. The storage object is immutable and is intended to provide runtime configuration information only. Users
    * should <em>never open logs, snapshots, or other storage related files</em> through the {@link Storage} API. Doing so
    * can conflict with internal server operations, resulting in the loss of state.
-   * <p>
-   * To delete the server's on-disk state, use the {@link #delete()} method rather than operating on the {@link Storage}
-   * object directly.
    *
    * @return The server storage.
    */
@@ -410,13 +352,13 @@ public class CopycatServer {
    * Returns the server's cluster configuration.
    * <p>
    * The {@link Cluster} is representative of the server's current view of the cluster configuration. The first time
-   * the server is {@link #start() started}, the cluster configuration will be initialized using the {@link Address}
-   * list provided to the server {@link #builder(Address, Address...) builder}. For {@link StorageLevel#DISK persistent}
+   * the server is {@link #bootstrap() started}, the cluster configuration will be initialized using the {@link Address}
+   * list provided to the server {@link #builder(Address) builder}. For {@link StorageLevel#DISK persistent}
    * servers, subsequent starts will result in the last known cluster configuration being loaded from disk.
    * <p>
    * The returned {@link Cluster} can be used to modify the state of the cluster to which this server belongs. Note,
-   * however, that users need not explicitly {@link Cluster#join() join} or {@link Cluster#leave() leave} the cluster
-   * since starting and stopping the server results in joining and leaving the cluster respectively.
+   * however, that users need not explicitly {@link Cluster#join(Address...) join} or {@link Cluster#leave() leave} the
+   * cluster since starting and stopping the server results in joining and leaving the cluster respectively.
    *
    * @return The server's cluster configuration.
    */
@@ -469,7 +411,7 @@ public class CopycatServer {
   /**
    * Returns the Copycat server state.
    * <p>
-   * The initial state of a Raft server is {@link State#INACTIVE}. Once the server is {@link #start() started} and
+   * The initial state of a Raft server is {@link State#INACTIVE}. Once the server is {@link #bootstrap() started} and
    * until it is explicitly shutdown, the server will be in one of the active states - {@link State#PASSIVE},
    * {@link State#FOLLOWER}, {@link State#CANDIDATE}, or {@link State#LEADER}.
    *
@@ -528,17 +470,163 @@ public class CopycatServer {
   }
 
   /**
-   * Starts the server asynchronously.
+   * Bootstraps a single-node cluster.
    * <p>
-   * When the server is started, the server will attempt to search for an existing cluster by contacting all of
-   * the members in the provided members list. If no existing cluster is found, the server will immediately transition
-   * to the {@link State#FOLLOWER} state and continue normal Raft protocol operations. If a cluster is found, the server
-   * will attempt to join the cluster. Once the server has joined or started a cluster and a leader has been found,
-   * the returned {@link CompletableFuture} will be completed.
+   * Bootstrapping a single-node cluster results in the server forming a new cluster to which additional servers
+   * can be joined.
+   * <p>
+   * Only {@link Member.Type#ACTIVE} members can be included in a bootstrap configuration. If the local server is
+   * not initialized as an active member, it cannot be part of the bootstrap configuration for the cluster.
+   * <p>
+   * When the cluster is bootstrapped, the local server will be transitioned into the active state and begin
+   * participating in the Raft consensus algorithm. When the cluster is first bootstrapped, no leader will exist.
+   * The bootstrapped members will elect a leader amongst themselves. Once a cluster has been bootstrapped, additional
+   * members may be {@link #join(Address...) joined} to the cluster. In the event that the bootstrapped members cannot
+   * reach a quorum to elect a leader, bootstrap will continue until successful.
+   * <p>
+   * It is critical that all servers in a bootstrap configuration be started with the same exact set of members.
+   * Bootstrapping multiple servers with different configurations may result in split brain.
+   * <p>
+   * The {@link CompletableFuture} returned by this method will be completed once the cluster has been bootstrapped,
+   * a leader has been elected, and the leader has been notified of the local server's client configurations.
    *
-   * @return A completable future to be completed once the server has joined the cluster and a leader has been found.
+   * @return A completable future to be completed once the cluster has been bootstrapped.
    */
-  public CompletableFuture<CopycatServer> start() {
+  @SuppressWarnings("unchecked")
+  public CompletableFuture<CopycatServer> bootstrap() {
+    return bootstrap(Collections.EMPTY_LIST);
+  }
+
+  /**
+   * Bootstraps the cluster using the provided cluster configuration.
+   * <p>
+   * Bootstrapping the cluster results in a new cluster being formed with the provided configuration. The initial
+   * nodes in a cluster must always be bootstrapped. This is necessary to prevent split brain. If the provided
+   * configuration is empty, the local server will form a single-node cluster.
+   * <p>
+   * Only {@link Member.Type#ACTIVE} members can be included in a bootstrap configuration. If the local server is
+   * not initialized as an active member, it cannot be part of the bootstrap configuration for the cluster.
+   * <p>
+   * When the cluster is bootstrapped, the local server will be transitioned into the active state and begin
+   * participating in the Raft consensus algorithm. When the cluster is first bootstrapped, no leader will exist.
+   * The bootstrapped members will elect a leader amongst themselves. Once a cluster has been bootstrapped, additional
+   * members may be {@link #join(Address...) joined} to the cluster. In the event that the bootstrapped members cannot
+   * reach a quorum to elect a leader, bootstrap will continue until successful.
+   * <p>
+   * It is critical that all servers in a bootstrap configuration be started with the same exact set of members.
+   * Bootstrapping multiple servers with different configurations may result in split brain.
+   * <p>
+   * The {@link CompletableFuture} returned by this method will be completed once the cluster has been bootstrapped,
+   * a leader has been elected, and the leader has been notified of the local server's client configurations.
+   *
+   * @param cluster The bootstrap cluster configuration.
+   * @return A completable future to be completed once the cluster has been bootstrapped.
+   */
+  public CompletableFuture<CopycatServer> bootstrap(Address... cluster) {
+    return bootstrap(Arrays.asList(cluster));
+  }
+
+  /**
+   * Bootstraps the cluster using the provided cluster configuration.
+   * <p>
+   * Bootstrapping the cluster results in a new cluster being formed with the provided configuration. The initial
+   * nodes in a cluster must always be bootstrapped. This is necessary to prevent split brain. If the provided
+   * configuration is empty, the local server will form a single-node cluster.
+   * <p>
+   * Only {@link Member.Type#ACTIVE} members can be included in a bootstrap configuration. If the local server is
+   * not initialized as an active member, it cannot be part of the bootstrap configuration for the cluster.
+   * <p>
+   * When the cluster is bootstrapped, the local server will be transitioned into the active state and begin
+   * participating in the Raft consensus algorithm. When the cluster is first bootstrapped, no leader will exist.
+   * The bootstrapped members will elect a leader amongst themselves. Once a cluster has been bootstrapped, additional
+   * members may be {@link #join(Address...) joined} to the cluster. In the event that the bootstrapped members cannot
+   * reach a quorum to elect a leader, bootstrap will continue until successful.
+   * <p>
+   * It is critical that all servers in a bootstrap configuration be started with the same exact set of members.
+   * Bootstrapping multiple servers with different configurations may result in split brain.
+   * <p>
+   * The {@link CompletableFuture} returned by this method will be completed once the cluster has been bootstrapped,
+   * a leader has been elected, and the leader has been notified of the local server's client configurations.
+   *
+   * @param cluster The bootstrap cluster configuration.
+   * @return A completable future to be completed once the cluster has been bootstrapped.
+   */
+  public CompletableFuture<CopycatServer> bootstrap(Collection<Address> cluster) {
+    return start(() -> cluster().bootstrap(cluster));
+  }
+
+  /**
+   * Joins the cluster.
+   * <p>
+   * Joining the cluster results in the local server being added to an existing cluster that has already been
+   * bootstrapped. The provided configuration will be used to connect to the existing cluster and submit a join
+   * request. Once the server has been added to the existing cluster's configuration, the join operation is complete.
+   * <p>
+   * Any {@link Member.Type type} of server may join a cluster. In order to join a cluster, the provided list of
+   * bootstrapped members must be non-empty and must include at least one active member of the cluster. If no member
+   * in the configuration is reachable, the server will continue to attempt to join the cluster until successful. If
+   * the provided cluster configuration is empty, the returned {@link CompletableFuture} will be completed exceptionally.
+   * <p>
+   * When the server joins the cluster, the local server will be transitioned into its initial state as defined by
+   * the configured {@link Member.Type}. Once the server has joined, it will immediately begin participating in
+   * Raft and asynchronous replication according to its configuration.
+   * <p>
+   * It's important to note that the provided cluster configuration will only be used the first time the server attempts
+   * to join the cluster. Thereafter, in the event that the server crashes and is restarted by {@code join}ing the cluster
+   * again, the last known configuration will be used assuming the server is configured with persistent storage. Only when
+   * the server leaves the cluster will its configuration and log be reset.
+   * <p>
+   * In order to preserve safety during configuration changes, Copycat leaders do not allow concurrent configuration
+   * changes. In the event that an existing configuration change (a server joining or leaving the cluster or a
+   * member being {@link Member#promote() promoted} or {@link Member#demote() demoted}) is under way, the local
+   * server will retry attempts to join the cluster until successful. If the server fails to reach the leader,
+   * the join will be retried until successful.
+   *
+   * @param cluster A collection of cluster member addresses to join.
+   * @return A completable future to be completed once the local server has joined the cluster.
+   */
+  public CompletableFuture<CopycatServer> join(Address... cluster) {
+    return join(Arrays.asList(cluster));
+  }
+
+  /**
+   * Joins the cluster.
+   * <p>
+   * Joining the cluster results in the local server being added to an existing cluster that has already been
+   * bootstrapped. The provided configuration will be used to connect to the existing cluster and submit a join
+   * request. Once the server has been added to the existing cluster's configuration, the join operation is complete.
+   * <p>
+   * Any {@link Member.Type type} of server may join a cluster. In order to join a cluster, the provided list of
+   * bootstrapped members must be non-empty and must include at least one active member of the cluster. If no member
+   * in the configuration is reachable, the server will continue to attempt to join the cluster until successful. If
+   * the provided cluster configuration is empty, the returned {@link CompletableFuture} will be completed exceptionally.
+   * <p>
+   * When the server joins the cluster, the local server will be transitioned into its initial state as defined by
+   * the configured {@link Member.Type}. Once the server has joined, it will immediately begin participating in
+   * Raft and asynchronous replication according to its configuration.
+   * <p>
+   * It's important to note that the provided cluster configuration will only be used the first time the server attempts
+   * to join the cluster. Thereafter, in the event that the server crashes and is restarted by {@code join}ing the cluster
+   * again, the last known configuration will be used assuming the server is configured with persistent storage. Only when
+   * the server leaves the cluster will its configuration and log be reset.
+   * <p>
+   * In order to preserve safety during configuration changes, Copycat leaders do not allow concurrent configuration
+   * changes. In the event that an existing configuration change (a server joining or leaving the cluster or a
+   * member being {@link Member#promote() promoted} or {@link Member#demote() demoted}) is under way, the local
+   * server will retry attempts to join the cluster until successful. If the server fails to reach the leader,
+   * the join will be retried until successful.
+   *
+   * @param cluster A collection of cluster member addresses to join.
+   * @return A completable future to be completed once the local server has joined the cluster.
+   */
+  public CompletableFuture<CopycatServer> join(Collection<Address> cluster) {
+    return start(() -> cluster().join(cluster));
+  }
+
+  /**
+   * Starts the server.
+   */
+  private CompletableFuture<CopycatServer> start(Supplier<CompletableFuture<Void>> joiner) {
     if (started)
       return CompletableFuture.completedFuture(this);
 
@@ -548,7 +636,7 @@ public class CopycatServer {
           Function<Void, CompletionStage<CopycatServer>> completionFunction = state -> {
             CompletableFuture<CopycatServer> future = new CompletableFuture<>();
             openFuture = null;
-            cluster().join().whenComplete((result, error) -> {
+            joiner.get().whenComplete((result, error) -> {
               if (error == null) {
                 if (cluster().leader() != null) {
                   started = true;
@@ -594,11 +682,11 @@ public class CopycatServer {
   private CompletableFuture<Void> listen() {
     CompletableFuture<Void> future = new CompletableFuture<>();
     context.getThreadContext().executor().execute(() -> {
-      internalServer.listen(cluster().member().serverAddress(), c -> context.connectServer(c)).whenComplete((internalResult, internalError) -> {
+      internalServer.listen(cluster().member().serverAddress(), context::connectServer).whenComplete((internalResult, internalError) -> {
         if (internalError == null) {
           // If the client address is different than the server address, start a separate client server.
           if (clientServer != null) {
-            clientServer.listen(cluster().member().clientAddress(), c -> context.connectClient(c)).whenComplete((clientResult, clientError) -> {
+            clientServer.listen(cluster().member().clientAddress(), context::connectClient).whenComplete((clientResult, clientError) -> {
               started = true;
               future.complete(null);
             });
@@ -625,34 +713,11 @@ public class CopycatServer {
   }
 
   /**
-   * Stops the server asynchronously.
+   * Shuts down the server without leaving the Copycat cluster.
    *
-   * @return A completable future to be completed once the server has been stopped.
+   * @return A completable future to be completed once the server has been shutdown.
    */
-  public CompletableFuture<Void> stop() {
-    if (!started)
-      return CompletableFuture.completedFuture(null);
-
-    if (closeFuture == null) {
-      synchronized (this) {
-        if (closeFuture == null) {
-          if (openFuture == null) {
-            closeFuture = cluster().leave().thenCompose(v -> kill());
-          } else {
-            closeFuture = openFuture.thenCompose(c -> cluster().leave().thenCompose(v -> kill()));
-          }
-        }
-      }
-    }
-    return closeFuture;
-  }
-
-  /**
-   * Kills the server without leaving the cluster.
-   *
-   * @return A completable future to be completed once the server has been killed.
-   */
-  public CompletableFuture<Void> kill() {
+  public CompletableFuture<Void> shutdown() {
     if (!started)
       return Futures.exceptionalFuture(new IllegalStateException("context not open"));
 
@@ -693,17 +758,26 @@ public class CopycatServer {
   }
 
   /**
-   * Deletes the server and its logs.
-   * <p>
-   * If the server is not already stopped, it will be stopped upon calling this method. Once the server has been
-   * shut down, all state persisted on disk by the server will be deleted. On-disk state includes the last known
-   * cluster configuration and all logs and snapshots. In the event that the server is restarted after its state
-   * has been deleted, the server will start with a new log and no snapshots.
+   * Leaves the Copycat cluster.
    *
-   * @return A completable future to be completed once the server state has been deleted.
+   * @return A completable future to be completed once the server has left the cluster.
    */
-  public CompletableFuture<Void> delete() {
-    return stop().thenRun(context::delete);
+  public CompletableFuture<Void> leave() {
+    if (!started)
+      return CompletableFuture.completedFuture(null);
+
+    if (closeFuture == null) {
+      synchronized (this) {
+        if (closeFuture == null) {
+          if (openFuture == null) {
+            closeFuture = cluster().leave().thenCompose(v -> shutdown()).thenRun(context::delete);
+          } else {
+            closeFuture = openFuture.thenCompose(c -> cluster().leave().thenCompose(v -> shutdown()).thenRun(context::delete));
+          }
+        }
+      }
+    }
+    return closeFuture;
   }
 
   /**
@@ -712,16 +786,16 @@ public class CopycatServer {
    * This builder should be used to programmatically configure and construct a new {@link CopycatServer} instance.
    * The builder provides methods for configuring all aspects of a Copycat server. The {@code CopycatServer.Builder}
    * class cannot be instantiated directly. To create a new builder, use one of the
-   * {@link CopycatServer#builder(Address, Address...) server builder factory} methods.
+   * {@link CopycatServer#builder(Address) server builder factory} methods.
    * <pre>
    *   {@code
-   *   CopycatServer.Builder builder = CopycatServer.builder(address, members);
+   *   CopycatServer.Builder builder = CopycatServer.builder(address);
    *   }
    * </pre>
    * Once the server has been configured, use the {@link #build()} method to build the server instance:
    * <pre>
    *   {@code
-   *   CopycatServer server = CopycatServer.builder(address, members)
+   *   CopycatServer server = CopycatServer.builder(address)
    *     ...
    *     .build();
    *   }
@@ -732,7 +806,7 @@ public class CopycatServer {
    * its state when necessary.
    * <pre>
    *   {@code
-   *   CopycatServer server = CopycatServer.builder(address, members)
+   *   CopycatServer server = CopycatServer.builder(address)
    *     .withStateMachine(MyStateMachine::new)
    *     .build();
    *   }
@@ -757,17 +831,14 @@ public class CopycatServer {
     private Supplier<StateMachine> stateMachineFactory;
     private Address clientAddress;
     private Address serverAddress;
-    private Set<Address> cluster;
     private Duration electionTimeout = DEFAULT_ELECTION_TIMEOUT;
     private Duration heartbeatInterval = DEFAULT_HEARTBEAT_INTERVAL;
     private Duration sessionTimeout = DEFAULT_SESSION_TIMEOUT;
     private Duration globalSuspendTimeout = DEFAULT_GLOBAL_SUSPEND_TIMEOUT;
 
-    private Builder(Address clientAddress, Address serverAddress, Collection<Address> cluster) {
+    private Builder(Address clientAddress, Address serverAddress) {
       this.clientAddress = Assert.notNull(clientAddress, "clientAddress");
       this.serverAddress = Assert.notNull(serverAddress, "serverAddress");
-      this.cluster = new HashSet<>(Assert.notNull(cluster, "cluster"));
-      this.type = cluster.contains(serverAddress) ? Member.Type.ACTIVE : Member.Type.RESERVE;
     }
 
     /**
@@ -968,7 +1039,7 @@ public class CopycatServer {
       ConnectionManager connections = new ConnectionManager(serverTransport.client());
       ThreadContext threadContext = new SingleThreadContext(String.format("copycat-server-%s-%s", serverAddress, name), serializer);
 
-      ServerContext context = new ServerContext(name, type, serverAddress, clientAddress, cluster, storage, serializer, stateMachineFactory, connections, threadContext);
+      ServerContext context = new ServerContext(name, type, serverAddress, clientAddress, storage, serializer, stateMachineFactory, connections, threadContext);
       context.setElectionTimeout(electionTimeout)
         .setHeartbeatInterval(heartbeatInterval)
         .setSessionTimeout(sessionTimeout)

--- a/server/src/main/java/io/atomix/copycat/server/CopycatServer.java
+++ b/server/src/main/java/io/atomix/copycat/server/CopycatServer.java
@@ -213,9 +213,22 @@ import java.util.function.Supplier;
  */
 public class CopycatServer {
   private static final Logger LOGGER = LoggerFactory.getLogger(CopycatServer.class);
+  private static final String DEFAULT_HOST = "0.0.0.0";
+  private static final int DEFAULT_PORT = 8700;
 
   /**
-   * Returns a new Raft server builder.
+   * Returns a new Copycat server builder using the default host:port.
+   * <p>
+   * The server will be constructed at 0.0.0.0:8700.
+   *
+   * @return The server builder.
+   */
+  public static Builder builder() {
+    return builder(new Address(DEFAULT_HOST, DEFAULT_PORT));
+  }
+
+  /**
+   * Returns a new Copycat server builder.
    * <p>
    * The provided {@link Address} is the address to which to bind the server being constructed.
    *
@@ -227,7 +240,7 @@ public class CopycatServer {
   }
 
   /**
-   * Returns a new Raft server builder.
+   * Returns a new Copycat server builder.
    * <p>
    * The provided {@link Address}es are the client and server address to which to bind the server being
    * constructed respectively.
@@ -241,7 +254,7 @@ public class CopycatServer {
   }
 
   /**
-   * Raft server state types.
+   * Copycat server state types.
    * <p>
    * States represent the context of the server's internal state machine. Throughout the lifetime of a server,
    * the server will periodically transition between states based on requests, responses, and timeouts.

--- a/server/src/main/java/io/atomix/copycat/server/state/ActiveState.java
+++ b/server/src/main/java/io/atomix/copycat/server/state/ActiveState.java
@@ -227,7 +227,7 @@ abstract class ActiveState extends PassiveState {
     }
     // If the requesting candidate is not a known member of the cluster (to this
     // node) then don't vote for it. Only vote for candidates that we know about.
-    else if (!context.getCluster().members().stream().<Integer>map(Member::id).collect(Collectors.toSet()).contains(request.candidate())) {
+    else if (!context.getClusterState().getRemoteMemberStates().stream().<Integer>map(m -> m.getMember().id()).collect(Collectors.toSet()).contains(request.candidate())) {
       LOGGER.debug("{} - Rejected {}: candidate is not known to the local member", context.getCluster().member().address(), request);
       return VoteResponse.builder()
         .withStatus(Response.Status.OK)

--- a/server/src/main/java/io/atomix/copycat/server/state/ServerContext.java
+++ b/server/src/main/java/io/atomix/copycat/server/state/ServerContext.java
@@ -39,7 +39,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.time.Duration;
-import java.util.Collection;
 import java.util.concurrent.ExecutionException;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
@@ -80,7 +79,7 @@ public class ServerContext implements AutoCloseable {
   private long globalIndex;
 
   @SuppressWarnings("unchecked")
-  public ServerContext(String name, Member.Type type, Address serverAddress, Address clientAddress, Collection<Address> members, Storage storage, Serializer serializer, Supplier<StateMachine> stateMachineFactory, ConnectionManager connections, ThreadContext threadContext) {
+  public ServerContext(String name, Member.Type type, Address serverAddress, Address clientAddress, Storage storage, Serializer serializer, Supplier<StateMachine> stateMachineFactory, ConnectionManager connections, ThreadContext threadContext) {
     this.name = Assert.notNull(name, "name");
     this.storage = Assert.notNull(storage, "storage");
     this.serializer = Assert.notNull(serializer, "serializer");
@@ -99,7 +98,7 @@ public class ServerContext implements AutoCloseable {
     // Reset the state machine.
     threadContext.execute(this::reset).join();
 
-    this.cluster = new ClusterState(type, serverAddress, clientAddress, members, this);
+    this.cluster = new ClusterState(type, serverAddress, clientAddress, this);
   }
 
   /**

--- a/server/src/test/java/io/atomix/copycat/server/state/CandidateStateTest.java
+++ b/server/src/test/java/io/atomix/copycat/server/state/CandidateStateTest.java
@@ -169,9 +169,9 @@ public class CandidateStateTest extends AbstractStateTest<CandidateState> {
     });
 
     runOnServer(() -> {
-      for (Member member : serverContext.getCluster().members()) {
+      for (MemberState member : serverContext.getClusterState().getRemoteMemberStates()) {
         Server server = transport.server();
-        server.listen(member.serverAddress(), c -> {
+        server.listen(member.getMember().serverAddress(), c -> {
           c.handler(VoteRequest.class, request -> CompletableFuture.completedFuture(VoteResponse.builder()
             .withTerm(2)
             .withVoted(true)
@@ -199,9 +199,9 @@ public class CandidateStateTest extends AbstractStateTest<CandidateState> {
     });
 
     runOnServer(() -> {
-      for (Member member : serverContext.getCluster().members()) {
+      for (MemberState member : serverContext.getClusterState().getRemoteMemberStates()) {
         Server server = transport.server();
-        server.listen(member.serverAddress(), c -> {
+        server.listen(member.getMember().serverAddress(), c -> {
           c.handler(VoteRequest.class, request -> CompletableFuture.completedFuture(VoteResponse.builder()
             .withTerm(2)
             .withVoted(false)

--- a/server/src/test/java/io/atomix/copycat/server/state/ServerStateMachineTest.java
+++ b/server/src/test/java/io/atomix/copycat/server/state/ServerStateMachineTest.java
@@ -43,9 +43,6 @@ import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 import java.time.Instant;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicLong;
 
@@ -81,14 +78,9 @@ public class ServerStateMachineTest extends ConcurrentTestCase {
     transport = new LocalTransport(registry);
     Storage storage = new Storage(StorageLevel.MEMORY);
     ServerMember member = new ServerMember(Member.Type.ACTIVE, new Address("localhost", 5000), new Address("localhost", 6000), Instant.now());
-    Collection<Address> members = new ArrayList<>(Arrays.asList(
-      new Address("localhost", 5000),
-      new Address("localhost", 5000),
-      new Address("localhost", 5000)
-    ));
 
     new SingleThreadContext("test", serializer.clone()).executor().execute(() -> {
-      state = new ServerContext("test", member.type(), member.serverAddress(), member.clientAddress(), members, storage, serializer, TestStateMachine::new, new ConnectionManager(new LocalTransport(registry).client()), callerContext);
+      state = new ServerContext("test", member.type(), member.serverAddress(), member.clientAddress(), storage, serializer, TestStateMachine::new, new ConnectionManager(new LocalTransport(registry).client()), callerContext);
       resume();
     });
     await(1000);

--- a/test/src/test/java/io/atomix/copycat/test/ClusterTest.java
+++ b/test/src/test/java/io/atomix/copycat/test/ClusterTest.java
@@ -1359,13 +1359,13 @@ public class ClusterTest extends ConcurrentTestCase {
    * Creates a Copycat client.
    */
   private CopycatClient createClient() throws Throwable {
-    CopycatClient client = CopycatClient.builder(members.stream().map(Member::clientAddress).collect(Collectors.toList()))
+    CopycatClient client = CopycatClient.builder()
       .withTransport(new LocalTransport(registry))
       .withConnectionStrategy(ConnectionStrategies.FIBONACCI_BACKOFF)
       .withRetryStrategy(RetryStrategies.FIBONACCI_BACKOFF)
       .build();
     client.serializer().disableWhitelist();
-    client.connect().thenRun(this::resume);
+    client.connect(members.stream().map(Member::clientAddress).collect(Collectors.toList())).thenRun(this::resume);
     await(30000);
     clients.add(client);
     return client;

--- a/test/src/test/java/io/atomix/copycat/test/ClusterTest.java
+++ b/test/src/test/java/io/atomix/copycat/test/ClusterTest.java
@@ -71,13 +71,13 @@ public class ClusterTest extends ConcurrentTestCase {
    */
   public void testSingleMemberStart() throws Throwable {
     CopycatServer server = createServers(1).get(0);
-    server.start().thenRun(this::resume);
+    server.bootstrap().thenRun(this::resume);
     await(5000);
-    CopycatServer joiner1 = createServer(members, nextMember(Member.Type.ACTIVE));
-    joiner1.start().thenRun(this::resume);
+    CopycatServer joiner1 = createServer(nextMember(Member.Type.ACTIVE));
+    joiner1.join(server.cluster().member().address()).thenRun(this::resume);
     await(5000);
-    CopycatServer joiner2 = createServer(members, nextMember(Member.Type.ACTIVE));
-    joiner2.start().thenRun(this::resume);
+    CopycatServer joiner2 = createServer(nextMember(Member.Type.ACTIVE));
+    joiner2.join(server.cluster().member().address()).thenRun(this::resume);
     await(5000);
   }
 
@@ -110,12 +110,12 @@ public class ClusterTest extends ConcurrentTestCase {
     CopycatClient client = createClient();
     submit(client, 0, 1000);
     await(30000);
-    CopycatServer joiner = createServer(members, nextMember(type));
+    CopycatServer joiner = createServer(nextMember(type));
     joiner.onStateChange(s -> {
       if (s == state)
         resume();
     });
-    joiner.start().thenRun(this::resume);
+    joiner.join(members.stream().map(Member::serverAddress).collect(Collectors.toList())).thenRun(this::resume);
     await(30000, 2);
   }
 
@@ -141,9 +141,9 @@ public class ClusterTest extends ConcurrentTestCase {
     CopycatClient client = createClient();
     submit(client, 0, 1000);
     await(30000);
-    servers.get(0).kill().join();
-    CopycatServer server = createServer(members, members.get(0));
-    server.start().thenRun(this::resume);
+    servers.get(0).shutdown().join();
+    CopycatServer server = createServer(members.get(0));
+    server.join(members.stream().map(Member::serverAddress).collect(Collectors.toList())).thenRun(this::resume);
     await(30000);
     submit(client, 0, 1000);
     await(30000);
@@ -155,7 +155,7 @@ public class ClusterTest extends ConcurrentTestCase {
   public void testServerLeave() throws Throwable {
     List<CopycatServer> servers = createServers(3);
     CopycatServer server = servers.get(0);
-    server.stop().thenRun(this::resume);
+    server.leave().thenRun(this::resume);
     await(30000);
   }
 
@@ -165,7 +165,7 @@ public class ClusterTest extends ConcurrentTestCase {
   public void testLeaderLeave() throws Throwable {
     List<CopycatServer> servers = createServers(3);
     CopycatServer server = servers.stream().filter(s -> s.state() == CopycatServer.State.LEADER).findFirst().get();
-    server.stop().thenRun(this::resume);
+    server.leave().thenRun(this::resume);
     await(30000);
   }
 
@@ -205,8 +205,8 @@ public class ClusterTest extends ConcurrentTestCase {
    */
   private void testServerJoin(Member.Type type) throws Throwable {
     createServers(3);
-    CopycatServer server = createServer(members, nextMember(type));
-    server.start().thenRun(this::resume);
+    CopycatServer server = createServer(nextMember(type));
+    server.join(members.stream().map(Member::serverAddress).collect(Collectors.toList())).thenRun(this::resume);
     await(10000);
   }
 
@@ -215,12 +215,12 @@ public class ClusterTest extends ConcurrentTestCase {
    */
   public void testResize() throws Throwable {
     CopycatServer server = createServers(1).get(0);
-    CopycatServer joiner = createServer(members, nextMember(Member.Type.ACTIVE));
-    joiner.start().thenRun(this::resume);
+    CopycatServer joiner = createServer(nextMember(Member.Type.ACTIVE));
+    joiner.join(members.stream().map(Member::serverAddress).collect(Collectors.toList())).thenRun(this::resume);
     await(10000);
-    server.stop().thenRun(this::resume);
+    server.leave().thenRun(this::resume);
     await(10000);
-    joiner.stop().thenRun(this::resume);
+    joiner.leave().thenRun(this::resume);
   }
 
   /**
@@ -259,11 +259,11 @@ public class ClusterTest extends ConcurrentTestCase {
     });
 
     Member member = nextMember(type);
-    CopycatServer joiner = createServer(members, member);
-    joiner.start().thenRun(this::resume);
+    CopycatServer joiner = createServer(member);
+    joiner.join(members.stream().map(Member::serverAddress).collect(Collectors.toList())).thenRun(this::resume);
     await(10000);
 
-    joiner.kill().thenRun(this::resume);
+    joiner.shutdown().thenRun(this::resume);
     await(10000, 2);
   }
 
@@ -273,8 +273,8 @@ public class ClusterTest extends ConcurrentTestCase {
   public void testPassiveReserveAvailabilityChange() throws Throwable {
     createServers(3);
 
-    CopycatServer passive = createServer(members, nextMember(Member.Type.PASSIVE));
-    passive.start().thenRun(this::resume);
+    CopycatServer passive = createServer(nextMember(Member.Type.PASSIVE));
+    passive.join(members.stream().map(Member::serverAddress).collect(Collectors.toList())).thenRun(this::resume);
 
     await(10000);
 
@@ -287,12 +287,12 @@ public class ClusterTest extends ConcurrentTestCase {
       });
     });
 
-    CopycatServer reserve = createServer(members, reserveMember);
-    reserve.start().thenRun(this::resume);
+    CopycatServer reserve = createServer(reserveMember);
+    reserve.join(members.stream().map(Member::serverAddress).collect(Collectors.toList())).thenRun(this::resume);
 
     await(10000);
 
-    reserve.kill().thenRun(this::resume);
+    reserve.shutdown().thenRun(this::resume);
     await(10000, 2);
   }
 
@@ -302,11 +302,11 @@ public class ClusterTest extends ConcurrentTestCase {
   public void testReservePassiveAvailabilityChange() throws Throwable {
     createServers(3);
 
-    CopycatServer passive = createServer(members, nextMember(Member.Type.PASSIVE));
-    passive.start().thenRun(this::resume);
+    CopycatServer passive = createServer(nextMember(Member.Type.PASSIVE));
+    passive.join(members.stream().map(Member::serverAddress).collect(Collectors.toList())).thenRun(this::resume);
 
-    CopycatServer reserve = createServer(members, nextMember(Member.Type.RESERVE));
-    reserve.start().thenRun(this::resume);
+    CopycatServer reserve = createServer(nextMember(Member.Type.RESERVE));
+    reserve.join(members.stream().map(Member::serverAddress).collect(Collectors.toList())).thenRun(this::resume);
 
     await(10000, 2);
 
@@ -315,7 +315,7 @@ public class ClusterTest extends ConcurrentTestCase {
       resume();
     });
 
-    passive.kill().thenRun(this::resume);
+    passive.shutdown().thenRun(this::resume);
     await(10000, 2);
   }
 
@@ -355,8 +355,8 @@ public class ClusterTest extends ConcurrentTestCase {
       resume();
     });
 
-    CopycatServer joiner = createServer(members, member);
-    joiner.start().thenRun(this::resume);
+    CopycatServer joiner = createServer(member);
+    joiner.join(members.stream().map(Member::serverAddress).collect(Collectors.toList())).thenRun(this::resume);
     await(10000, 2);
   }
 
@@ -1036,7 +1036,7 @@ public class ClusterTest extends ConcurrentTestCase {
     }
 
     CopycatServer leader = servers.stream().filter(s -> s.state() == CopycatServer.State.LEADER).findFirst().get();
-    leader.stop().join();
+    leader.shutdown().join();
 
     for (int i = 0 ; i < 10; i++) {
       String event = UUID.randomUUID().toString();
@@ -1097,7 +1097,7 @@ public class ClusterTest extends ConcurrentTestCase {
     });
 
     CopycatServer follower = servers.stream().filter(s -> s.state() == CopycatServer.State.FOLLOWER).findFirst().get();
-    follower.kill().join();
+    follower.shutdown().join();
 
     await(30000, 2);
 
@@ -1153,7 +1153,7 @@ public class ClusterTest extends ConcurrentTestCase {
     });
 
     CopycatServer leader = servers.stream().filter(s -> s.state() == CopycatServer.State.LEADER).findFirst().get();
-    leader.kill().join();
+    leader.shutdown().join();
 
     await(30000, 2);
 
@@ -1286,15 +1286,6 @@ public class ClusterTest extends ConcurrentTestCase {
   /**
    * Returns the next server address.
    *
-   * @return The next server address.
-   */
-  private Member nextMember() {
-    return nextMember(Member.Type.INACTIVE);
-  }
-
-  /**
-   * Returns the next server address.
-   *
    * @param type The startup member type.
    * @return The next server address.
    */
@@ -1309,12 +1300,12 @@ public class ClusterTest extends ConcurrentTestCase {
     List<CopycatServer> servers = new ArrayList<>();
 
     for (int i = 0; i < nodes; i++) {
-      members.add(nextMember());
+      members.add(nextMember(Member.Type.ACTIVE));
     }
 
     for (int i = 0; i < nodes; i++) {
-      CopycatServer server = createServer(members, members.get(i));
-      server.start().thenRun(this::resume);
+      CopycatServer server = createServer(members.get(i));
+      server.bootstrap(members.stream().map(Member::serverAddress).collect(Collectors.toList())).thenRun(this::resume);
       servers.add(server);
     }
 
@@ -1330,12 +1321,12 @@ public class ClusterTest extends ConcurrentTestCase {
     List<CopycatServer> servers = new ArrayList<>();
 
     for (int i = 0; i < total; i++) {
-      members.add(nextMember());
+      members.add(nextMember(Member.Type.ACTIVE));
     }
 
     for (int i = 0; i < live; i++) {
-      CopycatServer server = createServer(members, members.get(i));
-      server.start().thenRun(this::resume);
+      CopycatServer server = createServer(members.get(i));
+      server.bootstrap(members.stream().map(Member::serverAddress).collect(Collectors.toList())).thenRun(this::resume);
       servers.add(server);
     }
 
@@ -1347,8 +1338,9 @@ public class ClusterTest extends ConcurrentTestCase {
   /**
    * Creates a Copycat server.
    */
-  private CopycatServer createServer(List<Member> members, Member member) {
-    CopycatServer.Builder builder = CopycatServer.builder(member.clientAddress(), member.serverAddress(), members.stream().map(Member::serverAddress).collect(Collectors.toList()))
+  private CopycatServer createServer(Member member) {
+    CopycatServer.Builder builder = CopycatServer.builder(member.clientAddress(), member.serverAddress())
+      .withType(member.type())
       .withTransport(new LocalTransport(registry))
       .withStorage(Storage.builder()
         .withStorageLevel(StorageLevel.MEMORY)
@@ -1356,10 +1348,6 @@ public class ClusterTest extends ConcurrentTestCase {
         .withCompactionThreads(1)
         .build())
       .withStateMachine(TestStateMachine::new);
-
-    if (member.type() != Member.Type.INACTIVE) {
-      builder.withType(member.type());
-    }
 
     CopycatServer server = builder.build();
     server.serializer().disableWhitelist();
@@ -1396,8 +1384,7 @@ public class ClusterTest extends ConcurrentTestCase {
     servers.forEach(s -> {
       try {
         if (s.isRunning()) {
-          s.kill().join();
-          s.delete().join();
+          s.shutdown().join();
         }
       } catch (Exception e) {
       }


### PR DESCRIPTION
This PR refactors the cluster configuration API to separate `bootstrap` and `join` methods. This will promote clarity for users on what occurs when a server is started. The current API which transparently reconfigures the cluster has proven to be too confusing to Copycat and Atomix users.