### PR TITLE
Ensure event threads can be blocked by futures

### DIFF
--- a/client/src/main/java/io/atomix/copycat/client/DefaultCopycatClient.java
+++ b/client/src/main/java/io/atomix/copycat/client/DefaultCopycatClient.java
@@ -20,10 +20,10 @@ import io.atomix.catalyst.transport.Address;
 import io.atomix.catalyst.transport.Transport;
 import io.atomix.catalyst.util.Assert;
 import io.atomix.catalyst.util.Listener;
+import io.atomix.catalyst.util.concurrent.BlockingFuture;
 import io.atomix.catalyst.util.concurrent.Futures;
 import io.atomix.catalyst.util.concurrent.ThreadContext;
 import io.atomix.copycat.Command;
-import io.atomix.copycat.Operation;
 import io.atomix.copycat.Query;
 import io.atomix.copycat.client.session.ClientSession;
 import io.atomix.copycat.client.util.AddressSelector;
@@ -35,7 +35,8 @@ import org.slf4j.LoggerFactory;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Set;
-import java.util.concurrent.*;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CopyOnWriteArraySet;
 import java.util.function.Consumer;
 
 /**
@@ -197,22 +198,12 @@ public class DefaultCopycatClient implements CopycatClient {
     if (session == null)
       return Futures.exceptionalFuture(new ClosedSessionException("session closed"));
 
-    BlockingFuture<T> future = new BlockingFuture<>();
+    BlockingFuture<T> future = new BlockingFuture<>(eventContext);
     session.submit(command).whenComplete((result, error) -> {
-      if (future.blocked) {
-        if (error == null) {
-          future.complete(result);
-        } else {
-          future.completeExceptionally(error);
-        }
+      if (eventContext.isBlocked()) {
+        future.accept(result, error);
       } else {
-        eventContext.executor().execute(() -> {
-          if (error == null) {
-            future.complete(result);
-          } else {
-            future.completeExceptionally(error);
-          }
-        });
+        eventContext.executor().execute(() -> future.accept(result, error));
       }
     });
     return future;
@@ -224,22 +215,12 @@ public class DefaultCopycatClient implements CopycatClient {
     if (session == null)
       return Futures.exceptionalFuture(new ClosedSessionException("session closed"));
 
-    BlockingFuture<T> future = new BlockingFuture<>();
+    BlockingFuture<T> future = new BlockingFuture<>(eventContext);
     session.submit(query).whenComplete((result, error) -> {
-      if (future.blocked) {
-        if (error == null) {
-          future.complete(result);
-        } else {
-          future.completeExceptionally(error);
-        }
+      if (eventContext.isBlocked()) {
+        future.accept(result, error);
       } else {
-        eventContext.executor().execute(() -> {
-          if (error == null) {
-            future.complete(result);
-          } else {
-            future.completeExceptionally(error);
-          }
-        });
+        eventContext.executor().execute(() -> future.accept(result, error));
       }
     });
     return future;
@@ -344,17 +325,6 @@ public class DefaultCopycatClient implements CopycatClient {
   }
 
   /**
-   * A completable future related to a single operation.
-   */
-  private static final class OperationFuture<T> extends CompletableFuture<T> {
-    private final Operation<T> operation;
-
-    private OperationFuture(Operation<T> operation) {
-      this.operation = operation;
-    }
-  }
-
-  /**
    * State change listener.
    */
   private final class StateChangeListener implements Listener<State> {
@@ -399,7 +369,11 @@ public class DefaultCopycatClient implements CopycatClient {
 
     @Override
     public void accept(T message) {
-      eventContext.executor().execute(() -> callback.accept(message));
+      if (eventContext.isBlocked()) {
+        callback.accept(message);
+      } else {
+        eventContext.executor().execute(() -> callback.accept(message));
+      }
     }
 
     @Override
@@ -408,34 +382,4 @@ public class DefaultCopycatClient implements CopycatClient {
       eventListeners.remove(this);
     }
   }
-
-  /**
-   * Future that sets a flag when blocked.
-   */
-  private static class BlockingFuture<T> extends CompletableFuture<T> {
-    private volatile boolean blocked;
-
-    @Override
-    public T get() throws InterruptedException, ExecutionException {
-      blocked = true;
-      return super.get();
-    }
-
-    @Override
-    public T get(long timeout, TimeUnit unit) throws InterruptedException, ExecutionException, TimeoutException {
-      blocked = true;
-      try {
-        return super.get(timeout, unit);
-      } finally {
-        blocked = false;
-      }
-    }
-
-    @Override
-    public T join() {
-      blocked = true;
-      return super.join();
-    }
-  }
-
 }

--- a/client/src/main/java/io/atomix/copycat/client/DefaultCopycatClient.java
+++ b/client/src/main/java/io/atomix/copycat/client/DefaultCopycatClient.java
@@ -198,7 +198,7 @@ public class DefaultCopycatClient implements CopycatClient {
     if (session == null)
       return Futures.exceptionalFuture(new ClosedSessionException("session closed"));
 
-    BlockingFuture<T> future = new BlockingFuture<>(eventContext);
+    BlockingFuture<T> future = new BlockingFuture<>();
     session.submit(command).whenComplete((result, error) -> {
       if (eventContext.isBlocked()) {
         future.accept(result, error);
@@ -215,7 +215,7 @@ public class DefaultCopycatClient implements CopycatClient {
     if (session == null)
       return Futures.exceptionalFuture(new ClosedSessionException("session closed"));
 
-    BlockingFuture<T> future = new BlockingFuture<>(eventContext);
+    BlockingFuture<T> future = new BlockingFuture<>();
     session.submit(query).whenComplete((result, error) -> {
       if (eventContext.isBlocked()) {
         future.accept(result, error);

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
     <java.version>1.8</java.version>
     <slf4j.version>1.7.7</slf4j.version>
     <logback.version>1.1.2</logback.version>
-    <catalyst.version>1.0.7</catalyst.version>
+    <catalyst.version>1.0.8-SNAPSHOT</catalyst.version>
 
     <maven.source.plugin.version>2.2.1</maven.source.plugin.version>
     <maven.compiler.plugin.version>3.0</maven.compiler.plugin.version>

--- a/server/src/main/java/io/atomix/copycat/server/StateMachineExecutor.java
+++ b/server/src/main/java/io/atomix/copycat/server/StateMachineExecutor.java
@@ -77,6 +77,19 @@ public interface StateMachineExecutor extends ThreadContext {
    */
   StateMachineContext context();
 
+  @Override
+  default boolean isBlocked() {
+    return false;
+  }
+
+  @Override
+  default void block() {
+  }
+
+  @Override
+  default void unblock() {
+  }
+
   /**
    * Registers a void operation callback.
    * <p>

--- a/server/src/main/java/io/atomix/copycat/server/state/ServerStateMachineExecutor.java
+++ b/server/src/main/java/io/atomix/copycat/server/state/ServerStateMachineExecutor.java
@@ -18,6 +18,7 @@ package io.atomix.copycat.server.state;
 
 import io.atomix.catalyst.serializer.Serializer;
 import io.atomix.catalyst.util.Assert;
+import io.atomix.catalyst.util.concurrent.NonBlockingFuture;
 import io.atomix.catalyst.util.concurrent.Scheduled;
 import io.atomix.catalyst.util.concurrent.ThreadContext;
 import io.atomix.copycat.NoOpCommand;
@@ -209,7 +210,7 @@ class ServerStateMachineExecutor implements StateMachineExecutor {
   @Override
   public <T> CompletableFuture<T> execute(Supplier<T> callback) {
     Assert.state(context.type() == ServerStateMachineContext.Type.COMMAND, "callbacks can only be scheduled during command execution");
-    CompletableFuture<T> future = new CompletableFuture<>();
+    CompletableFuture<T> future = new NonBlockingFuture<>();
     tasks.add(new ServerTask(callback, future));
     return future;
   }

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -38,6 +38,12 @@
     </dependency>
     <dependency>
       <groupId>io.atomix.catalyst</groupId>
+      <artifactId>catalyst-netty</artifactId>
+      <version>${catalyst.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.atomix.catalyst</groupId>
       <artifactId>catalyst-local</artifactId>
       <version>${catalyst.version}</version>
       <scope>test</scope>


### PR DESCRIPTION
This PR resolves a bug in support for blocking the event thread when session events are received from the cluster. The previous implementation only checked blocking for responses and not events. This implementation uses the new `BlockingFuture` provided by Catalyst to detect blocked event threads for responses and events. If an event thread is blocked, both response futures and event callbacks will be completed in the client's I/O thread.