### PR TITLE
Always allow new appends if no appends are in progress

### DIFF
--- a/server/src/main/java/io/atomix/copycat/server/state/MemberState.java
+++ b/server/src/main/java/io/atomix/copycat/server/state/MemberState.java
@@ -218,7 +218,7 @@ final class MemberState {
    * @return Indicates whether an append request can be sent to the member.
    */
   boolean canAppend() {
-    return appending < MAX_APPENDS && System.nanoTime() - (timeBuffer.average() / MAX_APPENDS) >= appendTime;
+    return appending == 0 || (appending < MAX_APPENDS && System.nanoTime() - (timeBuffer.average() / MAX_APPENDS) >= appendTime);
   }
 
   /**


### PR DESCRIPTION
This PR fixes a bug where a leader could stall processing a `LINEARIAZBLE` query. This typically happens when a bunch of such queries are submitted one after another in quick succession.
A `LINEARIZABLE` query needs to perform a quick heartbeat to ascertain quorum. But due to the bug the corresponding `AppendRequest` cannot be sent out because `MemberState::canAppend` returns `false`. This leaves `heartbeatFuture` as non-null and subsequent heartbeat’s get queued up. Only way to exit this impasse if is if a new entry is appended to the log (A `KeepAlive` will do) and replicated. But if the followers timeout on leader heartbeat before that happens, they will start a new poll and one of them will take over leadership.