### PR TITLE
Ensure server configurations are not loaded on commit

### DIFF
--- a/server/src/main/java/io/atomix/copycat/server/state/ServerContext.java
+++ b/server/src/main/java/io/atomix/copycat/server/state/ServerContext.java
@@ -364,10 +364,14 @@ public class ServerContext implements AutoCloseable {
    */
   ServerContext setCommitIndex(long commitIndex) {
     Assert.argNot(commitIndex < 0, "commit index must be positive");
-    this.commitIndex = Math.max(this.commitIndex, commitIndex);
-    log.commit(Math.min(this.commitIndex, log.lastIndex()));
-    if (cluster.getConfiguration().index() <= commitIndex) {
-      cluster.commit();
+    long previousCommitIndex = this.commitIndex;
+    if (commitIndex > previousCommitIndex) {
+      this.commitIndex = commitIndex;
+      log.commit(Math.min(commitIndex, log.lastIndex()));
+      long configurationIndex = cluster.getConfiguration().index();
+      if (configurationIndex > previousCommitIndex && configurationIndex <= commitIndex) {
+        cluster.commit();
+      }
     }
     return this;
   }


### PR DESCRIPTION
This PR fixes a bug wherein `ClusterState` was loading the cluster configuration from disk on each commit. This resulted in a significant loss of performance. To prevent this, we simply don't call `commit()` on the `ClusterState` unless its configuration has actually been committed.