### PR TITLE
Make flushing to disk on commit optional

### DIFF
--- a/server/src/main/java/io/atomix/copycat/server/state/ActiveState.java
+++ b/server/src/main/java/io/atomix/copycat/server/state/ActiveState.java
@@ -128,9 +128,6 @@ abstract class ActiveState extends PassiveState {
           context.getStateMachine().executor().context().sessions().registerAddress(connectEntry.getClient(), connectEntry.getAddress());
         }
       }
-
-      // Flush the log entries to disk.
-      context.getLog().flush();
     }
 
     // If we've made it this far, apply commits and send a successful response.

--- a/server/src/main/java/io/atomix/copycat/server/state/LeaderAppender.java
+++ b/server/src/main/java/io/atomix/copycat/server/state/LeaderAppender.java
@@ -323,7 +323,6 @@ final class LeaderAppender extends AbstractAppender {
     // the index of the leader's no-op entry. Update the commit index and trigger commit futures.
     long previousCommitIndex = context.getCommitIndex();
     if (commitIndex > 0 && commitIndex > previousCommitIndex && (leaderIndex > 0 && commitIndex >= leaderIndex)) {
-      context.getLog().flush();
       context.setCommitIndex(commitIndex);
       completeCommits(previousCommitIndex, commitIndex);
     }

--- a/server/src/main/java/io/atomix/copycat/server/storage/Storage.java
+++ b/server/src/main/java/io/atomix/copycat/server/storage/Storage.java
@@ -61,6 +61,7 @@ public class Storage {
   private static final String DEFAULT_DIRECTORY = System.getProperty("user.dir");
   private static final int DEFAULT_MAX_SEGMENT_SIZE = 1024 * 1024 * 32;
   private static final int DEFAULT_MAX_ENTRIES_PER_SEGMENT = 1024 * 1024;
+  private static final boolean DEFAULT_FLUSH_ON_COMMIT = false;
   private static final boolean DEFAULT_RETAIN_STALE_SNAPSHOTS = false;
   private static final int DEFAULT_COMPACTION_THREADS = Runtime.getRuntime().availableProcessors() / 2;
   private static final Duration DEFAULT_MINOR_COMPACTION_INTERVAL = Duration.ofMinutes(1);
@@ -71,6 +72,7 @@ public class Storage {
   private File directory = new File(DEFAULT_DIRECTORY);
   private int maxSegmentSize = DEFAULT_MAX_SEGMENT_SIZE;
   private int maxEntriesPerSegment = DEFAULT_MAX_ENTRIES_PER_SEGMENT;
+  private boolean flushOnCommit = DEFAULT_FLUSH_ON_COMMIT;
   private boolean retainStaleSnapshots = DEFAULT_RETAIN_STALE_SNAPSHOTS;
   private int compactionThreads = DEFAULT_COMPACTION_THREADS;
   private Duration minorCompactionInterval = DEFAULT_MINOR_COMPACTION_INTERVAL;
@@ -159,6 +161,15 @@ public class Storage {
    */
   public int maxEntriesPerSegment() {
     return maxEntriesPerSegment;
+  }
+
+  /**
+   * Returns whether to flush buffers to disk when entries are committed.
+   *
+   * @return Whether to flush buffers to disk when entries are committed.
+   */
+  public boolean flushOnCommit() {
+    return flushOnCommit;
   }
 
   /**
@@ -417,7 +428,35 @@ public class Storage {
     }
 
     /**
-     * Sets whether to retain stale snapshots on disk, returning the builder for method chaining.
+     * Enables flushing buffers to disk when entries are committed to a segment, returning the builder
+     * for method chaining.
+     * <p>
+     * When flush-on-commit is enabled, log entry buffers will be automatically flushed to disk each time
+     * an entry is committed in a given segment.
+     *
+     * @return The storage builder.
+     */
+    public Builder withFlushOnCommit() {
+      return withFlushOnCommit(true);
+    }
+
+    /**
+     * Sets whether to flush buffers to disk when entries are committed to a segment, returning the builder
+     * for method chaining.
+     * <p>
+     * When flush-on-commit is enabled, log entry buffers will be automatically flushed to disk each time
+     * an entry is committed in a given segment.
+     *
+     * @param flushOnCommit Whether to flush buffers to disk when entries are committed to a segment.
+     * @return The storage builder.
+     */
+    public Builder withFlushOnCommit(boolean flushOnCommit) {
+      storage.flushOnCommit = flushOnCommit;
+      return this;
+    }
+
+    /**
+     * Enables retaining stale snapshots on disk, returning the builder for method chaining.
      * <p>
      * As the system state progresses, periodic snapshots of the state machine's state are taken.
      * Once a new snapshot of the state machine is taken, all preceding snapshots no longer contribute


### PR DESCRIPTION
This PR adds an option to the `Storage` object to enable flushing to disk on commits. By default, flushing to disk on commits is now disabled for performance reasons.