### PR TITLE
Buffer entries at the tail of the log

### DIFF
--- a/server/src/main/java/io/atomix/copycat/server/storage/Storage.java
+++ b/server/src/main/java/io/atomix/copycat/server/storage/Storage.java
@@ -61,6 +61,7 @@ public class Storage {
   private static final String DEFAULT_DIRECTORY = System.getProperty("user.dir");
   private static final int DEFAULT_MAX_SEGMENT_SIZE = 1024 * 1024 * 32;
   private static final int DEFAULT_MAX_ENTRIES_PER_SEGMENT = 1024 * 1024;
+  private static final int DEFAULT_ENTRY_BUFFER_SIZE = 1024;
   private static final boolean DEFAULT_RETAIN_STALE_SNAPSHOTS = false;
   private static final int DEFAULT_COMPACTION_THREADS = Runtime.getRuntime().availableProcessors() / 2;
   private static final Duration DEFAULT_MINOR_COMPACTION_INTERVAL = Duration.ofMinutes(1);
@@ -71,6 +72,7 @@ public class Storage {
   private File directory = new File(DEFAULT_DIRECTORY);
   private int maxSegmentSize = DEFAULT_MAX_SEGMENT_SIZE;
   private int maxEntriesPerSegment = DEFAULT_MAX_ENTRIES_PER_SEGMENT;
+  private int entryBufferSize = DEFAULT_ENTRY_BUFFER_SIZE;
   private boolean retainStaleSnapshots = DEFAULT_RETAIN_STALE_SNAPSHOTS;
   private int compactionThreads = DEFAULT_COMPACTION_THREADS;
   private Duration minorCompactionInterval = DEFAULT_MINOR_COMPACTION_INTERVAL;
@@ -159,6 +161,18 @@ public class Storage {
    */
   public int maxEntriesPerSegment() {
     return maxEntriesPerSegment;
+  }
+
+  /**
+   * Returns the entry buffer size.
+   * <p>
+   * The entry buffer size dictates the number of entries that will be held in memory for read operations
+   * at the tail of the log.
+   *
+   * @return The entry buffer size.
+   */
+  public int entryBufferSize() {
+    return entryBufferSize;
   }
 
   /**
@@ -413,6 +427,22 @@ public class Storage {
       Assert.argNot(maxEntriesPerSegment > DEFAULT_MAX_ENTRIES_PER_SEGMENT,
         "max entries per segment cannot be greater than " + DEFAULT_MAX_ENTRIES_PER_SEGMENT);
       storage.maxEntriesPerSegment = maxEntriesPerSegment;
+      return this;
+    }
+
+    /**
+     * Sets the entry buffer size.
+     * <p>
+     * The entry buffer size dictates the number of entries to hold in memory at the tail of the log. Increasing
+     * the buffer size increases the number of entries that will be held in memory and thus implies greater memory
+     * consumption, but server performance may be improved due to reduced disk access.
+     *
+     * @param entryBufferSize The entry buffer size.
+     * @return The storage builder.
+     * @throws IllegalArgumentException if the buffer size is not positive
+     */
+    public Builder withEntryBufferSize(int entryBufferSize) {
+      storage.entryBufferSize = Assert.arg(entryBufferSize, entryBufferSize > 0, "entryBufferSize must be positive");
       return this;
     }
 

--- a/server/src/main/java/io/atomix/copycat/server/storage/util/EntryBuffer.java
+++ b/server/src/main/java/io/atomix/copycat/server/storage/util/EntryBuffer.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License
+ */
+package io.atomix.copycat.server.storage.util;
+
+import io.atomix.copycat.server.storage.entry.Entry;
+
+/**
+ * Log entry buffer.
+ *
+ * @author <a href="http://github.com/kuujo>Jordan Halterman</a>
+ */
+public class EntryBuffer {
+  private final Entry[] buffer;
+
+  public EntryBuffer(int size) {
+    this.buffer = new Entry[size];
+  }
+
+  /**
+   * Appends an entry to the buffer.
+   *
+   * @param entry The entry to append.
+   * @return The entry buffer.
+   */
+  public EntryBuffer append(Entry entry) {
+    int offset = offset(entry.getIndex());
+    Entry oldEntry = buffer[offset];
+    buffer[offset] = entry.acquire();
+    if (oldEntry != null) {
+      oldEntry.release();
+    }
+    return this;
+  }
+
+  /**
+   * Looks up an entry in the buffer.
+   *
+   * @param index The entry index.
+   * @param <T> The entry type.
+   * @return The entry or {@code null} if the entry is not present in the index.
+   */
+  @SuppressWarnings("unchecked")
+  public <T extends Entry> T get(long index) {
+    Entry entry = buffer[offset(index)];
+    return entry != null && entry.getIndex() == index ? (T) entry.acquire() : null;
+  }
+
+  /**
+   * Clears the buffer and resets the index to the given index.
+   *
+   * @return The entry buffer.
+   */
+  public EntryBuffer clear() {
+    for (int i = 0; i < buffer.length; i++) {
+      buffer[i] = null;
+    }
+    return this;
+  }
+
+  /**
+   * Returns the buffer index for the given offset.
+   */
+  private int offset(long index) {
+    int offset = (int) (index % buffer.length);
+    if (offset < 0) {
+      offset += buffer.length;
+    }
+    return offset;
+  }
+}

--- a/server/src/main/java/io/atomix/copycat/server/storage/util/OffsetPredicate.java
+++ b/server/src/main/java/io/atomix/copycat/server/storage/util/OffsetPredicate.java
@@ -50,7 +50,7 @@ public final class OffsetPredicate implements Predicate<Long>, AutoCloseable {
    */
   @Override
   public boolean test(Long offset) {
-    return offset == -1 || bits.size() <= offset || !bits.get(offset);
+    return offset != -1 && (bits.size() <= offset || !bits.get(offset));
   }
 
   /**


### PR DESCRIPTION
This PR adds a circular buffer at the tail of the log to buffer recent entries in memory. The small buffer precludes the need to hit disk immediately after entries are written to the log. This results in significantly greater performance in many cases.