### PR TITLE
Fixes the sequencing logic so that failed queries can be skipped over

### DIFF
--- a/client/src/main/java/io/atomix/copycat/client/session/ClientSessionSubmitter.java
+++ b/client/src/main/java/io/atomix/copycat/client/session/ClientSessionSubmitter.java
@@ -138,6 +138,7 @@ final class ClientSessionSubmitter {
       state.getLogger().debug("{} - Sending {}", state.getSessionId(), attempt.request);
       attempts.put(attempt.sequence, attempt);
       connection.<T, U>send(attempt.request).whenComplete(attempt);
+      attempt.future.whenComplete((r, e) -> attempts.remove(attempt.sequence));
     }
   }
 
@@ -355,7 +356,7 @@ final class ClientSessionSubmitter {
 
     @Override
     protected void complete(Throwable error) {
-      future.completeExceptionally(error);
+      sequence(null, () -> future.completeExceptionally(error));
     }
   }
 

--- a/client/src/test/java/io/atomix/copycat/client/session/ClientSessionSubmitterTest.java
+++ b/client/src/test/java/io/atomix/copycat/client/session/ClientSessionSubmitterTest.java
@@ -19,8 +19,10 @@ import io.atomix.catalyst.transport.Connection;
 import io.atomix.catalyst.util.concurrent.ThreadContext;
 import io.atomix.copycat.Command;
 import io.atomix.copycat.Query;
+import io.atomix.copycat.error.QueryException;
 import io.atomix.copycat.protocol.*;
 import io.atomix.copycat.session.Session;
+
 import org.mockito.Mockito;
 import org.testng.annotations.Test;
 
@@ -191,6 +193,50 @@ public class ClientSessionSubmitterTest {
     assertEquals(result1.get(), "Hello world!");
     assertTrue(result2.isDone());
     assertEquals(result2.get(), "Hello world again!");
+
+    assertEquals(state.getResponseIndex(), 10);
+  }
+
+  /**
+   * Tests skipping over a failed query attempt.
+   */
+  public void testSkippingOverFailedQuery() throws Throwable {
+    CompletableFuture<QueryResponse> future1 = new CompletableFuture<>();
+    CompletableFuture<QueryResponse> future2 = new CompletableFuture<>();
+
+    Connection connection = mock(Connection.class);
+    Mockito.<CompletableFuture<QueryResponse>>when(connection.send(any(QueryRequest.class)))
+      .thenReturn(future1)
+      .thenReturn(future2);
+
+    ClientSessionState state = new ClientSessionState(UUID.randomUUID())
+      .setSessionId(1)
+      .setState(Session.State.OPEN);
+
+    Executor executor = new MockExecutor();
+    ThreadContext context = mock(ThreadContext.class);
+    when(context.executor()).thenReturn(executor);
+
+    ClientSessionSubmitter submitter = new ClientSessionSubmitter(connection, state, new ClientSequencer(state), context);
+
+    CompletableFuture<String> result1 = submitter.submit(new TestQuery());
+    CompletableFuture<String> result2 = submitter.submit(new TestQuery());
+
+    assertEquals(state.getResponseIndex(), 1);
+
+    assertFalse(result1.isDone());
+    assertFalse(result2.isDone());
+
+    future1.completeExceptionally(new QueryException("failure"));
+    future2.complete(QueryResponse.builder()
+        .withStatus(Response.Status.OK)
+        .withIndex(10)
+        .withResult("Hello world!")
+        .build());
+
+    assertTrue(result1.isCompletedExceptionally());
+    assertTrue(result2.isDone());
+    assertEquals(result2.get(), "Hello world!");
 
     assertEquals(state.getResponseIndex(), 10);
   }


### PR DESCRIPTION
This PR fixes how responses are sequenced in the face of query failures. When a query fails we should mark its sequence number as abandoned and move on so that we don't block subsequent operations. This change ensure that.


