### PR TITLE
Fixes client sequencing bug

### DIFF
--- a/client/src/main/java/io/atomix/copycat/client/session/ClientSequencer.java
+++ b/client/src/main/java/io/atomix/copycat/client/session/ClientSequencer.java
@@ -177,7 +177,7 @@ final class ClientSequencer {
       }
     }
 
-    // If after completing pending events the eventIndex is equal to the response's eventIndex, complete the response.
+    // If after completing pending events the eventIndex is greater than or equal to the response's eventIndex, complete the response.
     // Note that the event protocol initializes the eventIndex to the session ID.
     if (response.eventIndex() <= eventIndex || (eventIndex == 0 && response.eventIndex() == state.getSessionId())) {
       callback.run();

--- a/client/src/main/java/io/atomix/copycat/client/session/ClientSequencer.java
+++ b/client/src/main/java/io/atomix/copycat/client/session/ClientSequencer.java
@@ -179,7 +179,7 @@ final class ClientSequencer {
 
     // If after completing pending events the eventIndex is equal to the response's eventIndex, complete the response.
     // Note that the event protocol initializes the eventIndex to the session ID.
-    if (response.eventIndex() == eventIndex || (eventIndex == 0 && response.eventIndex() == state.getSessionId())) {
+    if (response.eventIndex() <= eventIndex || (eventIndex == 0 && response.eventIndex() == state.getSessionId())) {
       callback.run();
       return true;
     } else {


### PR DESCRIPTION
This PR fixes a bug in the client sequencing logic. For this bug to manifest responses need to arrive out of order *and* each response should have a different event index *and* the later arriving response should have a higher event index

Here is an example that causes this:

(starting `eventIndex` is `500`)
- Client sends request with seq `100`
- Client sends request with seq `101`
- Response arrives for request `101` with event Index `500` (gets added to queue)
- Event `501` arrives (gets added to queue)
- Response arrives for request `100` with event Index `501` (this completes event `501` and request `100`)

Request `101` can no longer be completed because `eventIndex` has now advanced to `501`.
