### PR TITLE
Avoid submitting operations when session is not open

### DIFF
--- a/client/src/main/java/io/atomix/copycat/client/session/ClientSession.java
+++ b/client/src/main/java/io/atomix/copycat/client/session/ClientSession.java
@@ -17,6 +17,7 @@ package io.atomix.copycat.client.session;
 
 import io.atomix.catalyst.transport.Client;
 import io.atomix.catalyst.util.Assert;
+import io.atomix.catalyst.concurrent.Futures;
 import io.atomix.catalyst.concurrent.Listener;
 import io.atomix.catalyst.concurrent.ThreadContext;
 import io.atomix.copycat.Command;
@@ -25,6 +26,7 @@ import io.atomix.copycat.Query;
 import io.atomix.copycat.client.ConnectionStrategy;
 import io.atomix.copycat.client.util.AddressSelector;
 import io.atomix.copycat.client.util.ClientConnection;
+import io.atomix.copycat.session.ClosedSessionException;
 import io.atomix.copycat.session.Session;
 
 import java.util.UUID;
@@ -114,6 +116,10 @@ public class ClientSession implements Session {
    * @return A completable future to be completed with the command result.
    */
   public <T> CompletableFuture<T> submit(Command<T> command) {
+    State state = state();
+    if (state == State.CLOSED || state == State.EXPIRED) {
+      return Futures.exceptionalFuture(new ClosedSessionException("session closed"));
+    }
     return submitter.submit(command);
   }
 
@@ -125,6 +131,10 @@ public class ClientSession implements Session {
    * @return A completable future to be completed with the query result.
    */
   public <T> CompletableFuture<T> submit(Query<T> query) {
+    State state = state();
+    if (state == State.CLOSED || state == State.EXPIRED) {
+      return Futures.exceptionalFuture(new ClosedSessionException("session closed"));
+    }
     return submitter.submit(query);
   }
 


### PR DESCRIPTION
This PR fixes assertion failures that can occur during session recovery.
There is a short window during client recovery then a new session object is created but not yet registered. Operations submitted during this window will fail with the following error

```
java.lang.IllegalArgumentException: session cannot be less than 1
	at io.atomix.catalyst.util.Assert.arg(Assert.java:15)[40:io.atomix.all:1.0.0.rc7]
	at io.atomix.catalyst.util.Assert.arg(Assert.java:22)[40:io.atomix.all:1.0.0.rc7]
	at io.atomix.catalyst.util.Assert.argNot(Assert.java:37)[40:io.atomix.all:1.0.0.rc7]
	at io.atomix.copycat.protocol.SessionRequest$Builder.withSession(SessionRequest.java:70)[40:io.atomix.all:1.0.0.rc7]
	at io.atomix.copycat.client.session.ClientSessionSubmitter.submitCommand(ClientSessionSubmitter.java:88)[40:io.atomix.all:1.0.0.rc7]
	at io.atomix.copycat.client.session.ClientSessionSubmitter.lambda$submit$1(ClientSessionSubmitter.java:79)[40:io.atomix.all:1.0.0.rc7]
	at io.atomix.copycat.client.session.ClientSessionSubmitter$$Lambda$215/1061048191.run(Unknown Source)[40:io.atomix.all:1.0.0.rc7]
	at io.atomix.catalyst.concurrent.Runnables.lambda$logFailure$2(Runnables.java:20)[40:io.atomix.all:1.0.0.rc7]
	at io.atomix.catalyst.concurrent.Runnables$$Lambda$48/731917339.run(Unknown Source)[40:io.atomix.all:1.0.0.rc7]
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)[:1.8.0_31]
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)[:1.8.0_31]
	at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.access$201(ScheduledThreadPoolExecutor.java:180)[:1.8.0_31]
	at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:293)[:1.8.0_31]
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)[:1.8.0_31]
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)[:1.8.0_31]
	at java.lang.Thread.run(Thread.java:745)[:1.8.0_31]
```