### PR TITLE
Add expire() method to ClientSession for testing

### DIFF
--- a/client/src/main/java/io/atomix/copycat/client/session/ClientSession.java
+++ b/client/src/main/java/io/atomix/copycat/client/session/ClientSession.java
@@ -15,11 +15,11 @@
  */
 package io.atomix.copycat.client.session;
 
-import io.atomix.catalyst.transport.Client;
-import io.atomix.catalyst.util.Assert;
 import io.atomix.catalyst.concurrent.Futures;
 import io.atomix.catalyst.concurrent.Listener;
 import io.atomix.catalyst.concurrent.ThreadContext;
+import io.atomix.catalyst.transport.Client;
+import io.atomix.catalyst.util.Assert;
 import io.atomix.copycat.Command;
 import io.atomix.copycat.Operation;
 import io.atomix.copycat.Query;
@@ -194,6 +194,15 @@ public class ClientSession implements Session {
       .thenCompose(v -> listener.close())
       .thenCompose(v -> manager.close())
       .thenCompose(v -> connection.close());
+  }
+
+  /**
+   * Expires the session.
+   *
+   * @return A completable future to be completed once the session has been expired.
+   */
+  public CompletableFuture<Void> expire() {
+    return manager.expire();
   }
 
   /**

--- a/client/src/main/java/io/atomix/copycat/client/session/ClientSessionManager.java
+++ b/client/src/main/java/io/atomix/copycat/client/session/ClientSessionManager.java
@@ -60,6 +60,22 @@ final class ClientSessionManager {
   }
 
   /**
+   * Expires the manager.
+   *
+   * @return A completable future to be completed once the session has been expired.
+   */
+  public CompletableFuture<Void> expire() {
+    CompletableFuture<Void> future = new CompletableFuture<>();
+    context.executor().execute(() -> {
+      if (keepAlive != null)
+        keepAlive.cancel();
+      state.setState(Session.State.EXPIRED);
+      future.complete(null);
+    });
+    return future;
+  }
+
+  /**
    * Registers a session.
    */
   private void register(RegisterAttempt attempt) {


### PR DESCRIPTION
This PR adds a simple `expire()` method to `ClientSession` for testing. When a session is forcefully expired, the keep-alive is cancelled and the session's state is set to `EXPIRED`. This is enough to cause `RecoveryStrategy` to be called.