### PR TITLE
Ensure duplicate PublishRequests are handle appropriately

### DIFF
--- a/client/src/main/java/io/atomix/copycat/client/session/ClientSessionListener.java
+++ b/client/src/main/java/io/atomix/copycat/client/session/ClientSessionListener.java
@@ -95,6 +95,13 @@ final class ClientSessionListener {
       return Futures.exceptionalFuture(new UnknownSessionException("incorrect session ID"));
     }
 
+    if (request.eventIndex() <= state.getEventIndex()) {
+      return CompletableFuture.completedFuture(PublishResponse.builder()
+          .withStatus(Response.Status.OK)
+          .withIndex(state.getEventIndex())
+          .build());
+    }
+
     // If the request's previous event index doesn't equal the previous received event index,
     // respond with an undefined error and the last index received. This will cause the cluster
     // to resend events starting at eventIndex + 1.

--- a/client/src/test/java/io/atomix/copycat/client/session/ClientSessionListenerTest.java
+++ b/client/src/test/java/io/atomix/copycat/client/session/ClientSessionListenerTest.java
@@ -128,7 +128,7 @@ public class ClientSessionListenerTest {
       .withEvents(new Event<String>("foo", "Hello world!"))
       .build()).get();
 
-    assertEquals(response.status(), Response.Status.ERROR);
+    assertEquals(response.status(), Response.Status.OK);
     assertEquals(response.index(), 10);
     assertEquals(state.getEventIndex(), 10);
     assertFalse(received.get());

--- a/protocol/src/main/java/io/atomix/copycat/protocol/PublishResponse.java
+++ b/protocol/src/main/java/io/atomix/copycat/protocol/PublishResponse.java
@@ -108,7 +108,7 @@ public class PublishResponse extends SessionResponse {
 
   @Override
   public String toString() {
-    return String.format("%s[status=%s, index=%d]", getClass().getSimpleName(), status, index);
+    return String.format("%s[status=%s, error=%s, index=%d]", getClass().getSimpleName(), status, error, index);
   }
 
   /**


### PR DESCRIPTION
This PR addresses stability issues that were being observed when several concurrent updates are made to a resource and where each such update generates a event notification. The issue stems from the fact that events can be delivered out of order and when that happens the out of sequence event gets rejected by the client (with `ERROR` status). This forces the server to immediately resend another large batch of events that are potentially in flight already. In my testing I have observed that this causes a flood or messages forcing new timeouts and more out of order delivery and thereby putting the system into a tail spin.