### PR TITLE
fix loosing exception cause

### DIFF
--- a/server/src/main/java/io/atomix/copycat/server/state/ServerStateMachineExecutor.java
+++ b/server/src/main/java/io/atomix/copycat/server/state/ServerStateMachineExecutor.java
@@ -143,7 +143,7 @@ class ServerStateMachineExecutor implements StateMachineExecutor {
       try {
         return (U) function.apply(commit);
       } catch (Exception e) {
-        throw new ApplicationException("An application error occurred", e);
+        throw new ApplicationException(e, "An application error occurred");
       }
     }
   }


### PR DESCRIPTION
Wrong constructor was being called and the exception cause was effectively being lost.
