### PR TITLE
ServerSessionManager: only try to remove consistent information

### DIFF
--- a/server/src/main/java/io/atomix/copycat/server/state/ServerSessionManager.java
+++ b/server/src/main/java/io/atomix/copycat/server/state/ServerSessionManager.java
@@ -126,9 +126,9 @@ class ServerSessionManager implements Sessions {
   ServerSessionContext unregisterSession(long sessionId) {
     ServerSessionContext session = sessions.remove(sessionId);
     if (session != null) {
-      clients.remove(session.client());
-      addresses.remove(session.client());
-      connections.remove(session.client());
+      clients.remove(session.client(), session);
+      addresses.remove(session.client(), session.getAddress());
+      connections.remove(session.client(), session.getConnection());
     }
     return session;
   }


### PR DESCRIPTION
It is possible that a client creates 2 sessions if the first attempt
times out. In this case the ServerSessionManager will associate the 2nd
session to the client but the 1st session that is left unatended will
time out and eventually be unregistered.

When this is done it will cause the maps in this object to have the
client/session entry removed but those are already pointing to the new
information that is in use. Their removal will cause issues in cluster
operation.

Fixes #257