### PR TITLE
Reject messages from clients that are connected to the wrong server

### DIFF
--- a/protocol/src/main/java/io/atomix/copycat/protocol/SessionRequest.java
+++ b/protocol/src/main/java/io/atomix/copycat/protocol/SessionRequest.java
@@ -30,6 +30,7 @@ import io.atomix.catalyst.util.Assert;
  */
 public abstract class SessionRequest extends AbstractRequest {
   protected long session;
+  protected boolean forwarded;
 
   /**
    * Returns the session ID.
@@ -42,12 +43,24 @@ public abstract class SessionRequest extends AbstractRequest {
 
   @Override
   public void readObject(BufferInput<?> buffer, Serializer serializer) {
+    super.readObject(buffer, serializer);
     session = buffer.readLong();
+    forwarded = buffer.readBoolean();
   }
 
   @Override
   public void writeObject(BufferOutput<?> buffer, Serializer serializer) {
+    super.writeObject(buffer, serializer);
     buffer.writeLong(session);
+    buffer.writeBoolean(forwarded);
+  }
+
+  public void setForwarded() {
+    forwarded = true;
+  }
+
+  public boolean wasForwarded() {
+    return forwarded;
   }
 
   /**
@@ -68,6 +81,11 @@ public abstract class SessionRequest extends AbstractRequest {
     @SuppressWarnings("unchecked")
     public T withSession(long session) {
       request.session = Assert.argNot(session, session < 1, "session cannot be less than 1");
+      return (T) this;
+    }
+
+    public T forwarded() {
+      request.forwarded = true;
       return (T) this;
     }
 

--- a/server/src/main/java/io/atomix/copycat/server/state/ServerSessionManager.java
+++ b/server/src/main/java/io/atomix/copycat/server/state/ServerSessionManager.java
@@ -25,6 +25,7 @@ import io.atomix.copycat.server.session.Sessions;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
@@ -162,4 +163,15 @@ class ServerSessionManager implements Sessions {
     return (Iterator) sessions.values().iterator();
   }
 
+  public boolean hasConnection(long sessionId) {
+    ServerSessionContext serverSessionContext = sessions.get(sessionId);
+    Optional<Map.Entry<String, ServerSessionContext>> entry = clients.entrySet().stream().filter(k -> k.getValue().equals(serverSessionContext)).findFirst();
+    if (entry.isPresent()) {
+      String client = entry.get().getKey();
+      return connections.containsKey(client);
+    } else {
+      // We don't know about this session, might be a newly registered. Just let it pass for now.
+      return true;
+    }
+  }
 }


### PR DESCRIPTION
This will make them eventually timeout and try a new server instead of
trying to use a server that they aren't supposed to be using.

This can happen on races of clients connecting to multiple servers
due to a sequence of timeouts (frequent on high-load scenarios) and
the ConnectRequest/AcceptRequests ending up on the Leader at the
wrong order.

Example:

1) Client A tries to connect to Server X and times out
2) Client A tries to connect to Server Y and succeeds
3) Leader receives AcceptRequest from Server Y and processes/publishes it
4) Leader receives AcceptRequest from Server X and processes/publishes it

After this, Client A is connected to Server Y but the cluster believes
it should be connected to server X. This causes some inconsistency
checks that eventually leads to the Client A becoming useless and having
all its operations timeout. Its internal session state won't receive
publishes because Server Y won't send them (its connection was closed
once it received the message that Client A is now connected to Server
X).

The solution on this patch is to reject messages from clients that are
not connected to a particular server, leading the client to eventually
timeout and start a new connection. A new field was added to Session
requests to allow identifying when a request was forwarded (must be
handled) or when it came directly from a client (needs check if the
client is connected to the receiver).

Fixes #259