### PR TITLE
Change client names to strings and make them configurable

### DIFF
--- a/client/src/main/java/io/atomix/copycat/client/CopycatClient.java
+++ b/client/src/main/java/io/atomix/copycat/client/CopycatClient.java
@@ -34,6 +34,7 @@ import io.atomix.copycat.util.ProtocolSerialization;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Consumer;
 
@@ -553,6 +554,7 @@ public interface CopycatClient {
    */
   final class Builder implements io.atomix.catalyst.util.Builder<CopycatClient> {
     private final Collection<Address> cluster;
+    private String clientId = UUID.randomUUID().toString();
     private Transport transport;
     private Serializer serializer;
     private ConnectionStrategy connectionStrategy = ConnectionStrategies.ONCE;
@@ -561,6 +563,21 @@ public interface CopycatClient {
 
     private Builder(Collection<Address> cluster) {
       this.cluster = Assert.notNull(cluster, "cluster");
+    }
+
+    /**
+     * Sets the client ID.
+     * <p>
+     * The client ID is a name that should be unique among all clients. The ID will be used to resolve
+     * and recover sessions.
+     *
+     * @param clientId The client ID.
+     * @return The client builder.
+     * @throws NullPointerException if {@code clientId} is null
+     */
+    public Builder withClientId(String clientId) {
+      this.clientId = Assert.notNull(clientId, "clientId");
+      return this;
     }
 
     /**
@@ -649,7 +666,7 @@ public interface CopycatClient {
       serializer.resolve(new ClientResponseTypeResolver());
       serializer.resolve(new ProtocolSerialization());
 
-      return new DefaultCopycatClient(cluster, transport, new SingleThreadContext("copycat-client-io-%d", serializer.clone()), new SingleThreadContext("copycat-client-event-%d", serializer.clone()), serverSelectionStrategy, connectionStrategy, recoveryStrategy);
+      return new DefaultCopycatClient(clientId, cluster, transport, new SingleThreadContext("copycat-client-io-%d", serializer.clone()), new SingleThreadContext("copycat-client-event-%d", serializer.clone()), serverSelectionStrategy, connectionStrategy, recoveryStrategy);
     }
   }
 

--- a/client/src/main/java/io/atomix/copycat/client/DefaultCopycatClient.java
+++ b/client/src/main/java/io/atomix/copycat/client/DefaultCopycatClient.java
@@ -48,6 +48,7 @@ public class DefaultCopycatClient implements CopycatClient {
   private static final Logger LOGGER = LoggerFactory.getLogger(DefaultCopycatClient.class);
   private static final String DEFAULT_HOST = "0.0.0.0";
   private static final int DEFAULT_PORT = 8700;
+  private final String clientId;
   private final Collection<Address> cluster;
   private final Transport transport;
   private final ThreadContext ioContext;
@@ -64,7 +65,8 @@ public class DefaultCopycatClient implements CopycatClient {
   private final Set<EventListener<?>> eventListeners = new CopyOnWriteArraySet<>();
   private Listener<Session.State> changeListener;
 
-  DefaultCopycatClient(Collection<Address> cluster, Transport transport, ThreadContext ioContext, ThreadContext eventContext, ServerSelectionStrategy selectionStrategy, ConnectionStrategy connectionStrategy, RecoveryStrategy recoveryStrategy) {
+  DefaultCopycatClient(String clientId, Collection<Address> cluster, Transport transport, ThreadContext ioContext, ThreadContext eventContext, ServerSelectionStrategy selectionStrategy, ConnectionStrategy connectionStrategy, RecoveryStrategy recoveryStrategy) {
+    this.clientId = Assert.notNull(clientId, "clientId");
     this.cluster = Assert.notNull(cluster, "cluster");
     this.transport = Assert.notNull(transport, "transport");
     this.ioContext = Assert.notNull(ioContext, "ioContext");
@@ -120,7 +122,7 @@ public class DefaultCopycatClient implements CopycatClient {
    * Creates a new child session.
    */
   private ClientSession newSession() {
-    ClientSession session = new ClientSession(transport.client(), selector, ioContext, connectionStrategy);
+    ClientSession session = new ClientSession(clientId, transport.client(), selector, ioContext, connectionStrategy);
 
     // Update the session change listener.
     if (changeListener != null)

--- a/client/src/main/java/io/atomix/copycat/client/session/ClientSession.java
+++ b/client/src/main/java/io/atomix/copycat/client/session/ClientSession.java
@@ -29,7 +29,6 @@ import io.atomix.copycat.client.util.ClientConnection;
 import io.atomix.copycat.session.ClosedSessionException;
 import io.atomix.copycat.session.Session;
 
-import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Consumer;
 
@@ -59,11 +58,7 @@ public class ClientSession implements Session {
   private final ClientSessionListener listener;
   private final ClientSessionSubmitter submitter;
 
-  public ClientSession(Client client, AddressSelector selector, ThreadContext context, ConnectionStrategy connectionStrategy) {
-    this(UUID.randomUUID(), client, selector, context, connectionStrategy);
-  }
-
-  public ClientSession(UUID id, Client client, AddressSelector selector, ThreadContext context, ConnectionStrategy connectionStrategy) {
+  public ClientSession(String id, Client client, AddressSelector selector, ThreadContext context, ConnectionStrategy connectionStrategy) {
     this(new ClientConnection(id, client, selector), new ClientSessionState(id), context, connectionStrategy);
   }
 

--- a/client/src/main/java/io/atomix/copycat/client/session/ClientSessionState.java
+++ b/client/src/main/java/io/atomix/copycat/client/session/ClientSessionState.java
@@ -15,14 +15,13 @@
  */
 package io.atomix.copycat.client.session;
 
-import io.atomix.catalyst.util.Assert;
 import io.atomix.catalyst.concurrent.Listener;
+import io.atomix.catalyst.util.Assert;
 import io.atomix.copycat.session.Session;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.Set;
-import java.util.UUID;
 import java.util.concurrent.CopyOnWriteArraySet;
 import java.util.function.Consumer;
 
@@ -33,7 +32,7 @@ import java.util.function.Consumer;
  */
 final class ClientSessionState {
   private static final Logger LOGGER = LoggerFactory.getLogger(ClientSession.class);
-  private final UUID clientId;
+  private final String clientId;
   private volatile long sessionId;
   private volatile Session.State state = Session.State.CLOSED;
   private long commandRequest;
@@ -42,7 +41,7 @@ final class ClientSessionState {
   private long eventIndex;
   private final Set<Listener<Session.State>> changeListeners = new CopyOnWriteArraySet<>();
 
-  ClientSessionState(UUID clientId) {
+  ClientSessionState(String clientId) {
     this.clientId = Assert.notNull(clientId, "clientId");
   }
 
@@ -51,7 +50,7 @@ final class ClientSessionState {
    *
    * @return The client ID.
    */
-  public UUID getClientId() {
+  public String getClientId() {
     return clientId;
   }
 

--- a/client/src/main/java/io/atomix/copycat/client/util/ClientConnection.java
+++ b/client/src/main/java/io/atomix/copycat/client/util/ClientConnection.java
@@ -15,9 +15,9 @@
  */
 package io.atomix.copycat.client.util;
 
+import io.atomix.catalyst.concurrent.Listener;
 import io.atomix.catalyst.transport.*;
 import io.atomix.catalyst.util.Assert;
-import io.atomix.catalyst.concurrent.Listener;
 import io.atomix.copycat.error.CopycatError;
 import io.atomix.copycat.protocol.ConnectRequest;
 import io.atomix.copycat.protocol.ConnectResponse;
@@ -30,7 +30,6 @@ import java.net.ConnectException;
 import java.nio.channels.ClosedChannelException;
 import java.util.Collection;
 import java.util.Map;
-import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeoutException;
@@ -43,7 +42,7 @@ import java.util.function.Consumer;
  */
 public class ClientConnection implements Connection {
   private static final Logger LOGGER = LoggerFactory.getLogger(ClientConnection.class);
-  private final UUID id;
+  private final String id;
   private final Client client;
   private final AddressSelector selector;
   private CompletableFuture<Connection> connectFuture;
@@ -51,7 +50,7 @@ public class ClientConnection implements Connection {
   private Connection connection;
   private boolean open = true;
 
-  public ClientConnection(UUID id, Client client, AddressSelector selector) {
+  public ClientConnection(String id, Client client, AddressSelector selector) {
     this.id = Assert.notNull(id, "id");
     this.client = Assert.notNull(client, "client");
     this.selector = Assert.notNull(selector, "selector");

--- a/client/src/test/java/io/atomix/copycat/client/session/ClientSequencerTest.java
+++ b/client/src/test/java/io/atomix/copycat/client/session/ClientSequencerTest.java
@@ -39,7 +39,7 @@ public class ClientSequencerTest {
    * Tests sequencing an event that arrives before a command response.
    */
   public void testSequenceEventBeforeCommand() throws Throwable {
-    ClientSequencer sequencer = new ClientSequencer(new ClientSessionState(UUID.randomUUID()));
+    ClientSequencer sequencer = new ClientSequencer(new ClientSessionState(UUID.randomUUID().toString()));
     long sequence = sequencer.nextRequest();
 
     PublishRequest request = PublishRequest.builder()
@@ -64,7 +64,7 @@ public class ClientSequencerTest {
    * Tests sequencing an event that arrives before a command response.
    */
   public void testSequenceEventAfterCommand() throws Throwable {
-    ClientSequencer sequencer = new ClientSequencer(new ClientSessionState(UUID.randomUUID()));
+    ClientSequencer sequencer = new ClientSequencer(new ClientSessionState(UUID.randomUUID().toString()));
     long sequence = sequencer.nextRequest();
 
     PublishRequest request = PublishRequest.builder()
@@ -89,7 +89,7 @@ public class ClientSequencerTest {
    * Tests sequencing an event that arrives before a command response.
    */
   public void testSequenceEventAtCommand() throws Throwable {
-    ClientSequencer sequencer = new ClientSequencer(new ClientSessionState(UUID.randomUUID()));
+    ClientSequencer sequencer = new ClientSequencer(new ClientSessionState(UUID.randomUUID().toString()));
     long sequence = sequencer.nextRequest();
 
     PublishRequest request = PublishRequest.builder()
@@ -114,7 +114,7 @@ public class ClientSequencerTest {
    * Tests sequencing an event that arrives before a command response.
    */
   public void testSequenceEventAfterAllCommands() throws Throwable {
-    ClientSequencer sequencer = new ClientSequencer(new ClientSessionState(UUID.randomUUID()));
+    ClientSequencer sequencer = new ClientSequencer(new ClientSessionState(UUID.randomUUID().toString()));
     long sequence = sequencer.nextRequest();
 
     PublishRequest request1 = PublishRequest.builder()
@@ -146,7 +146,7 @@ public class ClientSequencerTest {
    * Tests sequencing an event that arrives before a command response.
    */
   public void testSequenceEventAbsentCommand() throws Throwable {
-    ClientSequencer sequencer = new ClientSequencer(new ClientSessionState(UUID.randomUUID()));
+    ClientSequencer sequencer = new ClientSequencer(new ClientSessionState(UUID.randomUUID().toString()));
 
     PublishRequest request1 = PublishRequest.builder()
       .withSession(1)
@@ -170,7 +170,7 @@ public class ClientSequencerTest {
    * Tests sequencing callbacks with the sequencer.
    */
   public void testSequenceResponses() throws Throwable {
-    ClientSequencer sequencer = new ClientSequencer(new ClientSessionState(UUID.randomUUID()));
+    ClientSequencer sequencer = new ClientSequencer(new ClientSessionState(UUID.randomUUID().toString()));
     long sequence1 = sequencer.nextRequest();
     long sequence2 = sequencer.nextRequest();
     assertTrue(sequence2 == sequence1 + 1);

--- a/client/src/test/java/io/atomix/copycat/client/session/ClientSessionListenerTest.java
+++ b/client/src/test/java/io/atomix/copycat/client/session/ClientSessionListenerTest.java
@@ -15,13 +15,6 @@
  */
 package io.atomix.copycat.client.session;
 
-import static org.mockito.Matchers.any;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
-import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertFalse;
-import static org.testng.Assert.assertTrue;
 import io.atomix.catalyst.concurrent.ThreadContext;
 import io.atomix.catalyst.transport.Connection;
 import io.atomix.catalyst.transport.MessageHandler;
@@ -30,13 +23,16 @@ import io.atomix.copycat.protocol.PublishResponse;
 import io.atomix.copycat.protocol.Response;
 import io.atomix.copycat.session.Event;
 import io.atomix.copycat.session.Session;
+import org.mockito.ArgumentCaptor;
+import org.testng.annotations.Test;
 
 import java.util.UUID;
 import java.util.concurrent.Executor;
 import java.util.concurrent.atomic.AtomicBoolean;
 
-import org.mockito.ArgumentCaptor;
-import org.testng.annotations.Test;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.*;
+import static org.testng.Assert.*;
 
 /**
  * Client session listener test.
@@ -56,7 +52,7 @@ public class ClientSessionListenerTest {
     ArgumentCaptor<MessageHandler> captor = ArgumentCaptor.forClass(MessageHandler.class);
     Connection connection = mock(Connection.class);
 
-    state = new ClientSessionState(UUID.randomUUID());
+    state = new ClientSessionState(UUID.randomUUID().toString());
     Executor executor = new MockExecutor();
     ThreadContext context = mock(ThreadContext.class);
     when(context.executor()).thenReturn(executor);

--- a/client/src/test/java/io/atomix/copycat/client/session/ClientSessionManagerTest.java
+++ b/client/src/test/java/io/atomix/copycat/client/session/ClientSessionManagerTest.java
@@ -18,12 +18,8 @@ package io.atomix.copycat.client.session;
 import io.atomix.catalyst.concurrent.ThreadContext;
 import io.atomix.catalyst.transport.Address;
 import io.atomix.copycat.client.ConnectionStrategies;
-import io.atomix.copycat.protocol.RegisterRequest;
-import io.atomix.copycat.protocol.UnregisterRequest;
-import io.atomix.copycat.protocol.RegisterResponse;
-import io.atomix.copycat.protocol.Response;
-import io.atomix.copycat.protocol.UnregisterResponse;
 import io.atomix.copycat.client.util.ClientConnection;
+import io.atomix.copycat.protocol.*;
 import io.atomix.copycat.session.Session;
 import org.testng.annotations.Test;
 
@@ -63,7 +59,7 @@ public class ClientSessionManagerTest {
         .withTimeout(1000)
         .build()));
 
-    ClientSessionState state = new ClientSessionState(UUID.randomUUID());
+    ClientSessionState state = new ClientSessionState(UUID.randomUUID().toString());
     ThreadContext context = mock(ThreadContext.class);
     Executor executor = new MockExecutor();
     when(context.executor()).thenReturn(executor);

--- a/client/src/test/java/io/atomix/copycat/client/session/ClientSessionStateTest.java
+++ b/client/src/test/java/io/atomix/copycat/client/session/ClientSessionStateTest.java
@@ -37,7 +37,7 @@ public class ClientSessionStateTest {
    * Tests session state defaults.
    */
   public void testSessionStateDefaults() {
-    UUID clientId = UUID.randomUUID();
+    String clientId = UUID.randomUUID().toString();
     ClientSessionState state = new ClientSessionState(clientId);
     assertEquals(state.getClientId(), clientId);
     assertEquals(state.getSessionId(), 0);
@@ -52,7 +52,7 @@ public class ClientSessionStateTest {
    * Tests updating client session state.
    */
   public void testSessionState() {
-    ClientSessionState state = new ClientSessionState(UUID.randomUUID());
+    ClientSessionState state = new ClientSessionState(UUID.randomUUID().toString());
     assertEquals(state.setSessionId(1).getSessionId(), 1);
     assertEquals(state.getResponseIndex(), 1);
     assertEquals(state.getEventIndex(), 1);
@@ -70,7 +70,7 @@ public class ClientSessionStateTest {
    * Tests session state change callbacks.
    */
   public void testSessionStateChange() {
-    ClientSessionState state = new ClientSessionState(UUID.randomUUID());
+    ClientSessionState state = new ClientSessionState(UUID.randomUUID().toString());
     AtomicBoolean changed = new AtomicBoolean();
     AtomicReference<Session.State> change = new AtomicReference<>();
     Listener<Session.State> listener = state.onStateChange(s -> {

--- a/client/src/test/java/io/atomix/copycat/client/session/ClientSessionSubmitterTest.java
+++ b/client/src/test/java/io/atomix/copycat/client/session/ClientSessionSubmitterTest.java
@@ -15,14 +15,13 @@
  */
 package io.atomix.copycat.client.session;
 
-import io.atomix.catalyst.transport.Connection;
 import io.atomix.catalyst.concurrent.ThreadContext;
+import io.atomix.catalyst.transport.Connection;
 import io.atomix.copycat.Command;
 import io.atomix.copycat.Query;
 import io.atomix.copycat.error.QueryException;
 import io.atomix.copycat.protocol.*;
 import io.atomix.copycat.session.Session;
-
 import org.mockito.Mockito;
 import org.testng.annotations.Test;
 
@@ -53,7 +52,7 @@ public class ClientSessionSubmitterTest {
         .withResult("Hello world!")
         .build()));
 
-    ClientSessionState state = new ClientSessionState(UUID.randomUUID())
+    ClientSessionState state = new ClientSessionState(UUID.randomUUID().toString())
       .setSessionId(1)
       .setState(Session.State.OPEN);
 
@@ -80,7 +79,7 @@ public class ClientSessionSubmitterTest {
       .thenReturn(future1)
       .thenReturn(future2);
 
-    ClientSessionState state = new ClientSessionState(UUID.randomUUID())
+    ClientSessionState state = new ClientSessionState(UUID.randomUUID().toString())
       .setSessionId(1)
       .setState(Session.State.OPEN);
 
@@ -134,7 +133,7 @@ public class ClientSessionSubmitterTest {
         .withResult("Hello world!")
         .build()));
 
-    ClientSessionState state = new ClientSessionState(UUID.randomUUID())
+    ClientSessionState state = new ClientSessionState(UUID.randomUUID().toString())
       .setSessionId(1)
       .setState(Session.State.OPEN);
 
@@ -159,7 +158,7 @@ public class ClientSessionSubmitterTest {
       .thenReturn(future1)
       .thenReturn(future2);
 
-    ClientSessionState state = new ClientSessionState(UUID.randomUUID())
+    ClientSessionState state = new ClientSessionState(UUID.randomUUID().toString())
       .setSessionId(1)
       .setState(Session.State.OPEN);
 
@@ -209,7 +208,7 @@ public class ClientSessionSubmitterTest {
       .thenReturn(future1)
       .thenReturn(future2);
 
-    ClientSessionState state = new ClientSessionState(UUID.randomUUID())
+    ClientSessionState state = new ClientSessionState(UUID.randomUUID().toString())
       .setSessionId(1)
       .setState(Session.State.OPEN);
 

--- a/protocol/src/main/java/io/atomix/copycat/protocol/ConnectRequest.java
+++ b/protocol/src/main/java/io/atomix/copycat/protocol/ConnectRequest.java
@@ -21,7 +21,6 @@ import io.atomix.catalyst.serializer.Serializer;
 import io.atomix.catalyst.util.Assert;
 
 import java.util.Objects;
-import java.util.UUID;
 
 /**
  * Connect client request.
@@ -55,27 +54,27 @@ public class ConnectRequest extends AbstractRequest {
     return new Builder(request);
   }
 
-  private UUID client;
+  private String client;
 
   /**
    * Returns the connecting client ID.
    *
    * @return The connecting client ID.
    */
-  public UUID client() {
+  public String client() {
     return client;
   }
 
   @Override
   public void writeObject(BufferOutput<?> buffer, Serializer serializer) {
     super.writeObject(buffer, serializer);
-    buffer.writeString(client.toString());
+    buffer.writeString(client);
   }
 
   @Override
   public void readObject(BufferInput<?> buffer, Serializer serializer) {
     super.readObject(buffer, serializer);
-    client = UUID.fromString(buffer.readString());
+    client = buffer.readString();
   }
 
   @Override
@@ -107,7 +106,7 @@ public class ConnectRequest extends AbstractRequest {
      * @param clientId The connecting client ID.
      * @return The connect request builder.
      */
-    public Builder withClientId(UUID clientId) {
+    public Builder withClientId(String clientId) {
       request.client = Assert.notNull(clientId, "clientId");
       return this;
     }

--- a/protocol/src/main/java/io/atomix/copycat/protocol/RegisterRequest.java
+++ b/protocol/src/main/java/io/atomix/copycat/protocol/RegisterRequest.java
@@ -21,7 +21,6 @@ import io.atomix.catalyst.serializer.Serializer;
 import io.atomix.catalyst.util.Assert;
 
 import java.util.Objects;
-import java.util.UUID;
 
 /**
  * Register session request.
@@ -56,27 +55,27 @@ public class RegisterRequest extends AbstractRequest {
     return new Builder(request);
   }
 
-  private UUID client;
+  private String client;
 
   /**
    * Returns the client ID.
    *
    * @return The client ID.
    */
-  public UUID client() {
+  public String client() {
     return client;
   }
 
   @Override
   public void writeObject(BufferOutput<?> buffer, Serializer serializer) {
     super.writeObject(buffer, serializer);
-    buffer.writeString(client.toString());
+    buffer.writeString(client);
   }
 
   @Override
   public void readObject(BufferInput<?> buffer, Serializer serializer) {
     super.readObject(buffer, serializer);
-    client = UUID.fromString(buffer.readString());
+    client = buffer.readString();
   }
 
   @Override
@@ -113,7 +112,7 @@ public class RegisterRequest extends AbstractRequest {
      * @return The request builder.
      * @throws NullPointerException if {@code client} is null
      */
-    public Builder withClient(UUID client) {
+    public Builder withClient(String client) {
       request.client = Assert.notNull(client, "client");
       return this;
     }

--- a/server/src/main/java/io/atomix/copycat/server/protocol/AcceptRequest.java
+++ b/server/src/main/java/io/atomix/copycat/server/protocol/AcceptRequest.java
@@ -23,7 +23,6 @@ import io.atomix.catalyst.util.Assert;
 import io.atomix.copycat.protocol.AbstractRequest;
 
 import java.util.Objects;
-import java.util.UUID;
 
 /**
  * Accept client request.
@@ -58,7 +57,7 @@ public class AcceptRequest extends AbstractRequest {
     return new Builder(request);
   }
 
-  private UUID client;
+  private String client;
   private Address address;
 
   /**
@@ -66,7 +65,7 @@ public class AcceptRequest extends AbstractRequest {
    *
    * @return The accepted client ID.
    */
-  public UUID client() {
+  public String client() {
     return client;
   }
 
@@ -82,14 +81,14 @@ public class AcceptRequest extends AbstractRequest {
   @Override
   public void readObject(BufferInput<?> buffer, Serializer serializer) {
     super.readObject(buffer, serializer);
-    client = UUID.fromString(buffer.readString());
+    client = buffer.readString();
     address = serializer.readObject(buffer);
   }
 
   @Override
   public void writeObject(BufferOutput<?> buffer, Serializer serializer) {
     super.writeObject(buffer, serializer);
-    buffer.writeString(client.toString());
+    buffer.writeString(client);
     serializer.writeObject(address, buffer);
   }
 
@@ -126,7 +125,7 @@ public class AcceptRequest extends AbstractRequest {
      * @param client The request client.
      * @return The request builder.
      */
-    public Builder withClient(UUID client) {
+    public Builder withClient(String client) {
       request.client = Assert.notNull(client, "client");
       return this;
     }

--- a/server/src/main/java/io/atomix/copycat/server/state/LeaderState.java
+++ b/server/src/main/java/io/atomix/copycat/server/state/LeaderState.java
@@ -15,9 +15,9 @@
  */
 package io.atomix.copycat.server.state;
 
-import io.atomix.catalyst.transport.Connection;
 import io.atomix.catalyst.concurrent.ComposableFuture;
 import io.atomix.catalyst.concurrent.Scheduled;
+import io.atomix.catalyst.transport.Connection;
 import io.atomix.copycat.Command;
 import io.atomix.copycat.Query;
 import io.atomix.copycat.error.CopycatError;

--- a/server/src/main/java/io/atomix/copycat/server/state/ServerSessionContext.java
+++ b/server/src/main/java/io/atomix/copycat/server/state/ServerSessionContext.java
@@ -15,11 +15,11 @@
  */
 package io.atomix.copycat.server.state;
 
+import io.atomix.catalyst.concurrent.Listener;
+import io.atomix.catalyst.concurrent.Listeners;
 import io.atomix.catalyst.transport.Address;
 import io.atomix.catalyst.transport.Connection;
 import io.atomix.catalyst.util.Assert;
-import io.atomix.catalyst.concurrent.Listener;
-import io.atomix.catalyst.concurrent.Listeners;
 import io.atomix.copycat.protocol.PublishRequest;
 import io.atomix.copycat.protocol.PublishResponse;
 import io.atomix.copycat.protocol.Response;
@@ -41,7 +41,7 @@ import java.util.function.Consumer;
 class ServerSessionContext implements ServerSession {
   private static final Logger LOGGER = LoggerFactory.getLogger(ServerSessionContext.class);
   private final long id;
-  private final UUID client;
+  private final String client;
   private final Log log;
   private final ServerStateMachineContext context;
   private boolean open;
@@ -70,7 +70,7 @@ class ServerSessionContext implements ServerSession {
   private boolean unregistering;
   private final Listeners<State> changeListeners = new Listeners<>();
 
-  ServerSessionContext(long id, UUID client, Log log, ServerStateMachineContext context, long timeout) {
+  ServerSessionContext(long id, String client, Log log, ServerStateMachineContext context, long timeout) {
     this.id = id;
     this.client = Assert.notNull(client, "client");
     this.log = Assert.notNull(log, "log");
@@ -91,7 +91,7 @@ class ServerSessionContext implements ServerSession {
    *
    * @return The session client ID.
    */
-  public UUID client() {
+  public String client() {
     return client;
   }
 

--- a/server/src/main/java/io/atomix/copycat/server/state/ServerSessionManager.java
+++ b/server/src/main/java/io/atomix/copycat/server/state/ServerSessionManager.java
@@ -22,7 +22,10 @@ import io.atomix.copycat.server.session.ServerSession;
 import io.atomix.copycat.server.session.SessionListener;
 import io.atomix.copycat.server.session.Sessions;
 
-import java.util.*;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
 /**
@@ -31,10 +34,10 @@ import java.util.concurrent.ConcurrentHashMap;
  * @author <a href="http://github.com/kuujo">Jordan Halterman</a>
  */
 class ServerSessionManager implements Sessions {
-  private final Map<UUID, Address> addresses = new ConcurrentHashMap<>();
-  private final Map<UUID, Connection> connections = new ConcurrentHashMap<>();
+  private final Map<String, Address> addresses = new ConcurrentHashMap<>();
+  private final Map<String, Connection> connections = new ConcurrentHashMap<>();
   final Map<Long, ServerSessionContext> sessions = new ConcurrentHashMap<>();
-  final Map<UUID, ServerSessionContext> clients = new ConcurrentHashMap<>();
+  final Map<String, ServerSessionContext> clients = new ConcurrentHashMap<>();
   final Set<SessionListener> listeners = new HashSet<>();
   private final ServerContext context;
 
@@ -62,7 +65,7 @@ class ServerSessionManager implements Sessions {
   /**
    * Registers an address.
    */
-  ServerSessionManager registerAddress(UUID client, Address address) {
+  ServerSessionManager registerAddress(String client, Address address) {
     ServerSessionContext session = clients.get(client);
     if (session != null) {
       session.setAddress(address);
@@ -82,7 +85,7 @@ class ServerSessionManager implements Sessions {
   /**
    * Registers a connection.
    */
-  ServerSessionManager registerConnection(UUID client, Connection connection) {
+  ServerSessionManager registerConnection(String client, Connection connection) {
     ServerSessionContext session = clients.get(client);
     if (session != null) {
       session.setConnection(connection);
@@ -95,9 +98,9 @@ class ServerSessionManager implements Sessions {
    * Unregisters a connection.
    */
   ServerSessionManager unregisterConnection(Connection connection) {
-    Iterator<Map.Entry<UUID, Connection>> iterator = connections.entrySet().iterator();
+    Iterator<Map.Entry<String, Connection>> iterator = connections.entrySet().iterator();
     while (iterator.hasNext()) {
-      Map.Entry<UUID, Connection> entry = iterator.next();
+      Map.Entry<String, Connection> entry = iterator.next();
       if (entry.getValue().equals(connection)) {
         ServerSessionContext session = clients.get(entry.getKey());
         if (session != null) {
@@ -149,7 +152,7 @@ class ServerSessionManager implements Sessions {
    * @param clientId The client ID.
    * @return The session or {@code null} if the session doesn't exist.
    */
-  ServerSessionContext getSession(UUID clientId) {
+  ServerSessionContext getSession(String clientId) {
     return clients.get(clientId);
   }
 

--- a/server/src/main/java/io/atomix/copycat/server/storage/entry/ConnectEntry.java
+++ b/server/src/main/java/io/atomix/copycat/server/storage/entry/ConnectEntry.java
@@ -22,8 +22,6 @@ import io.atomix.catalyst.transport.Address;
 import io.atomix.catalyst.util.Assert;
 import io.atomix.catalyst.util.reference.ReferenceManager;
 
-import java.util.UUID;
-
 /**
  * Stores a connection between a client and server.
  * <p>
@@ -34,7 +32,7 @@ import java.util.UUID;
  * @author <a href="http://github.com/kuujo">Jordan Halterman</a>
  */
 public class ConnectEntry extends TimestampedEntry<ConnectEntry> {
-  private UUID client;
+  private String client;
   private Address address;
 
   public ConnectEntry() {
@@ -49,7 +47,7 @@ public class ConnectEntry extends TimestampedEntry<ConnectEntry> {
    *
    * @return The entry client ID.
    */
-  public UUID getClient() {
+  public String getClient() {
     return client;
   }
 
@@ -60,7 +58,7 @@ public class ConnectEntry extends TimestampedEntry<ConnectEntry> {
    * @return The register entry.
    * @throws NullPointerException if {@code client} is null
    */
-  public ConnectEntry setClient(UUID client) {
+  public ConnectEntry setClient(String client) {
     this.client = Assert.notNull(client, "client");
     return this;
   }
@@ -89,14 +87,14 @@ public class ConnectEntry extends TimestampedEntry<ConnectEntry> {
   @Override
   public void writeObject(BufferOutput buffer, Serializer serializer) {
     super.writeObject(buffer, serializer);
-    buffer.writeString(client.toString());
+    buffer.writeString(client);
     serializer.writeObject(address, buffer);
   }
 
   @Override
   public void readObject(BufferInput buffer, Serializer serializer) {
     super.readObject(buffer, serializer);
-    client = UUID.fromString(buffer.readString());
+    client = buffer.readString();
     address = serializer.readObject(buffer);
   }
 

--- a/server/src/main/java/io/atomix/copycat/server/storage/entry/RegisterEntry.java
+++ b/server/src/main/java/io/atomix/copycat/server/storage/entry/RegisterEntry.java
@@ -22,8 +22,6 @@ import io.atomix.catalyst.util.Assert;
 import io.atomix.catalyst.util.reference.ReferenceManager;
 import io.atomix.copycat.protocol.RegisterRequest;
 
-import java.util.UUID;
-
 /**
  * Stores a client register request.
  * <p>
@@ -36,7 +34,7 @@ import java.util.UUID;
  * @author <a href="http://github.com/kuujo">Jordan Halterman</a>
  */
 public class RegisterEntry extends TimestampedEntry<RegisterEntry> {
-  private UUID client;
+  private String client;
   private long timeout;
 
   public RegisterEntry() {
@@ -51,7 +49,7 @@ public class RegisterEntry extends TimestampedEntry<RegisterEntry> {
    *
    * @return The entry client ID.
    */
-  public UUID getClient() {
+  public String getClient() {
     return client;
   }
 
@@ -62,7 +60,7 @@ public class RegisterEntry extends TimestampedEntry<RegisterEntry> {
    * @return The register entry.
    * @throws NullPointerException if {@code client} is null
    */
-  public RegisterEntry setClient(UUID client) {
+  public RegisterEntry setClient(String client) {
     this.client = Assert.notNull(client, "client");
     return this;
   }
@@ -90,14 +88,14 @@ public class RegisterEntry extends TimestampedEntry<RegisterEntry> {
   @Override
   public void writeObject(BufferOutput buffer, Serializer serializer) {
     super.writeObject(buffer, serializer);
-    buffer.writeString(client.toString());
+    buffer.writeString(client);
     buffer.writeLong(timeout);
   }
 
   @Override
   public void readObject(BufferInput buffer, Serializer serializer) {
     super.readObject(buffer, serializer);
-    client = UUID.fromString(buffer.readString());
+    client = buffer.readString();
     timeout = buffer.readLong();
   }
 

--- a/server/src/test/java/io/atomix/copycat/server/state/LeaderStateTest.java
+++ b/server/src/test/java/io/atomix/copycat/server/state/LeaderStateTest.java
@@ -74,7 +74,7 @@ public class LeaderStateTest extends AbstractStateTest<LeaderState> {
           .executor()
           .context()
           .sessions()
-          .registerSession(new ServerSessionContext(1, UUID.randomUUID(), serverContext.getLog(), serverContext.getStateMachine().executor().context(), 1000));
+          .registerSession(new ServerSessionContext(1, UUID.randomUUID().toString(), serverContext.getLog(), serverContext.getStateMachine().executor().context(), 1000));
       CommandRequest request1 = CommandRequest.builder()
           .withSession(1)
           .withSequence(2)

--- a/server/src/test/java/io/atomix/copycat/server/state/ServerSessionTest.java
+++ b/server/src/test/java/io/atomix/copycat/server/state/ServerSessionTest.java
@@ -37,7 +37,7 @@ public class ServerSessionTest {
    */
   public void testInitializeSession() throws Throwable {
     ServerStateMachineContext context = mock(ServerStateMachineContext.class);
-    ServerSessionContext session = new ServerSessionContext(10, UUID.randomUUID(), mock(Log.class), context, 1000);
+    ServerSessionContext session = new ServerSessionContext(10, UUID.randomUUID().toString(), mock(Log.class), context, 1000);
     assertEquals(session.id(), 10);
     assertEquals(session.getLastCompleted(), 9);
     assertEquals(session.getLastApplied(), 9);
@@ -48,7 +48,7 @@ public class ServerSessionTest {
    */
   public void testSequenceCommand() throws Throwable {
     ServerStateMachineContext context = mock(ServerStateMachineContext.class);
-    ServerSessionContext session = new ServerSessionContext(10, UUID.randomUUID(), mock(Log.class), context, 1000);
+    ServerSessionContext session = new ServerSessionContext(10, UUID.randomUUID().toString(), mock(Log.class), context, 1000);
     assertEquals(session.getRequestSequence(), 0);
     AtomicBoolean complete = new AtomicBoolean();
     session.registerRequest(2, () -> complete.set(true));
@@ -62,7 +62,7 @@ public class ServerSessionTest {
    */
   public void testSequenceIndexQuery() throws Throwable {
     ServerStateMachineContext context = mock(ServerStateMachineContext.class);
-    ServerSessionContext session = new ServerSessionContext(10, UUID.randomUUID(), mock(Log.class), context, 1000);
+    ServerSessionContext session = new ServerSessionContext(10, UUID.randomUUID().toString(), mock(Log.class), context, 1000);
     AtomicBoolean complete = new AtomicBoolean();
     session.registerIndexQuery(10, () -> complete.set(true));
     assertFalse(complete.get());
@@ -77,7 +77,7 @@ public class ServerSessionTest {
    */
   public void testSequenceSequenceQuery() throws Throwable {
     ServerStateMachineContext context = mock(ServerStateMachineContext.class);
-    ServerSessionContext session = new ServerSessionContext(10, UUID.randomUUID(), mock(Log.class), context, 1000);
+    ServerSessionContext session = new ServerSessionContext(10, UUID.randomUUID().toString(), mock(Log.class), context, 1000);
     AtomicBoolean complete = new AtomicBoolean();
     session.registerSequenceQuery(10, () -> complete.set(true));
     assertFalse(complete.get());
@@ -92,7 +92,7 @@ public class ServerSessionTest {
    */
   public void testCacheResponse() throws Throwable {
     ServerStateMachineContext context = mock(ServerStateMachineContext.class);
-    ServerSessionContext session = new ServerSessionContext(10, UUID.randomUUID(), mock(Log.class), context, 1000);
+    ServerSessionContext session = new ServerSessionContext(10, UUID.randomUUID().toString(), mock(Log.class), context, 1000);
     session.registerResult(2, new ServerStateMachine.Result(2, 2, "Hello world!"));
     assertEquals(session.getResult(2).result, "Hello world!");
     session.clearResults(3);

--- a/server/src/test/java/io/atomix/copycat/server/state/ServerStateMachineTest.java
+++ b/server/src/test/java/io/atomix/copycat/server/state/ServerStateMachineTest.java
@@ -15,13 +15,13 @@
  */
 package io.atomix.copycat.server.state;
 
-import io.atomix.catalyst.serializer.Serializer;
-import io.atomix.catalyst.transport.Address;
-import io.atomix.catalyst.transport.local.LocalServerRegistry;
-import io.atomix.catalyst.transport.local.LocalTransport;
-import io.atomix.catalyst.transport.Transport;
 import io.atomix.catalyst.concurrent.SingleThreadContext;
 import io.atomix.catalyst.concurrent.ThreadContext;
+import io.atomix.catalyst.serializer.Serializer;
+import io.atomix.catalyst.transport.Address;
+import io.atomix.catalyst.transport.Transport;
+import io.atomix.catalyst.transport.local.LocalServerRegistry;
+import io.atomix.catalyst.transport.local.LocalTransport;
 import io.atomix.copycat.Command;
 import io.atomix.copycat.Query;
 import io.atomix.copycat.protocol.ClientRequestTypeResolver;
@@ -99,7 +99,7 @@ public class ServerStateMachineTest extends ConcurrentTestCase {
         entry.setTerm(1)
           .setTimestamp(timestamp)
           .setTimeout(500)
-          .setClient(UUID.randomUUID());
+          .setClient(UUID.randomUUID().toString());
         index = state.getLog().append(entry);
       }
 
@@ -150,7 +150,7 @@ public class ServerStateMachineTest extends ConcurrentTestCase {
         entry.setTerm(1)
           .setTimestamp(timestamp)
           .setTimeout(500)
-          .setClient(UUID.randomUUID());
+          .setClient(UUID.randomUUID().toString());
         index = state.getLog().append(entry);
       }
 
@@ -198,7 +198,7 @@ public class ServerStateMachineTest extends ConcurrentTestCase {
         entry.setTerm(1)
           .setTimestamp(timestamp)
           .setTimeout(500)
-          .setClient(UUID.randomUUID());
+          .setClient(UUID.randomUUID().toString());
         index = state.getLog().append(entry);
       }
 
@@ -249,7 +249,7 @@ public class ServerStateMachineTest extends ConcurrentTestCase {
         entry.setTerm(1)
           .setTimestamp(timestamp)
           .setTimeout(500)
-          .setClient(UUID.randomUUID());
+          .setClient(UUID.randomUUID().toString());
         index = state.getLog().append(entry);
       }
 
@@ -301,7 +301,7 @@ public class ServerStateMachineTest extends ConcurrentTestCase {
         entry.setTerm(1)
           .setTimestamp(timestamp)
           .setTimeout(500)
-          .setClient(UUID.randomUUID());
+          .setClient(UUID.randomUUID().toString());
         index = state.getLog().append(entry);
       }
 
@@ -398,7 +398,7 @@ public class ServerStateMachineTest extends ConcurrentTestCase {
         entry.setTerm(1)
           .setTimestamp(timestamp)
           .setTimeout(500)
-          .setClient(UUID.randomUUID());
+          .setClient(UUID.randomUUID().toString());
         index = state.getLog().append(entry);
       }
 


### PR DESCRIPTION
This PR replaces the use of `UUID`s for clients to simple `String`s to allow clients to specify names. This may be later used to ensure past client sessions are unregistered when a new session is registered or to recover state that hasn't yet been lost from a past session.