### PR TITLE
Support configurable per-client session timeouts

### DIFF
--- a/client/src/main/java/io/atomix/copycat/client/session/ClientSession.java
+++ b/client/src/main/java/io/atomix/copycat/client/session/ClientSession.java
@@ -29,6 +29,7 @@ import io.atomix.copycat.client.util.ClientConnection;
 import io.atomix.copycat.session.ClosedSessionException;
 import io.atomix.copycat.session.Session;
 
+import java.time.Duration;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Consumer;
 
@@ -58,14 +59,14 @@ public class ClientSession implements Session {
   private final ClientSessionListener listener;
   private final ClientSessionSubmitter submitter;
 
-  public ClientSession(String id, Client client, AddressSelector selector, ThreadContext context, ConnectionStrategy connectionStrategy) {
-    this(new ClientConnection(id, client, selector), new ClientSessionState(id), context, connectionStrategy);
+  public ClientSession(String id, Client client, AddressSelector selector, ThreadContext context, ConnectionStrategy connectionStrategy, Duration sessionTimeout) {
+    this(new ClientConnection(id, client, selector), new ClientSessionState(id), context, connectionStrategy, sessionTimeout);
   }
 
-  private ClientSession(ClientConnection connection, ClientSessionState state, ThreadContext context, ConnectionStrategy connectionStrategy) {
+  private ClientSession(ClientConnection connection, ClientSessionState state, ThreadContext context, ConnectionStrategy connectionStrategy, Duration sessionTimeout) {
     this.connection = Assert.notNull(connection, "connection");
     this.state = Assert.notNull(state, "state");
-    this.manager = new ClientSessionManager(connection, state, context, connectionStrategy);
+    this.manager = new ClientSessionManager(connection, state, context, connectionStrategy, sessionTimeout);
     ClientSequencer sequencer = new ClientSequencer(state);
     this.listener = new ClientSessionListener(connection, state, sequencer, context);
     this.submitter = new ClientSessionSubmitter(connection, state, sequencer, context);

--- a/client/src/main/java/io/atomix/copycat/client/session/ClientSessionManager.java
+++ b/client/src/main/java/io/atomix/copycat/client/session/ClientSessionManager.java
@@ -15,9 +15,9 @@
  */
 package io.atomix.copycat.client.session;
 
-import io.atomix.catalyst.util.Assert;
 import io.atomix.catalyst.concurrent.Scheduled;
 import io.atomix.catalyst.concurrent.ThreadContext;
+import io.atomix.catalyst.util.Assert;
 import io.atomix.copycat.client.ConnectionStrategy;
 import io.atomix.copycat.client.util.ClientConnection;
 import io.atomix.copycat.error.CopycatError;
@@ -39,14 +39,16 @@ final class ClientSessionManager {
   private final ClientConnection connection;
   private final ThreadContext context;
   private final ConnectionStrategy strategy;
+  private final Duration sessionTimeout;
   private Duration interval;
   private Scheduled keepAlive;
 
-  ClientSessionManager(ClientConnection connection, ClientSessionState state, ThreadContext context, ConnectionStrategy connectionStrategy) {
+  ClientSessionManager(ClientConnection connection, ClientSessionState state, ThreadContext context, ConnectionStrategy connectionStrategy, Duration sessionTimeout) {
     this.connection = Assert.notNull(connection, "connection");
     this.state = Assert.notNull(state, "state");
     this.context = Assert.notNull(context, "context");
     this.strategy = Assert.notNull(connectionStrategy, "connectionStrategy");
+    this.sessionTimeout = Assert.notNull(sessionTimeout, "sessionTimeout");
   }
 
   /**
@@ -84,6 +86,7 @@ final class ClientSessionManager {
 
     RegisterRequest request = RegisterRequest.builder()
       .withClient(state.getClientId())
+      .withTimeout(sessionTimeout.toMillis())
       .build();
 
     state.getLogger().debug("Sending {}", request);

--- a/client/src/test/java/io/atomix/copycat/client/session/ClientSessionManagerTest.java
+++ b/client/src/test/java/io/atomix/copycat/client/session/ClientSessionManagerTest.java
@@ -23,6 +23,7 @@ import io.atomix.copycat.protocol.*;
 import io.atomix.copycat.session.Session;
 import org.testng.annotations.Test;
 
+import java.time.Duration;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.UUID;
@@ -64,7 +65,7 @@ public class ClientSessionManagerTest {
     Executor executor = new MockExecutor();
     when(context.executor()).thenReturn(executor);
 
-    ClientSessionManager manager = new ClientSessionManager(connection, state, context, ConnectionStrategies.EXPONENTIAL_BACKOFF);
+    ClientSessionManager manager = new ClientSessionManager(connection, state, context, ConnectionStrategies.EXPONENTIAL_BACKOFF, Duration.ZERO);
     manager.open().join();
 
     assertEquals(state.getSessionId(), 1);

--- a/protocol/src/main/java/io/atomix/copycat/protocol/RegisterRequest.java
+++ b/protocol/src/main/java/io/atomix/copycat/protocol/RegisterRequest.java
@@ -56,6 +56,7 @@ public class RegisterRequest extends AbstractRequest {
   }
 
   private String client;
+  private long timeout;
 
   /**
    * Returns the client ID.
@@ -66,16 +67,27 @@ public class RegisterRequest extends AbstractRequest {
     return client;
   }
 
+  /**
+   * Returns the client session timeout.
+   *
+   * @return The client session timeout.
+   */
+  public long timeout() {
+    return timeout;
+  }
+
   @Override
   public void writeObject(BufferOutput<?> buffer, Serializer serializer) {
     super.writeObject(buffer, serializer);
     buffer.writeString(client);
+    buffer.writeLong(timeout);
   }
 
   @Override
   public void readObject(BufferInput<?> buffer, Serializer serializer) {
     super.readObject(buffer, serializer);
     client = buffer.readString();
+    timeout = buffer.readLong();
   }
 
   @Override
@@ -87,7 +99,7 @@ public class RegisterRequest extends AbstractRequest {
   public boolean equals(Object object) {
     if (object instanceof RegisterRequest) {
       RegisterRequest request = (RegisterRequest) object;
-      return request.client.equals(client);
+      return request.client.equals(client) && request.timeout == timeout;
     }
     return false;
   }
@@ -114,6 +126,18 @@ public class RegisterRequest extends AbstractRequest {
      */
     public Builder withClient(String client) {
       request.client = Assert.notNull(client, "client");
+      return this;
+    }
+
+    /**
+     * Sets the client session timeout.
+     *
+     * @param timeout The client session timeout.
+     * @return The request builder.
+     * @throws IllegalArgumentException if the timeout is not {@code -1} or a positive number
+     */
+    public Builder withTimeout(long timeout) {
+      request.timeout = Assert.arg(timeout, timeout >= -1, "timeout must be -1 or greater");
       return this;
     }
 

--- a/server/src/main/java/io/atomix/copycat/server/CopycatServer.java
+++ b/server/src/main/java/io/atomix/copycat/server/CopycatServer.java
@@ -16,16 +16,16 @@
 package io.atomix.copycat.server;
 
 import io.atomix.catalyst.buffer.PooledHeapAllocator;
+import io.atomix.catalyst.concurrent.Futures;
+import io.atomix.catalyst.concurrent.Listener;
+import io.atomix.catalyst.concurrent.SingleThreadContext;
+import io.atomix.catalyst.concurrent.ThreadContext;
 import io.atomix.catalyst.serializer.Serializer;
 import io.atomix.catalyst.transport.Address;
 import io.atomix.catalyst.transport.Server;
 import io.atomix.catalyst.transport.Transport;
 import io.atomix.catalyst.util.Assert;
 import io.atomix.catalyst.util.ConfigurationException;
-import io.atomix.catalyst.concurrent.Listener;
-import io.atomix.catalyst.concurrent.Futures;
-import io.atomix.catalyst.concurrent.SingleThreadContext;
-import io.atomix.catalyst.concurrent.ThreadContext;
 import io.atomix.copycat.Command;
 import io.atomix.copycat.Query;
 import io.atomix.copycat.protocol.ClientRequestTypeResolver;
@@ -463,9 +463,9 @@ public class CopycatServer {
    * <p>
    * The thread context is the event loop that this server uses to communicate other Raft servers.
    * Implementations must guarantee that all asynchronous {@link java.util.concurrent.CompletableFuture} callbacks are
-   * executed on a single thread via the returned {@link io.atomix.catalyst.util.concurrent.ThreadContext}.
+   * executed on a single thread via the returned {@link io.atomix.catalyst.concurrent.ThreadContext}.
    * <p>
-   * The {@link io.atomix.catalyst.util.concurrent.ThreadContext} can also be used to access the Raft server's internal
+   * The {@link io.atomix.catalyst.concurrent.ThreadContext} can also be used to access the Raft server's internal
    * {@link io.atomix.catalyst.serializer.Serializer serializer} via {@link ThreadContext#serializer()}. Catalyst serializers
    * are not thread safe, so to use the context serializer, users should clone it:
    * <pre>


### PR DESCRIPTION
This PR implements configurable per-client session timeouts. By default, the existing configurable server session timeout will be used, but clients can override it in the client builder:
```java
CopycatClient client = CopycatClient.builder()
  .withSessionTimeout(Duration.ofSeconds(5))
  ...
  .build();
```