### PR TITLE
Ensure follower commitIndex is not increased beyond AppendRequest entry index

### DIFF
--- a/server/src/test/java/io/atomix/copycat/server/state/MemberTest.java
+++ b/server/src/test/java/io/atomix/copycat/server/state/MemberTest.java
@@ -71,8 +71,8 @@ public class MemberTest {
     member.update(Member.Type.INACTIVE, instant);
     assertEquals(member.type(), Member.Type.INACTIVE);
     assertEquals(member.updated(), instant);
-    member.update(ServerMember.Status.UNAVAILABLE, instant);
     instant = Instant.now();
+    member.update(ServerMember.Status.UNAVAILABLE, instant);
     assertEquals(member.status(), ServerMember.Status.UNAVAILABLE);
     assertNull(member.clientAddress());
     assertEquals(member.updated(), instant);


### PR DESCRIPTION
This PR fixes #265 by simply following the solution in the Raft paper. The change simply ensures that the follower's `commitIndex` cannot be increased beyond the index of the last entry in an `AppendRequest` to ensure that consistency checks occur prior to committing an entry.