### PR TITLE
Implement AppendRequest commit index fix in ActiveState

### DIFF
--- a/server/src/main/java/io/atomix/copycat/server/state/PassiveState.java
+++ b/server/src/main/java/io/atomix/copycat/server/state/PassiveState.java
@@ -211,6 +211,7 @@ class PassiveState extends ReserveState {
     }
 
     // Update the context commit and global indices.
+    LOGGER.debug("{} - Committed entries up to index {}", context.getCluster().member().address(), commitIndex);
     context.setCommitIndex(commitIndex);
     context.setGlobalIndex(request.globalIndex());
 


### PR DESCRIPTION
This PR is actually an additional fix for #265. The original commit only fixed the issue in `PassiveState`, but since `appendEntries` is overridden in `ActiveState`, it was not fixed for Raft nodes where it's most important. So, we simply implement the same fix in `ActiveState.appendEntries`