### PR TITLE
Ensure ServerSelectionStrategies.FOLLOWERS can connect to single node

### DIFF
--- a/client/src/main/java/io/atomix/copycat/client/ServerSelectionStrategies.java
+++ b/client/src/main/java/io/atomix/copycat/client/ServerSelectionStrategies.java
@@ -79,7 +79,7 @@ public enum ServerSelectionStrategies implements ServerSelectionStrategy {
     @Override
     public List<Address> selectConnections(Address leader, List<Address> servers) {
       Collections.shuffle(servers);
-      if (leader != null) {
+      if (leader != null && servers.size() > 1) {
         List<Address> results = new ArrayList<>(servers.size());
         for (Address address : servers) {
           if (!address.equals(leader)) {


### PR DESCRIPTION
The `ServerSelectionStrategies.FOLLOWERS` strategy does not work properly in a single node cluster. This PR adds a check for the number of nodes in the cluster to ensure the client can connect to a single node/leader cluster.