### PR TITLE
Override old sessions when a new session is registered from the same client

### DIFF
--- a/server/src/main/java/io/atomix/copycat/server/state/ServerSessionContext.java
+++ b/server/src/main/java/io/atomix/copycat/server/state/ServerSessionContext.java
@@ -641,7 +641,9 @@ class ServerSessionContext implements ServerSession {
     // If no references to session commands are open, release session-related entries.
     if (references == 0) {
       log.release(id);
-      log.release(index);
+      if (index > 0) {
+        log.release(index);
+      }
     } else {
       this.closeIndex = index;
     }

--- a/server/src/main/java/io/atomix/copycat/server/state/ServerSessionManager.java
+++ b/server/src/main/java/io/atomix/copycat/server/state/ServerSessionManager.java
@@ -94,10 +94,14 @@ class ServerSessionManager implements Sessions {
    * Registers a session.
    */
   ServerSessionContext registerSession(ServerSessionContext session) {
+    ServerSessionContext oldSession = clients.remove(session.client());
+    if (oldSession != null) {
+      sessions.remove(oldSession.id());
+    }
     session.setConnection(connections.get(session.client()));
     sessions.put(session.id(), session);
     clients.put(session.client(), session);
-    return session;
+    return oldSession;
   }
 
   /**


### PR DESCRIPTION
This PR improves session management in Copycat servers by proactively expiring past sessions from a client when the client registers a new session. This can occur if the client is partitioned from the cluster and decides to expire its own session. In order to simplify state machines, it's best to ensure that each client can only hold one session at a time.