### PR TITLE
Ensure correct leader address is returned by followers

### DIFF
--- a/server/src/main/java/io/atomix/copycat/server/state/PassiveState.java
+++ b/server/src/main/java/io/atomix/copycat/server/state/PassiveState.java
@@ -74,7 +74,8 @@ class PassiveState extends ReserveState {
     context.checkThread();
     logRequest(request);
 
-    if (context.getLeader() == null) {
+    Member leader = context.getLeader();
+    if (leader == null) {
       return CompletableFuture.completedFuture(logResponse(ConnectResponse.builder()
         .withStatus(Response.Status.ERROR)
         .withError(CopycatError.Type.NO_LEADER_ERROR)
@@ -85,7 +86,7 @@ class PassiveState extends ReserveState {
 
       return CompletableFuture.completedFuture(ConnectResponse.builder()
         .withStatus(Response.Status.OK)
-        .withLeader(context.getLeader().clientAddress())
+        .withLeader(leader.clientAddress())
         .withMembers(context.getCluster().members().stream()
           .map(Member::clientAddress)
           .filter(m -> m != null)

--- a/server/src/main/java/io/atomix/copycat/server/state/PassiveState.java
+++ b/server/src/main/java/io/atomix/copycat/server/state/PassiveState.java
@@ -85,7 +85,7 @@ class PassiveState extends ReserveState {
 
       return CompletableFuture.completedFuture(ConnectResponse.builder()
         .withStatus(Response.Status.OK)
-        .withLeader(context.getCluster().member().clientAddress())
+        .withLeader(context.getLeader().clientAddress())
         .withMembers(context.getCluster().members().stream()
           .map(Member::clientAddress)
           .filter(m -> m != null)


### PR DESCRIPTION
This PR fixes a bug in the `ConnectResponse` sent by followers/passive nodes. These nodes were sending the local address as the leader. When a client uses a `FOLLOWERS` connection strategy, this can cause the client to continuously switch servers trying to get away from the leader.