### PR TITLE
Ensure segment lock is flushed to disk prior to deleting compacted segments

### DIFF
--- a/server/src/main/java/io/atomix/copycat/server/storage/SegmentManager.java
+++ b/server/src/main/java/io/atomix/copycat/server/storage/SegmentManager.java
@@ -264,6 +264,7 @@ public class SegmentManager implements AutoCloseable {
     // Update the segment descriptor and lock the segment.
     segment.descriptor().update(System.currentTimeMillis());
     segment.descriptor().lock();
+    segment.flush();
 
     // Iterate through old segments and remove them from the segments list.
     for (Segment oldSegment : segments) {


### PR DESCRIPTION
This PR fixes a bug that can cause logs to be lost if a node crashes shortly after compaction. Because the segment lock is not flushed to disk prior to deleting compacted segments, it's possible compacted segments could be deleted while an unlocked segment is still on disk, thus causing the server to delete the unlocked segment on restart. Use `getFD().sync()` to ensure the lock is on disk prior to deleting compacted segments.