### PR TITLE
Fix misaligned lock in segment file headers

### DIFF
--- a/server/src/main/java/io/atomix/copycat/server/storage/SegmentDescriptor.java
+++ b/server/src/main/java/io/atomix/copycat/server/storage/SegmentDescriptor.java
@@ -96,8 +96,8 @@ public final class SegmentDescriptor implements AutoCloseable {
   private final long index;
   private final long maxSegmentSize;
   private final int maxEntries;
-  private long updated;
-  private boolean locked;
+  private volatile long updated;
+  private volatile boolean locked;
 
   /**
    * @throws NullPointerException if {@code buffer} is null

--- a/server/src/main/java/io/atomix/copycat/server/storage/SegmentDescriptor.java
+++ b/server/src/main/java/io/atomix/copycat/server/storage/SegmentDescriptor.java
@@ -224,7 +224,6 @@ public final class SegmentDescriptor implements AutoCloseable {
       .writeLong(updated)
       .writeBoolean(locked)
       .skip(BYTES - buffer.position())
-      .flip()
       .flush();
     return this;
   }

--- a/server/src/main/java/io/atomix/copycat/server/storage/SegmentDescriptor.java
+++ b/server/src/main/java/io/atomix/copycat/server/storage/SegmentDescriptor.java
@@ -96,7 +96,7 @@ public final class SegmentDescriptor implements AutoCloseable {
     this.maxEntries = buffer.readInt();
     this.updated = buffer.readLong();
     this.locked = buffer.readBoolean();
-    buffer.skip(64 - buffer.position()); // 64 bytes reserved for the header
+    buffer.skip(BYTES - buffer.position()); // 64 bytes reserved for the header
   }
 
   /**

--- a/server/src/main/java/io/atomix/copycat/server/storage/SegmentDescriptor.java
+++ b/server/src/main/java/io/atomix/copycat/server/storage/SegmentDescriptor.java
@@ -51,22 +51,22 @@ public final class SegmentDescriptor implements AutoCloseable {
   public static final int BYTES = 64;
 
   // The lengths of each field in the header.
-  private static final int ID_LENGTH               = Bytes.LONG;    // 64-bit signed integer
-  private static final int VERSION_LENGTH          = Bytes.LONG;    // 64-bit signed integer
-  private static final int INDEX_LENGTH            = Bytes.LONG;    // 64-bit signed integer
-  private static final int MAX_SEGMENT_SIZE_LENGTH = Bytes.INTEGER; // 32-bit unsigned integer
-  private static final int MAX_ENTRIES_LENGTH      = Bytes.INTEGER; // 32-bit signed integer
-  private static final int UPDATED_LENGTH          = Bytes.LONG;    // 64-bit signed integer
-  private static final int LOCKED_LENGTH           = Bytes.BOOLEAN; // 8-bit boolean
+  private static final int          ID_LENGTH = Bytes.LONG;    // 64-bit signed integer
+  private static final int     VERSION_LENGTH = Bytes.LONG;    // 64-bit signed integer
+  private static final int       INDEX_LENGTH = Bytes.LONG;    // 64-bit signed integer
+  private static final int    MAX_SIZE_LENGTH = Bytes.INTEGER; // 32-bit unsigned integer
+  private static final int MAX_ENTRIES_LENGTH = Bytes.INTEGER; // 32-bit signed integer
+  private static final int     UPDATED_LENGTH = Bytes.LONG;    // 64-bit signed integer
+  private static final int      LOCKED_LENGTH = Bytes.BOOLEAN; // 8-bit boolean
 
   // The positions of each field in the header.
-  private static final long ID_POSITION               = 0;
-  private static final long VERSION_POSITION          = ID_POSITION + ID_LENGTH;
-  private static final long INDEX_POSITION            = VERSION_POSITION + VERSION_LENGTH;
-  private static final long MAX_SEGMENT_SIZE_POSITION = INDEX_POSITION + INDEX_LENGTH;
-  private static final long MAX_ENTRIES_POSITION      = MAX_SEGMENT_SIZE_POSITION + MAX_SEGMENT_SIZE_LENGTH;
-  private static final long UPDATED_POSITION          = MAX_ENTRIES_POSITION + MAX_ENTRIES_LENGTH;
-  private static final long LOCKED_POSITION           = UPDATED_POSITION + UPDATED_LENGTH;
+  private static final long          ID_POSITION = 0;                                         // 0
+  private static final long     VERSION_POSITION = ID_POSITION + ID_LENGTH;                   // 8
+  private static final long       INDEX_POSITION = VERSION_POSITION + VERSION_LENGTH;         // 16
+  private static final long    MAX_SIZE_POSITION = INDEX_POSITION + INDEX_LENGTH;             // 24
+  private static final long MAX_ENTRIES_POSITION = MAX_SIZE_POSITION + MAX_SIZE_LENGTH;       // 28
+  private static final long     UPDATED_POSITION = MAX_ENTRIES_POSITION + MAX_ENTRIES_LENGTH; // 32
+  private static final long      LOCKED_POSITION = UPDATED_POSITION + UPDATED_LENGTH;         // 40
 
   /**
    * Returns a descriptor builder.

--- a/server/src/test/java/io/atomix/copycat/server/storage/SegmentDescriptorTest.java
+++ b/server/src/test/java/io/atomix/copycat/server/storage/SegmentDescriptorTest.java
@@ -17,13 +17,14 @@ package io.atomix.copycat.server.storage;
 
 import io.atomix.catalyst.buffer.Buffer;
 import io.atomix.catalyst.buffer.FileBuffer;
-import org.testng.Assert;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.Test;
 
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
+
+import static org.testng.Assert.*;
 
 /**
  * Segment descriptor test.
@@ -46,20 +47,20 @@ public class SegmentDescriptorTest {
       .withMaxEntries(2048)
       .build();
 
-    Assert.assertEquals(descriptor.id(), 2);
-    Assert.assertEquals(descriptor.version(), 3);
-    Assert.assertEquals(descriptor.index(), 1025);
-    Assert.assertEquals(descriptor.maxSegmentSize(), 1024 * 1024);
-    Assert.assertEquals(descriptor.maxEntries(), 2048);
+    assertEquals(descriptor.id(), 2);
+    assertEquals(descriptor.version(), 3);
+    assertEquals(descriptor.index(), 1025);
+    assertEquals(descriptor.maxSegmentSize(), 1024 * 1024);
+    assertEquals(descriptor.maxEntries(), 2048);
 
-    Assert.assertEquals(descriptor.updated(), 0);
+    assertEquals(descriptor.updated(), 0);
     long time = System.currentTimeMillis();
     descriptor.update(time);
-    Assert.assertEquals(descriptor.updated(), time);
+    assertEquals(descriptor.updated(), time);
 
-    Assert.assertFalse(descriptor.locked());
+    assertFalse(descriptor.locked());
     descriptor.lock();
-    Assert.assertTrue(descriptor.locked());
+    assertTrue(descriptor.locked());
   }
 
   /**
@@ -75,20 +76,34 @@ public class SegmentDescriptorTest {
       .withMaxEntries(2048)
       .build();
 
-    Assert.assertEquals(descriptor.id(), 2);
-    Assert.assertEquals(descriptor.version(), 3);
-    Assert.assertEquals(descriptor.index(), 1025);
-    Assert.assertEquals(descriptor.maxSegmentSize(), 1024 * 1024);
-    Assert.assertEquals(descriptor.maxEntries(), 2048);
+    assertEquals(descriptor.id(), 2);
+    assertEquals(descriptor.version(), 3);
+    assertEquals(descriptor.index(), 1025);
+    assertEquals(descriptor.maxSegmentSize(), 1024 * 1024);
+    assertEquals(descriptor.maxEntries(), 2048);
 
     buffer.close();
 
     descriptor = new SegmentDescriptor(FileBuffer.allocate(file, SegmentDescriptor.BYTES));
 
-    Assert.assertEquals(descriptor.id(), 2);
-    Assert.assertEquals(descriptor.version(), 3);
-    Assert.assertEquals(descriptor.index(), 1025);
-    Assert.assertEquals(descriptor.maxSegmentSize(), 1024 * 1024);
+    assertEquals(descriptor.id(), 2);
+    assertEquals(descriptor.version(), 3);
+    assertEquals(descriptor.index(), 1025);
+    assertEquals(descriptor.maxSegmentSize(), 1024 * 1024);
+    assertFalse(descriptor.locked());
+
+    descriptor.lock();
+    assertTrue(descriptor.locked());
+
+    descriptor.close();
+
+    descriptor = new SegmentDescriptor(FileBuffer.allocate(file, SegmentDescriptor.BYTES));
+
+    assertEquals(descriptor.id(), 2);
+    assertEquals(descriptor.version(), 3);
+    assertEquals(descriptor.index(), 1025);
+    assertEquals(descriptor.maxSegmentSize(), 1024 * 1024);
+    assertTrue(descriptor.locked());
   }
 
   /**
@@ -109,13 +124,13 @@ public class SegmentDescriptorTest {
 
     descriptor = descriptor.copyTo(FileBuffer.allocate(file, SegmentDescriptor.BYTES));
 
-    Assert.assertEquals(descriptor.id(), 2);
-    Assert.assertEquals(descriptor.version(), 3);
-    Assert.assertEquals(descriptor.index(), 1025);
-    Assert.assertEquals(descriptor.maxSegmentSize(), 1024 * 1024);
-    Assert.assertEquals(descriptor.maxEntries(), 2048);
-    Assert.assertEquals(descriptor.updated(), time);
-    Assert.assertTrue(descriptor.locked());
+    assertEquals(descriptor.id(), 2);
+    assertEquals(descriptor.version(), 3);
+    assertEquals(descriptor.index(), 1025);
+    assertEquals(descriptor.maxSegmentSize(), 1024 * 1024);
+    assertEquals(descriptor.maxEntries(), 2048);
+    assertEquals(descriptor.updated(), time);
+    assertTrue(descriptor.locked());
   }
 
   /**


### PR DESCRIPTION
This PR fixes a bug wherein segment headers were being improperly written when locked. This could result in a server improperly deleting a compacted segment after a failure, believing the segment to simply be partially compacted.