### PR TITLE
Allow compactor to interrupt compaction threads on shutdown

### DIFF
--- a/server/src/main/java/io/atomix/copycat/server/storage/compaction/Compactor.java
+++ b/server/src/main/java/io/atomix/copycat/server/storage/compaction/Compactor.java
@@ -235,9 +235,9 @@ public class Compactor implements AutoCloseable {
   @Override
   public void close() {
     if (minor != null)
-      minor.cancel(false);
+      minor.cancel(true);
     if (major != null)
-      major.cancel(false);
+      major.cancel(true);
 
     executor.shutdown();
     try {


### PR DESCRIPTION
This PR allows the `Compactor` to interrupt compaction threads on shutdown. This is necessary since compaction threads will end up getting exceptions once the `Log` is shutdown anyways. The compaction algorithm protects against partially compacted segments and will clean up those segments on restart. We may, however, want to clean them up more gracefully when the server is shut down during compaction in the future.