### PR TITLE
Ensure server is shut down if cluster leave() fails on leave()

### DIFF
--- a/server/src/main/java/io/atomix/copycat/server/state/LeaderState.java
+++ b/server/src/main/java/io/atomix/copycat/server/state/LeaderState.java
@@ -507,10 +507,10 @@ final class LeaderState extends ActiveState {
       // If the request sequence number is more than 1k requests above the last sequenced request, reject the request.
       // The client should resubmit a request that fails with a COMMAND_ERROR.
       if (request.sequence() - session.getRequestSequence() > MAX_REQUEST_QUEUE_SIZE) {
-        future.complete(CommandResponse.builder()
+        future.complete(logResponse(CommandResponse.builder()
           .withStatus(Response.Status.ERROR)
           .withError(CopycatError.Type.COMMAND_ERROR)
-          .build());
+          .build()));
       }
       // Register the request in the request queue if it's not too far ahead of the current sequence number.
       else {


### PR DESCRIPTION
This PR is a minor cleanup of the server `leave()` method that ensures the server is `shutdown()` if `Cluster.leave()` fails.