### PR TITLE
Ensure apply() is completed exceptionally on unexpected exceptions in ServerStateMachine

### DIFF
--- a/server/src/main/java/io/atomix/copycat/server/state/ServerStateMachine.java
+++ b/server/src/main/java/io/atomix/copycat/server/state/ServerStateMachine.java
@@ -309,12 +309,12 @@ final class ServerStateMachine implements AutoCloseable {
         } else {
           return CompletableFuture.completedFuture(null);
         }
-      } finally {
-        setLastApplied(index);
       }
     } catch (Exception e) {
       e.printStackTrace();
       return Futures.exceptionalFuture(e);
+    } finally {
+      setLastApplied(index);
     }
   }
 


### PR DESCRIPTION
This PR adds a simple try-catch block to `apply` in `ServerStateMachine` to ensure that commands are completed exceptionally when unexpected errors occur and that exception information is properly logged.