### PR TITLE
Force reset of client connection when connection attempts have been exhausted

### DIFF
--- a/client/src/main/java/io/atomix/copycat/client/util/ClientConnection.java
+++ b/client/src/main/java/io/atomix/copycat/client/util/ClientConnection.java
@@ -127,7 +127,7 @@ public class ClientConnection implements Connection {
         if (connection != null) {
           connection.<T, U>send(request).whenComplete((r, e) -> handleResponse(request, r, e, future));
         } else {
-          future.completeExceptionally(new ConnectException("failed to connect"));
+          reset().next().whenComplete((c, e) -> sendRequest(request, c, e, future));
         }
       } else {
         LOGGER.debug("{} - Resetting connection. Reason: {}", id, error);


### PR DESCRIPTION
This PR is a simple fix to ensure that `ClientConnection` resets connection attempts when clients retry commands. Currently, when a client has exhausted all its connection attempts, commands will repeatedly fail since `connection` is `null` until the next `KeepAliveRequest` is attempted, resetting connection attempts. The way clients retry commands is an inefficiency that will be addressed in a separate PR.