### PR TITLE
Add checksums and in-memory buffering to log entries

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
     <java.version>1.8</java.version>
     <slf4j.version>1.7.7</slf4j.version>
     <logback.version>1.1.2</logback.version>
-    <catalyst.version>1.1.2</catalyst.version>
+    <catalyst.version>1.1.3-SNAPSHOT</catalyst.version>
 
     <maven.source.plugin.version>2.2.1</maven.source.plugin.version>
     <maven.compiler.plugin.version>3.0</maven.compiler.plugin.version>

--- a/server/src/main/java/io/atomix/copycat/server/storage/SegmentManager.java
+++ b/server/src/main/java/io/atomix/copycat/server/storage/SegmentManager.java
@@ -28,6 +28,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.File;
+import java.nio.ByteOrder;
 import java.util.Collection;
 import java.util.Map;
 import java.util.NavigableMap;

--- a/server/src/main/java/io/atomix/copycat/server/storage/snapshot/SnapshotReader.java
+++ b/server/src/main/java/io/atomix/copycat/server/storage/snapshot/SnapshotReader.java
@@ -15,6 +15,8 @@
  */
 package io.atomix.copycat.server.storage.snapshot;
 
+import java.nio.charset.Charset;
+
 import io.atomix.catalyst.buffer.Buffer;
 import io.atomix.catalyst.buffer.BufferInput;
 import io.atomix.catalyst.buffer.Bytes;
@@ -169,6 +171,11 @@ public class SnapshotReader implements BufferInput<SnapshotReader> {
   @Override
   public String readString() {
     return buffer.readString();
+  }
+
+  @Override
+  public String readString(Charset charset) {
+    return buffer.readString(charset);
   }
 
   @Override

--- a/server/src/main/java/io/atomix/copycat/server/storage/snapshot/SnapshotWriter.java
+++ b/server/src/main/java/io/atomix/copycat/server/storage/snapshot/SnapshotWriter.java
@@ -15,6 +15,8 @@
  */
 package io.atomix.copycat.server.storage.snapshot;
 
+import java.nio.charset.Charset;
+
 import io.atomix.catalyst.buffer.Buffer;
 import io.atomix.catalyst.buffer.BufferOutput;
 import io.atomix.catalyst.buffer.Bytes;
@@ -167,6 +169,12 @@ public class SnapshotWriter implements BufferOutput<SnapshotWriter> {
   @Override
   public SnapshotWriter writeString(String s) {
     buffer.writeString(s);
+    return this;
+  }
+
+  @Override
+  public SnapshotWriter writeString(String s, Charset charset) {
+    buffer.writeString(s, charset);
     return this;
   }
 


### PR DESCRIPTION
This PR adds checksums to all entries in the Copycat log. This is necessary to guard against entries that can be corrupted by crashes during writes. The checksums are implemented using CRC-32 and are stored as 32-bit unsigned integers. To compute checksums, entries are serialized in memory before being written to disk, and entries are read into an in-memory buffer and the checksum is computed prior to deserialization. In the event that a checksum fails when recovering from disk, all entries following the corrupted entry are discarded. This is safe since we ensure entries are fsynced prior to a commit, so only uncommitted entries should be corrupted and therefore can be discarded. In the event an entry is corrupted during compaction, the partially compacted file will not be committed.