### PR TITLE
always persist <term,vote> metadata on disk

### DIFF
--- a/server/src/main/java/io/atomix/copycat/server/storage/Storage.java
+++ b/server/src/main/java/io/atomix/copycat/server/storage/Storage.java
@@ -15,8 +15,8 @@
  */
 package io.atomix.copycat.server.storage;
 
-import io.atomix.catalyst.util.Assert;
 import io.atomix.catalyst.concurrent.ThreadContext;
+import io.atomix.catalyst.util.Assert;
 import io.atomix.copycat.server.storage.snapshot.SnapshotFile;
 import io.atomix.copycat.server.storage.snapshot.SnapshotStore;
 import io.atomix.copycat.server.storage.system.MetaStore;
@@ -275,7 +275,9 @@ public class Storage {
    */
   public void deleteMetaStore(String name) {
     StorageCleaner cleaner = new StorageCleaner(this);
-    cleaner.cleanFiles(f -> f.getName().equals(String.format("%s.meta", name)));
+    cleaner.cleanFiles(f -> f.getName().equals(String.format("%s.meta", name)) ||
+      f.getName().equals(String.format("%s.conf", name))
+    );
   }
 
   /**

--- a/server/src/test/java/io/atomix/copycat/server/state/AbstractStateTest.java
+++ b/server/src/test/java/io/atomix/copycat/server/state/AbstractStateTest.java
@@ -42,6 +42,8 @@ import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
@@ -58,6 +60,7 @@ public abstract class AbstractStateTest<T extends AbstractState> extends Concurr
   protected LocalTransport transport;
   protected ServerContext serverContext;
   protected List<Member> members;
+  protected Path storageDir;
 
   /**
    * Sets up a server state.
@@ -73,7 +76,8 @@ public abstract class AbstractStateTest<T extends AbstractState> extends Concurr
       new StorageSerialization()
     ).disableWhitelist();
 
-    storage = new Storage(StorageLevel.MEMORY);
+    storageDir = Files.createTempDirectory("copycat-test");
+    storage = Storage.builder().withStorageLevel(StorageLevel.MEMORY).withDirectory(storageDir.toFile()).build();
 
     members = createMembers(3);
     transport = new LocalTransport(new LocalServerRegistry());
@@ -94,6 +98,8 @@ public abstract class AbstractStateTest<T extends AbstractState> extends Concurr
    */
   @AfterMethod
   void afterMethod() throws Throwable {
+    storage.deleteMetaStore("test");
+    Files.delete(storageDir);
     serverCtx.close();
   }
 


### PR DESCRIPTION
this patch is to enable option (1) described in https://groups.google.com/forum/#!topic/atomixio/v29s36PvhMs .

basically, I would like to be able to store raft log and cluster configuration in memory while <term,vote> metadata should still be persisted on disk for raft safety.

~~there are some TODOs in the PR , I will finish those once we agree on the change.~~

there is intentional duplication in backward compatibility code so that later it could be removed easily.