### PR TITLE
Client connection/sequencing bug fixes

### DIFF
--- a/client/src/main/java/io/atomix/copycat/client/session/ClientSessionSubmitter.java
+++ b/client/src/main/java/io/atomix/copycat/client/session/ClientSessionSubmitter.java
@@ -347,7 +347,7 @@ final class ClientSessionSubmitter {
           || response.error() == CopycatError.Type.INTERNAL_ERROR) {
           complete(response.error().createException());
         }
-        // For all other errors other than UNKNOWN_SESSION_ERROR, use fibonacci backoff to resubmit the command.
+        // For all other errors, use fibonacci backoff to resubmit the command.
         else {
           retry(Duration.ofSeconds(FIBONACCI[Math.min(attempt-1, FIBONACCI.length-1)]));
         }

--- a/client/src/main/java/io/atomix/copycat/client/util/ClientConnection.java
+++ b/client/src/main/java/io/atomix/copycat/client/util/ClientConnection.java
@@ -143,6 +143,7 @@ public class ClientConnection implements Connection {
           future.completeExceptionally(new ConnectException("Failed to connect to the cluster"));
         }
       } else {
+        LOGGER.trace("{} - Resending {}: {}", id, request, error);
         resendRequest(error, request, sender, connection, future);
       }
     }

--- a/client/src/main/java/io/atomix/copycat/client/util/ClientConnection.java
+++ b/client/src/main/java/io/atomix/copycat/client/util/ClientConnection.java
@@ -204,7 +204,7 @@ public class ClientConnection implements Connection {
       }
 
       CompletableFuture<Connection> future = new OrderedCompletableFuture<>();
-      connectFuture.whenComplete((r, e) -> this.connectFuture = null);
+      future.whenComplete((r, e) -> this.connectFuture = null);
       this.connectFuture = future;
 
       Connection oldConnection = this.connection;

--- a/client/src/main/java/io/atomix/copycat/client/util/ClientConnection.java
+++ b/client/src/main/java/io/atomix/copycat/client/util/ClientConnection.java
@@ -177,7 +177,8 @@ public class ClientConnection implements Connection {
           || response.error() == CopycatError.Type.COMMAND_ERROR
           || response.error() == CopycatError.Type.QUERY_ERROR
           || response.error() == CopycatError.Type.APPLICATION_ERROR
-          || response.error() == CopycatError.Type.UNKNOWN_SESSION_ERROR) {
+          || response.error() == CopycatError.Type.UNKNOWN_SESSION_ERROR
+          || response.error() == CopycatError.Type.INTERNAL_ERROR) {
           LOGGER.trace("{} - Received {}", id, response);
           future.complete(response);
         } else {

--- a/client/src/main/java/io/atomix/copycat/client/util/ClientConnection.java
+++ b/client/src/main/java/io/atomix/copycat/client/util/ClientConnection.java
@@ -203,14 +203,15 @@ public class ClientConnection implements Connection {
         return connectFuture;
       }
 
-      connectFuture = new OrderedCompletableFuture<>();
-      connectFuture.whenComplete((r, e) -> connectFuture = null);
+      CompletableFuture<Connection> future = new OrderedCompletableFuture<>();
+      connectFuture.whenComplete((r, e) -> this.connectFuture = null);
+      this.connectFuture = future;
 
       Connection oldConnection = this.connection;
       this.connection = null;
       oldConnection.close();
-      connect(connectFuture);
-      return connectFuture;
+      connect(future);
+      return future;
     }
 
     // If a connection was already established then use that connection.
@@ -224,10 +225,11 @@ public class ClientConnection implements Connection {
     }
 
     // Create a new connect future and connect to the first server in the cluster.
-    connectFuture = new OrderedCompletableFuture<>();
-    connectFuture.whenComplete((r, e) -> connectFuture = null);
-    reset().connect(connectFuture);
-    return connectFuture;
+    CompletableFuture<Connection> future = new OrderedCompletableFuture<>();
+    future.whenComplete((r, e) -> this.connectFuture = null);
+    this.connectFuture = future;
+    reset().connect(future);
+    return future;
   }
 
   /**

--- a/client/src/main/java/io/atomix/copycat/client/util/ClientConnection.java
+++ b/client/src/main/java/io/atomix/copycat/client/util/ClientConnection.java
@@ -202,6 +202,7 @@ public class ClientConnection implements Connection {
       }
 
       connectFuture = new OrderedCompletableFuture<>();
+      connectFuture.whenComplete((r, e) -> connectFuture = null);
 
       Connection oldConnection = this.connection;
       this.connection = null;
@@ -222,6 +223,7 @@ public class ClientConnection implements Connection {
 
     // Create a new connect future and connect to the first server in the cluster.
     connectFuture = new OrderedCompletableFuture<>();
+    connectFuture.whenComplete((r, e) -> connectFuture = null);
     reset().connect(connectFuture);
     return connectFuture;
   }

--- a/client/src/main/java/io/atomix/copycat/client/util/OrderedCompletableFuture.java
+++ b/client/src/main/java/io/atomix/copycat/client/util/OrderedCompletableFuture.java
@@ -1,0 +1,246 @@
+package io.atomix.copycat.client.util;
+
+import java.util.LinkedList;
+import java.util.Queue;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.Executor;
+import java.util.function.BiConsumer;
+import java.util.function.BiFunction;
+import java.util.function.Consumer;
+import java.util.function.Function;
+
+/**
+ * A {@link CompletableFuture} that ensures callbacks are called in FIFO order.
+ * <p>
+ * The default {@link CompletableFuture} does not guarantee the ordering of callbacks, and indeed appears to
+ * execute then in LIFO order. This future guarantees callbacks will be called in FIFO order. Additionally,
+ * {@link CompletionStage}s returned by this future are guaranteed to be ordered as well.
+ */
+public class OrderedCompletableFuture<T> extends CompletableFuture<T> {
+  private final Queue<CompletableFuture<T>> orderedFutures = new LinkedList<>();
+
+  /**
+   * Adds a new ordered future.
+   */
+  private CompletableFuture<T> orderedFuture() {
+    synchronized (orderedFutures) {
+      if (orderedFutures.isEmpty()) {
+        super.whenComplete(this::completeFutures);
+      }
+
+      CompletableFuture<T> future = new OrderedCompletableFuture<>();
+      orderedFutures.add(future);
+      return future;
+    }
+  }
+
+  /**
+   * Completes futures in FIFO order.
+   */
+  private void completeFutures(T result, Throwable error) {
+    if (error == null) {
+      synchronized (orderedFutures) {
+        for (CompletableFuture<T> future : orderedFutures) {
+          future.complete(result);
+        }
+      }
+    } else {
+      synchronized (orderedFutures) {
+        for (CompletableFuture<T> future : orderedFutures) {
+          future.completeExceptionally(error);
+        }
+      }
+    }
+  }
+
+  @Override
+  public <U> CompletableFuture<U> thenApply(Function<? super T, ? extends U> fn) {
+    return orderedFuture().thenApply(fn);
+  }
+
+  @Override
+  public <U> CompletableFuture<U> thenApplyAsync(Function<? super T, ? extends U> fn) {
+    return orderedFuture().thenApplyAsync(fn);
+  }
+
+  @Override
+  public <U> CompletableFuture<U> thenApplyAsync(Function<? super T, ? extends U> fn, Executor executor) {
+    return orderedFuture().thenApplyAsync(fn, executor);
+  }
+
+  @Override
+  public CompletableFuture<Void> thenAccept(Consumer<? super T> action) {
+    return orderedFuture().thenAccept(action);
+  }
+
+  @Override
+  public CompletableFuture<Void> thenAcceptAsync(Consumer<? super T> action) {
+    return orderedFuture().thenAcceptAsync(action);
+  }
+
+  @Override
+  public CompletableFuture<Void> thenAcceptAsync(Consumer<? super T> action, Executor executor) {
+    return orderedFuture().thenAcceptAsync(action, executor);
+  }
+
+  @Override
+  public CompletableFuture<Void> thenRun(Runnable action) {
+    return orderedFuture().thenRun(action);
+  }
+
+  @Override
+  public CompletableFuture<Void> thenRunAsync(Runnable action) {
+    return orderedFuture().thenRunAsync(action);
+  }
+
+  @Override
+  public CompletableFuture<Void> thenRunAsync(Runnable action, Executor executor) {
+    return orderedFuture().thenRunAsync(action, executor);
+  }
+
+  @Override
+  public <U, V> CompletableFuture<V> thenCombine(CompletionStage<? extends U> other, BiFunction<? super T, ? super U, ? extends V> fn) {
+    return orderedFuture().thenCombine(other, fn);
+  }
+
+  @Override
+  public <U, V> CompletableFuture<V> thenCombineAsync(CompletionStage<? extends U> other, BiFunction<? super T, ? super U, ? extends V> fn) {
+    return orderedFuture().thenCombineAsync(other, fn);
+  }
+
+  @Override
+  public <U, V> CompletableFuture<V> thenCombineAsync(CompletionStage<? extends U> other, BiFunction<? super T, ? super U, ? extends V> fn, Executor executor) {
+    return orderedFuture().thenCombineAsync(other, fn, executor);
+  }
+
+  @Override
+  public <U> CompletableFuture<Void> thenAcceptBoth(CompletionStage<? extends U> other, BiConsumer<? super T, ? super U> action) {
+    return orderedFuture().thenAcceptBoth(other, action);
+  }
+
+  @Override
+  public <U> CompletableFuture<Void> thenAcceptBothAsync(CompletionStage<? extends U> other, BiConsumer<? super T, ? super U> action) {
+    return orderedFuture().thenAcceptBothAsync(other, action);
+  }
+
+  @Override
+  public <U> CompletableFuture<Void> thenAcceptBothAsync(CompletionStage<? extends U> other, BiConsumer<? super T, ? super U> action, Executor executor) {
+    return orderedFuture().thenAcceptBothAsync(other, action, executor);
+  }
+
+  @Override
+  public CompletableFuture<Void> runAfterBoth(CompletionStage<?> other, Runnable action) {
+    return orderedFuture().runAfterBoth(other, action);
+  }
+
+  @Override
+  public CompletableFuture<Void> runAfterBothAsync(CompletionStage<?> other, Runnable action) {
+    return orderedFuture().runAfterBothAsync(other, action);
+  }
+
+  @Override
+  public CompletableFuture<Void> runAfterBothAsync(CompletionStage<?> other, Runnable action, Executor executor) {
+    return orderedFuture().runAfterBothAsync(other, action, executor);
+  }
+
+  @Override
+  public <U> CompletableFuture<U> applyToEither(CompletionStage<? extends T> other, Function<? super T, U> fn) {
+    return orderedFuture().applyToEither(other, fn);
+  }
+
+  @Override
+  public <U> CompletableFuture<U> applyToEitherAsync(CompletionStage<? extends T> other, Function<? super T, U> fn) {
+    return orderedFuture().applyToEitherAsync(other, fn);
+  }
+
+  @Override
+  public <U> CompletableFuture<U> applyToEitherAsync(CompletionStage<? extends T> other, Function<? super T, U> fn, Executor executor) {
+    return orderedFuture().applyToEitherAsync(other, fn, executor);
+  }
+
+  @Override
+  public CompletableFuture<Void> acceptEither(CompletionStage<? extends T> other, Consumer<? super T> action) {
+    return orderedFuture().acceptEither(other, action);
+  }
+
+  @Override
+  public CompletableFuture<Void> acceptEitherAsync(CompletionStage<? extends T> other, Consumer<? super T> action) {
+    return orderedFuture().acceptEitherAsync(other, action);
+  }
+
+  @Override
+  public CompletableFuture<Void> acceptEitherAsync(CompletionStage<? extends T> other, Consumer<? super T> action, Executor executor) {
+    return orderedFuture().acceptEitherAsync(other, action, executor);
+  }
+
+  @Override
+  public CompletableFuture<Void> runAfterEither(CompletionStage<?> other, Runnable action) {
+    return orderedFuture().runAfterEither(other, action);
+  }
+
+  @Override
+  public CompletableFuture<Void> runAfterEitherAsync(CompletionStage<?> other, Runnable action) {
+    return orderedFuture().runAfterEitherAsync(other, action);
+  }
+
+  @Override
+  public CompletableFuture<Void> runAfterEitherAsync(CompletionStage<?> other, Runnable action, Executor executor) {
+    return orderedFuture().runAfterEitherAsync(other, action, executor);
+  }
+
+  @Override
+  public <U> CompletableFuture<U> thenCompose(Function<? super T, ? extends CompletionStage<U>> fn) {
+    return orderedFuture().thenCompose(fn);
+  }
+
+  @Override
+  public <U> CompletableFuture<U> thenComposeAsync(Function<? super T, ? extends CompletionStage<U>> fn) {
+    return orderedFuture().thenComposeAsync(fn);
+  }
+
+  @Override
+  public <U> CompletableFuture<U> thenComposeAsync(Function<? super T, ? extends CompletionStage<U>> fn, Executor executor) {
+    return orderedFuture().thenComposeAsync(fn, executor);
+  }
+
+  @Override
+  public CompletableFuture<T> whenComplete(BiConsumer<? super T, ? super Throwable> action) {
+    return orderedFuture().whenComplete(action);
+  }
+
+  @Override
+  public CompletableFuture<T> whenCompleteAsync(BiConsumer<? super T, ? super Throwable> action) {
+    return orderedFuture().whenCompleteAsync(action);
+  }
+
+  @Override
+  public CompletableFuture<T> whenCompleteAsync(BiConsumer<? super T, ? super Throwable> action, Executor executor) {
+    return orderedFuture().whenCompleteAsync(action, executor);
+  }
+
+  @Override
+  public <U> CompletableFuture<U> handle(BiFunction<? super T, Throwable, ? extends U> fn) {
+    return orderedFuture().handle(fn);
+  }
+
+  @Override
+  public <U> CompletableFuture<U> handleAsync(BiFunction<? super T, Throwable, ? extends U> fn) {
+    return orderedFuture().handleAsync(fn);
+  }
+
+  @Override
+  public <U> CompletableFuture<U> handleAsync(BiFunction<? super T, Throwable, ? extends U> fn, Executor executor) {
+    return orderedFuture().handleAsync(fn, executor);
+  }
+
+  @Override
+  public CompletableFuture<T> exceptionally(Function<Throwable, ? extends T> fn) {
+    return orderedFuture().exceptionally(fn);
+  }
+
+  @Override
+  public CompletableFuture<T> toCompletableFuture() {
+    return this;
+  }
+}

--- a/client/src/main/java/io/atomix/copycat/client/util/OrderedCompletableFuture.java
+++ b/client/src/main/java/io/atomix/copycat/client/util/OrderedCompletableFuture.java
@@ -14,8 +14,7 @@ import java.util.function.Function;
  * A {@link CompletableFuture} that ensures callbacks are called in FIFO order.
  * <p>
  * The default {@link CompletableFuture} does not guarantee the ordering of callbacks, and indeed appears to
- * execute then in LIFO order. This future guarantees callbacks will be called in FIFO order. Additionally,
- * {@link CompletionStage}s returned by this future are guaranteed to be ordered as well.
+ * execute then in LIFO order.
  */
 public class OrderedCompletableFuture<T> extends CompletableFuture<T> {
   private final Queue<CompletableFuture<T>> orderedFutures = new LinkedList<>();
@@ -29,7 +28,7 @@ public class OrderedCompletableFuture<T> extends CompletableFuture<T> {
         super.whenComplete(this::completeFutures);
       }
 
-      CompletableFuture<T> future = new OrderedCompletableFuture<>();
+      CompletableFuture<T> future = new CompletableFuture<T>();
       orderedFutures.add(future);
       return future;
     }

--- a/client/src/main/java/io/atomix/copycat/client/util/OrderedCompletableFuture.java
+++ b/client/src/main/java/io/atomix/copycat/client/util/OrderedCompletableFuture.java
@@ -14,7 +14,7 @@ import java.util.function.Function;
  * A {@link CompletableFuture} that ensures callbacks are called in FIFO order.
  * <p>
  * The default {@link CompletableFuture} does not guarantee the ordering of callbacks, and indeed appears to
- * execute then in LIFO order.
+ * execute them in LIFO order.
  */
 public class OrderedCompletableFuture<T> extends CompletableFuture<T> {
   private final Queue<CompletableFuture<T>> orderedFutures = new LinkedList<>();

--- a/client/src/test/java/io/atomix/copycat/client/session/ClientSessionManagerTest.java
+++ b/client/src/test/java/io/atomix/copycat/client/session/ClientSessionManagerTest.java
@@ -58,7 +58,15 @@ public class ClientSessionManagerTest {
           new Address("localhost", 5002)
         ))
         .withTimeout(1000)
-        .build()));
+        .build()))
+      .thenReturn(CompletableFuture.completedFuture(KeepAliveResponse.builder()
+        .withStatus(Response.Status.OK)
+        .withLeader(new Address("localhost", 5000))
+        .withMembers(Arrays.asList(
+          new Address("localhost", 5000),
+          new Address("localhost", 5001),
+          new Address("localhost", 5002)
+        )).build()));
 
     ClientSessionState state = new ClientSessionState(UUID.randomUUID().toString());
     ThreadContext context = mock(ThreadContext.class);
@@ -71,7 +79,7 @@ public class ClientSessionManagerTest {
     assertEquals(state.getSessionId(), 1);
     assertEquals(state.getState(), Session.State.OPEN);
 
-    verify(connection).reset(new Address("localhost", 5000), Arrays.asList(
+    verify(connection, times(2)).reset(new Address("localhost", 5000), Arrays.asList(
       new Address("localhost", 5000),
       new Address("localhost", 5001),
       new Address("localhost", 5002)

--- a/client/src/test/java/io/atomix/copycat/client/util/OrderedCompletableFutureTest.java
+++ b/client/src/test/java/io/atomix/copycat/client/util/OrderedCompletableFutureTest.java
@@ -48,7 +48,7 @@ public class OrderedCompletableFutureTest {
    * Tests ordered failure of future callbacks.
    */
   public void testOrderedFailure() throws Throwable {
-    CompletableFuture<String> future = new CompletableFuture<>();
+    CompletableFuture<String> future = new OrderedCompletableFuture<>();
     AtomicInteger order = new AtomicInteger();
     future.whenComplete((r, e) -> assertEquals(1, order.incrementAndGet()));
     future.whenComplete((r, e) -> assertEquals(2, order.incrementAndGet()));
@@ -65,4 +65,22 @@ public class OrderedCompletableFutureTest {
     future.completeExceptionally(new RuntimeException("foo"));
   }
 
+  /**
+   * Tests calling callbacks that are added after completion.
+   */
+  public void testAfterComplete() throws Throwable {
+    CompletableFuture<String> future = new OrderedCompletableFuture<>();
+    future.whenComplete((result, error) -> assertEquals(result, "foo"));
+    future.complete("foo");
+    AtomicInteger count = new AtomicInteger();
+    future.whenComplete((result, error) -> {
+      assertEquals(result, "foo");
+      assertEquals(count.incrementAndGet(), 1);
+    });
+    future.thenAccept(result -> {
+      assertEquals(result, "foo");
+      assertEquals(count.incrementAndGet(), 2);
+    });
+    assertEquals(count.get(), 2);
+  }
 }

--- a/client/src/test/java/io/atomix/copycat/client/util/OrderedCompletableFutureTest.java
+++ b/client/src/test/java/io/atomix/copycat/client/util/OrderedCompletableFutureTest.java
@@ -1,0 +1,68 @@
+package io.atomix.copycat.client.util;
+
+import org.testng.annotations.Test;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.fail;
+
+/**
+ * Ordered completable future test.
+ */
+@Test
+public class OrderedCompletableFutureTest {
+
+  /**
+   * Tests ordered completion of future callbacks.
+   */
+  public void testOrderedCompletion() throws Throwable {
+    CompletableFuture<String> future = new OrderedCompletableFuture<>();
+    AtomicInteger order = new AtomicInteger();
+    future.whenComplete((r, e) -> assertEquals(1, order.incrementAndGet()));
+    future.whenComplete((r, e) -> assertEquals(2, order.incrementAndGet()));
+    future.handle((r, e) -> {
+      assertEquals(3, order.incrementAndGet());
+      assertEquals(r, "foo");
+      return "bar";
+    });
+    future.thenRun(() -> assertEquals(3, order.incrementAndGet()));
+    future.thenAccept(r -> {
+      assertEquals(5, order.incrementAndGet());
+      assertEquals(r, "foo");
+    });
+    future.thenApply(r -> {
+      assertEquals(6, order.incrementAndGet());
+      assertEquals(r, "foo");
+      return "bar";
+    });
+    future.whenComplete((r, e) -> {
+      assertEquals(7, order.incrementAndGet());
+      assertEquals(r, "foo");
+    });
+    future.complete("foo");
+  }
+
+  /**
+   * Tests ordered failure of future callbacks.
+   */
+  public void testOrderedFailure() throws Throwable {
+    CompletableFuture<String> future = new CompletableFuture<>();
+    AtomicInteger order = new AtomicInteger();
+    future.whenComplete((r, e) -> assertEquals(1, order.incrementAndGet()));
+    future.whenComplete((r, e) -> assertEquals(2, order.incrementAndGet()));
+    future.handle((r, e) -> {
+      assertEquals(3, order.incrementAndGet());
+      return "bar";
+    });
+    future.thenRun(() -> fail());
+    future.thenAccept(r -> fail());
+    future.exceptionally(e -> {
+      assertEquals(3, order.incrementAndGet());
+      return "bar";
+    });
+    future.completeExceptionally(new RuntimeException("foo"));
+  }
+
+}

--- a/protocol/src/main/java/io/atomix/copycat/protocol/OperationResponse.java
+++ b/protocol/src/main/java/io/atomix/copycat/protocol/OperationResponse.java
@@ -87,9 +87,7 @@ public abstract class OperationResponse extends SessionResponse {
       result = serializer.readObject(buffer);
     } else {
       error = CopycatError.forId(buffer.readByte());
-      if (error instanceof OperationException) {
-        lastSequence = buffer.readLong();
-      }
+      lastSequence = buffer.readLong();
     }
   }
 
@@ -102,9 +100,7 @@ public abstract class OperationResponse extends SessionResponse {
       serializer.writeObject(result, buffer);
     } else {
       buffer.writeByte(error.id());
-      if (error instanceof OperationException) {
-        buffer.writeLong(lastSequence);
-      }
+      buffer.writeLong(lastSequence);
     }
   }
 
@@ -129,7 +125,11 @@ public abstract class OperationResponse extends SessionResponse {
 
   @Override
   public String toString() {
-    return String.format("%s[status=%s, error=%s, sequence=%d, index=%d, eventIndex=%d, result=%s]", getClass().getSimpleName(), status, error, lastSequence, index, eventIndex, result);
+    if (error == null) {
+      return String.format("%s[status=%s, index=%d, eventIndex=%d, result=%s]", getClass().getSimpleName(), status, index, eventIndex, result);
+    } else {
+      return String.format("%s[status=%s, error=%s, lastSequence=%d]", getClass().getSimpleName(), status, error, lastSequence);
+    }
   }
 
   /**

--- a/server/src/main/java/io/atomix/copycat/server/state/PassiveState.java
+++ b/server/src/main/java/io/atomix/copycat/server/state/PassiveState.java
@@ -390,6 +390,7 @@ class PassiveState extends ReserveState {
           .withError(((CopycatException) error).getType())
           .build());
       } else {
+        LOGGER.warn("An unexpected error occurred: {}", error);
         future.complete(builder.withStatus(Response.Status.ERROR)
           .withError(CopycatError.Type.INTERNAL_ERROR)
           .build());

--- a/server/src/main/java/io/atomix/copycat/server/state/ServerSessionContext.java
+++ b/server/src/main/java/io/atomix/copycat/server/state/ServerSessionContext.java
@@ -233,7 +233,12 @@ class ServerSessionContext implements ServerSession {
    * @return The server session context.
    */
   ServerSessionContext resetRequestSequence(long requestSequence) {
-    this.requestSequence = requestSequence;
+    // If the request sequence number is less than the applied sequence number, update the request
+    // sequence number. This is necessary to ensure that if the local server is a follower that is
+    // later elected leader, its sequences are consistent for commands.
+    if (requestSequence > this.requestSequence) {
+      this.requestSequence = requestSequence;
+    }
     return this;
   }
 
@@ -272,14 +277,6 @@ class ServerSessionContext implements ServerSession {
         }
       }
     }
-
-    // If the request sequence number is less than the applied sequence number, update the request
-    // sequence number. This is necessary to ensure that if the local server is a follower that is
-    // later elected leader, its sequences are consistent for commands.
-    if (sequence > requestSequence) {
-      this.requestSequence = sequence;
-    }
-
     return this;
   }
 

--- a/server/src/main/java/io/atomix/copycat/server/state/ServerStateMachineExecutor.java
+++ b/server/src/main/java/io/atomix/copycat/server/state/ServerStateMachineExecutor.java
@@ -143,7 +143,7 @@ class ServerStateMachineExecutor implements StateMachineExecutor {
       try {
         return (U) function.apply(commit);
       } catch (Exception e) {
-        LOGGER.warn("State machine operation failed: {}", e.getMessage());
+        LOGGER.warn("State machine operation failed: {}", e);
         throw new ApplicationException(e, "An application error occurred");
       }
     }


### PR DESCRIPTION
This PR fixes a bug in the Copycat client when concurrent requests have been submitted to the cluster and ultimately timeout. When that happens, currently the client resets the connection on every failed requests. This causes the client to reconnect repeatedly, causing more timeouts, causing more reconnections, and more or less resulting in recursion between the client and server. To prevent this, we simply ensure the current connection hasn't already been reset before resetting it.

@jhall11 I'm assigning you to review this