### PR TITLE
Reset follower failure count on PollRequest

### DIFF
--- a/server/src/main/java/io/atomix/copycat/server/state/ClusterState.java
+++ b/server/src/main/java/io/atomix/copycat/server/state/ClusterState.java
@@ -181,6 +181,16 @@ final class ClusterState implements Cluster, AutoCloseable {
   }
 
   /**
+   * Returns a member state by ID.
+   *
+   * @param id The member ID.
+   * @return The member state.
+   */
+  public MemberState getMemberState(int id) {
+    return membersMap.get(id);
+  }
+
+  /**
    * Returns a member by ID.
    *
    * @param id The member ID.

--- a/server/src/main/java/io/atomix/copycat/server/state/LeaderState.java
+++ b/server/src/main/java/io/atomix/copycat/server/state/LeaderState.java
@@ -421,10 +421,13 @@ final class LeaderState extends ActiveState {
     // If a member sends a PollRequest to the leader, that indicates that it likely healed from
     // a network partition and may have had its status set to UNAVAILABLE by the leader. In order
     // to ensure heartbeats are immediately stored to the member, update its status if necessary.
-    ServerMember member = context.getClusterState().getRemoteMember(request.candidate());
-    if (member != null && member.status() == Member.Status.UNAVAILABLE) {
-      member.update(Member.Status.AVAILABLE, Instant.now());
-      configure(context.getCluster().members());
+    MemberState member = context.getClusterState().getMemberState(request.candidate());
+    if (member != null) {
+      member.resetFailureCount();
+      if (member.getMember().status() == Member.Status.UNAVAILABLE) {
+        member.getMember().update(Member.Status.AVAILABLE, Instant.now());
+        configure(context.getCluster().members());
+      }
     }
 
     return CompletableFuture.completedFuture(logResponse(PollResponse.builder()


### PR DESCRIPTION
This PR improves the speed with which a crashed follower can recover and reconnect to the cluster. Currently, exponential backoff in `LeaderAppender` means it can take up to a minute for a crashed/recovered follower to learn about the leader. This PR uses `PollRequest` to reset the follower's failure count to force the leader to send the next `AppendRequest` to the follower.