### PR TITLE
Prevent pipelining after failed AppendRequests

### DIFF
--- a/server/src/main/java/io/atomix/copycat/server/state/LeaderAppender.java
+++ b/server/src/main/java/io/atomix/copycat/server/state/LeaderAppender.java
@@ -402,6 +402,7 @@ final class LeaderAppender extends AbstractAppender {
 
     // If replication succeeded then trigger commit futures.
     if (response.succeeded()) {
+      member.appendSucceeded();
       updateMatchIndex(member, response);
 
       // If entries were committed to the replica then check commit indexes.
@@ -422,6 +423,7 @@ final class LeaderAppender extends AbstractAppender {
     // If the response failed, the follower should have provided the correct last index in their log. This helps
     // us converge on the matchIndex faster than by simply decrementing nextIndex one index at a time.
     else {
+      member.appendFailed();
       resetMatchIndex(member, response);
       resetNextIndex(member);
 

--- a/server/src/main/java/io/atomix/copycat/server/state/MemberState.java
+++ b/server/src/main/java/io/atomix/copycat/server/state/MemberState.java
@@ -36,6 +36,7 @@ final class MemberState {
   private long heartbeatTime;
   private long heartbeatStartTime;
   private int appending;
+  private boolean appendSucceeded;
   private long appendTime;
   private boolean configuring;
   private boolean installing;
@@ -60,6 +61,7 @@ final class MemberState {
     timeBuffer.reset();
     configuring = false;
     installing = false;
+    appendSucceeded = false;
     failures = 0;
   }
 
@@ -218,7 +220,36 @@ final class MemberState {
    * @return Indicates whether an append request can be sent to the member.
    */
   boolean canAppend() {
-    return appending == 0 || (appending < MAX_APPENDS && System.nanoTime() - (timeBuffer.average() / MAX_APPENDS) >= appendTime);
+    return appending == 0 || (appendSucceeded && appending < MAX_APPENDS && System.nanoTime() - (timeBuffer.average() / MAX_APPENDS) >= appendTime);
+  }
+
+  /**
+   * Flags the last append to the member as successful.
+   *
+   * @return The member state.
+   */
+  MemberState appendSucceeded() {
+    return appendSucceeded(true);
+  }
+
+  /**
+   * Flags the last append to the member is failed.
+   *
+   * @return The member state.
+   */
+  MemberState appendFailed() {
+    return appendSucceeded(false);
+  }
+
+  /**
+   * Sets whether the last append to the member succeeded.
+   *
+   * @param succeeded Whether the last append to the member succeeded.
+   * @return The member state.
+   */
+  private MemberState appendSucceeded(boolean succeeded) {
+    this.appendSucceeded = succeeded;
+    return this;
   }
 
   /**


### PR DESCRIPTION
This PR prevents leaders from pipelining `AppendRequest`s to followers after a rejected `AppendRequest`. The problem is, when a follower's log contains entries from a different term at the tail, pipelining results in lots of unnecessary requests being sent from the leader to the follower while the end of the follower's log is being resolved by the leader since it optimistically assumes requests will be accepted. This PR prevents leaders from making that assumption, thus reducing the number of `AppendRequest`s that will be sent when resolving a follower's `matchIndex`.