### PR TITLE
Log debug message and return null result when cached result is missing

### DIFF
--- a/server/src/main/java/io/atomix/copycat/server/state/PassiveState.java
+++ b/server/src/main/java/io/atomix/copycat/server/state/PassiveState.java
@@ -379,7 +379,7 @@ class PassiveState extends ReserveState {
 
       if (error == null) {
         future.complete(builder.withStatus(Response.Status.OK)
-          .withResult(result.result)
+          .withResult(result != null ? result.result : null)
           .build());
       } else if (error instanceof CompletionException && error.getCause() instanceof CopycatException) {
         future.complete(builder.withStatus(Response.Status.ERROR)

--- a/server/src/main/java/io/atomix/copycat/server/state/ServerStateMachine.java
+++ b/server/src/main/java/io/atomix/copycat/server/state/ServerStateMachine.java
@@ -822,10 +822,9 @@ final class ServerStateMachine implements AutoCloseable {
 
     Result result = session.getResult(sequence);
     if (result == null) {
-      context.executor().execute(() -> future.completeExceptionally(new RuntimeException("missing result")));
-    } else {
-      context.executor().execute(() -> future.complete(result));
+      LOGGER.debug("Missing command result for {}:{}", session.id(), sequence);
     }
+    context.executor().execute(() -> future.complete(result));
   }
 
   /**


### PR DESCRIPTION
This PR logs a `DEBUG` message and returns a `null` result when a result is missing from the cache. This is safe since such commands are already completed by the client, and the null result will simply be discarded.