### PR TITLE
Buffer entries written to the log for better performance

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
     <java.version>1.8</java.version>
     <slf4j.version>1.7.7</slf4j.version>
     <logback.version>1.1.2</logback.version>
-    <catalyst.version>1.2.0</catalyst.version>
+    <catalyst.version>1.2.1-SNAPSHOT</catalyst.version>
 
     <maven.source.plugin.version>2.2.1</maven.source.plugin.version>
     <maven.compiler.plugin.version>3.0</maven.compiler.plugin.version>


### PR DESCRIPTION
This PR slightly modifies how individual entries are written to the log, buffering all but the entry size in memory before writing.