### PR TITLE
Bump Catalyst dependency version to 1.2.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
     <java.version>1.8</java.version>
     <slf4j.version>1.7.7</slf4j.version>
     <logback.version>1.1.2</logback.version>
-    <catalyst.version>1.2.1-SNAPSHOT</catalyst.version>
+    <catalyst.version>1.2.1</catalyst.version>
 
     <maven.source.plugin.version>2.2.1</maven.source.plugin.version>
     <maven.compiler.plugin.version>3.0</maven.compiler.plugin.version>


### PR DESCRIPTION
Catalyst 1.2.1 contains a fix for a performance regression introduced in Copycat 1.2.5