### PR TITLE
Fix memory leak in response sequencer

### DIFF
--- a/client/src/main/java/io/atomix/copycat/client/session/ClientSequencer.java
+++ b/client/src/main/java/io/atomix/copycat/client/session/ClientSequencer.java
@@ -123,7 +123,10 @@ final class ClientSequencer {
       } else {
         responseCallbacks.put(sequence, new ResponseCallback(response, callback));
       }
-    } else {
+    }
+    // If the response has not yet been sequenced, store it in the response callbacks map.
+    // Otherwise, the response for the operation with this sequence number has already been handled.
+    else if (sequence > responseSequence) {
       responseCallbacks.put(sequence, new ResponseCallback(response, callback));
     }
   }


### PR DESCRIPTION
This PR fixes a memory leak in the client response sequencer. The problem is, multiple submitted requests can result in multiple responses, and we see this periodically. When the client receives a response, it sequences the response and completes response callbacks in the order in which the associated requests were sent. However, when a second response is received for a request, it will store the response in the `responseCallbacks` map and never complete it since the sequence number will never equal `responseSequence + 1`. So, this PR skips putting the response in the `responseCallbacks` map and _does not call the callback_. This is necessary to ensure that side effects - like setting the `commandSequence` number in the client - don't occur twice.