### PR TITLE
Prevent recursion of commands during closed session state

### DIFF
--- a/client/src/main/java/io/atomix/copycat/client/session/ClientSessionSubmitter.java
+++ b/client/src/main/java/io/atomix/copycat/client/session/ClientSessionSubmitter.java
@@ -55,6 +55,9 @@ final class ClientSessionSubmitter {
       || e instanceof TimeoutException
       || e instanceof TransportException
       || e instanceof ClosedChannelException;
+  private static final Predicate<Throwable> CLOSED_PREDICATE = e ->
+    e instanceof ClosedSessionException
+      || e instanceof UnknownSessionException;
   private final Connection connection;
   private final ClientSessionState state;
   private final ClientSequencer sequencer;
@@ -361,7 +364,7 @@ final class ClientSessionSubmitter {
     @Override
     public void fail(Throwable cause) {
       super.fail(cause);
-      if (!(cause instanceof UnknownSessionException)) {
+      if (!CLOSED_PREDICATE.test(cause)) {
         CommandRequest request = CommandRequest.builder()
           .withSession(this.request.session())
           .withSequence(this.request.sequence())


### PR DESCRIPTION
This PR fixes a bug that appears to lead to infinite (asynchronous) recursion in the client. When a session is closed and its state is set to `EXPIRED` or `CLOSED`, additional operations submitted to the session will enter an infinite loop because `ClosedSessionException` is not properly handled in the `CommandAttempt.fail` method. This PR simply checks to ensure the exception is not a `ClosedSessionException` and effectively breaks out of the loop if it is.