### PR TITLE
Make number of KeepAlives Configurable

### DIFF
--- a/client/src/main/java/io/atomix/copycat/client/CopycatClient.java
+++ b/client/src/main/java/io/atomix/copycat/client/CopycatClient.java
@@ -560,6 +560,7 @@ public interface CopycatClient {
     private Serializer serializer;
     private Duration sessionTimeout = Duration.ZERO;
     private Duration unstabilityTimeout = Duration.ZERO;
+    private int keepAlivesPerTimeoutInterval = 2;
     private ConnectionStrategy connectionStrategy = ConnectionStrategies.ONCE;
     private ServerSelectionStrategy serverSelectionStrategy = ServerSelectionStrategies.ANY;
     private RecoveryStrategy recoveryStrategy = RecoveryStrategies.CLOSE;
@@ -620,6 +621,19 @@ public interface CopycatClient {
      */
     public Builder withSessionTimeout(Duration sessionTimeout) {
       this.sessionTimeout = Assert.arg(Assert.notNull(sessionTimeout, "sessionTimeout"), sessionTimeout.toMillis() >= -1, "session timeout must be positive or -1");
+      return this;
+    }
+
+    /**
+     * Sets the number of keep-alives to send during a session timeout interval. Default value is 2.
+     *
+     * @param keepAlivesPerTimeoutInterval The number of keep-alives to send during a session timeout interval
+     * @return The client builder.
+     * @throws IllegalArgumentException if the keepAlivesPerTimeoutInterval is not positive
+     */
+    public Builder withKeepAlivesPerTimeoutInterval(int keepAlivesPerTimeoutInterval) {
+      Assert.arg(keepAlivesPerTimeoutInterval > 0, "keepAlivesPerTimeoutInterval must be positive");
+      this.keepAlivesPerTimeoutInterval = keepAlivesPerTimeoutInterval;
       return this;
     }
 
@@ -711,7 +725,8 @@ public interface CopycatClient {
         connectionStrategy,
         recoveryStrategy,
         sessionTimeout,
-        unstabilityTimeout
+        unstabilityTimeout,
+        keepAlivesPerTimeoutInterval
       );
     }
   }

--- a/client/src/main/java/io/atomix/copycat/client/DefaultCopycatClient.java
+++ b/client/src/main/java/io/atomix/copycat/client/DefaultCopycatClient.java
@@ -57,6 +57,7 @@ public class DefaultCopycatClient implements CopycatClient {
   private final AddressSelector selector;
   private final Duration sessionTimeout;
   private final Duration unstabilityTimeout;
+  private final int keepAlivesPerTimeoutInterval;
   private final ConnectionStrategy connectionStrategy;
   private final RecoveryStrategy recoveryStrategy;
   private ClientSession session;
@@ -68,7 +69,10 @@ public class DefaultCopycatClient implements CopycatClient {
   private final Set<EventListener<?>> eventListeners = new CopyOnWriteArraySet<>();
   private Listener<Session.State> changeListener;
 
-  DefaultCopycatClient(String clientId, Collection<Address> cluster, Transport transport, ThreadContext ioContext, ThreadContext eventContext, ServerSelectionStrategy selectionStrategy, ConnectionStrategy connectionStrategy, RecoveryStrategy recoveryStrategy, Duration sessionTimeout, Duration unstabilityTimeout) {
+  DefaultCopycatClient(String clientId, Collection<Address> cluster, Transport transport, ThreadContext ioContext,
+                       ThreadContext eventContext, ServerSelectionStrategy selectionStrategy, ConnectionStrategy
+                           connectionStrategy, RecoveryStrategy recoveryStrategy, Duration sessionTimeout, Duration
+                           unstabilityTimeout, int keepAlivesPerTimeoutInterval) {
     this.clientId = Assert.notNull(clientId, "clientId");
     this.cluster = Assert.notNull(cluster, "cluster");
     this.transport = Assert.notNull(transport, "transport");
@@ -78,7 +82,8 @@ public class DefaultCopycatClient implements CopycatClient {
     this.connectionStrategy = Assert.notNull(connectionStrategy, "connectionStrategy");
     this.recoveryStrategy = Assert.notNull(recoveryStrategy, "recoveryStrategy");
     this.sessionTimeout = Assert.notNull(sessionTimeout, "sessionTimeout");
-    this.unstabilityTimeout = Assert.notNull(unstabilityTimeout, "unstabilityTimeout");;
+    this.unstabilityTimeout = Assert.notNull(unstabilityTimeout, "unstabilityTimeout");
+    this.keepAlivesPerTimeoutInterval = keepAlivesPerTimeoutInterval;
   }
 
   @Override
@@ -128,7 +133,7 @@ public class DefaultCopycatClient implements CopycatClient {
    */
   private ClientSession newSession() {
     ClientSession session = new ClientSession(clientId, transport.client(), selector, ioContext, connectionStrategy, sessionTimeout,
-                                              unstabilityTimeout
+                                              unstabilityTimeout, keepAlivesPerTimeoutInterval
     );
 
     // Update the session change listener.

--- a/client/src/main/java/io/atomix/copycat/client/session/ClientSession.java
+++ b/client/src/main/java/io/atomix/copycat/client/session/ClientSession.java
@@ -59,14 +59,14 @@ public class ClientSession implements Session {
   private final ClientSessionListener listener;
   private final ClientSessionSubmitter submitter;
 
-  public ClientSession(String id, Client client, AddressSelector selector, ThreadContext context, ConnectionStrategy connectionStrategy, Duration sessionTimeout, Duration unstabilityTimeout) {
-    this(new ClientConnection(id, client, selector), new ClientSessionState(id, unstabilityTimeout), context, connectionStrategy, sessionTimeout);
+  public ClientSession(String id, Client client, AddressSelector selector, ThreadContext context, ConnectionStrategy connectionStrategy, Duration sessionTimeout, Duration unstabilityTimeout, int keepalivesPerTimeoutInterval) {
+    this(new ClientConnection(id, client, selector), new ClientSessionState(id, unstabilityTimeout), context, connectionStrategy, sessionTimeout, keepalivesPerTimeoutInterval);
   }
 
-  private ClientSession(ClientConnection connection, ClientSessionState state, ThreadContext context, ConnectionStrategy connectionStrategy, Duration sessionTimeout) {
+  private ClientSession(ClientConnection connection, ClientSessionState state, ThreadContext context, ConnectionStrategy connectionStrategy, Duration sessionTimeout, int keepalivesPerTimeoutInterval) {
     this.connection = Assert.notNull(connection, "connection");
     this.state = Assert.notNull(state, "state");
-    this.manager = new ClientSessionManager(connection, state, context, connectionStrategy, sessionTimeout);
+    this.manager = new ClientSessionManager(connection, state, context, connectionStrategy, sessionTimeout, keepalivesPerTimeoutInterval);
     ClientSequencer sequencer = new ClientSequencer(state);
     this.listener = new ClientSessionListener(connection, state, sequencer, context);
     this.submitter = new ClientSessionSubmitter(connection, state, sequencer, context);

--- a/client/src/test/java/io/atomix/copycat/client/session/ClientSessionManagerTest.java
+++ b/client/src/test/java/io/atomix/copycat/client/session/ClientSessionManagerTest.java
@@ -73,7 +73,7 @@ public class ClientSessionManagerTest {
     Executor executor = new MockExecutor();
     when(context.executor()).thenReturn(executor);
 
-    ClientSessionManager manager = new ClientSessionManager(connection, state, context, ConnectionStrategies.EXPONENTIAL_BACKOFF, Duration.ZERO);
+    ClientSessionManager manager = new ClientSessionManager(connection, state, context, ConnectionStrategies.EXPONENTIAL_BACKOFF, Duration.ZERO, 2);
     manager.open().join();
 
     assertEquals(state.getSessionId(), 1);


### PR DESCRIPTION
We're seeing sessions regularly becoming expired. 
Would like to be able to be able to increase the number of keep alives to see whether this helps.